### PR TITLE
docs&test: add other windows spec and tests, disable dragging

### DIFF
--- a/docs/feat-spec/002_other_windows_tabs.md
+++ b/docs/feat-spec/002_other_windows_tabs.md
@@ -1,0 +1,109 @@
+# Feature Specification: Other Windows / 他のウィンドウ / 其他視窗
+
+> [!NOTE]
+> Special thanks to [Yuugou Ohno](https://github.com/YuugouOhno) for contributing this feature via [PR #2](https://github.com/Tai-ch0802/arc-like-chrome-extension/pull/2).
+
+## English
+
+### Overview
+This feature introduces an "Other Windows" section in the sidebar, allowing users to view and access tabs from other open Chrome windows directly within the current sidebar. The content in this section is **read-only** and meant for quick navigation.
+
+### Functional Requirements
+1.  **Display Other Windows**:
+    -   A new section titled "Other Windows" is displayed below the current window's tab list.
+    -   Lists all open Chrome windows excluding the current active window.
+    -   Windows with no tabs are hidden.
+    -   Each window is displayed as a collapsible folder, titled "Window {index} ({tabCount})".
+
+2.  **Tab & Group Rendering**:
+    -   Inside each window folder, tabs are listed vertically.
+    -   **Tab Groups**: Tabs belonging to a tab group are nested under a collapsible group header.
+        -   Group header displays the group title and color.
+        -   Group collapse/expand state is independent.
+    -   **Ungrouped Tabs**: Displayed directly under the window folder.
+
+3.  **Read-Only Interaction**:
+    -   **Switch to Tab**: Clicking a tab instantly activates that tab and brings its window to the foreground (`window.focused = true`).
+    -   **Collapse/Expand**: Folders and groups can be toggled.
+    -   **No Drag & Drop**: Tabs and groups in this section typically **cannot** be rearranged or dragged interactively. This prevents accidental modifications to other windows.
+    -   **Collapse/Expand**:
+        -   Window folders can be toggled to show/hide their contents.
+        -   Tab groups within windows can be toggled.
+
+4.  **Live Updates**:
+    -   The list updates automatically when windows are created or removed (`chrome.windows.onCreated`, `chrome.windows.onRemoved`).
+    -   Updates when tabs/groups change (via existing listeners in `updateTabList`).
+
+### Technical Details
+-   **Files Modified**: `modules/ui/tabRenderer.js`, `sidepanel.js`, `sidepanel.html` (header addition implied), `messages.json` (i18n).
+-   **API Used**: `chrome.windows.getAll`, `chrome.tabGroups.query`, `chrome.tabs.query`.
+
+---
+
+## 日本語
+
+### 概要
+この機能は、サイドバーに「他のウィンドウ」セクションを追加し、ユーザーが現在開いている他のChromeウィンドウのタブをサイドバー内で直接確認・アクセスできるようにします。このセクションの内容は**読み取り専用**であり、クイックナビゲーションを目的としています。
+
+### 機能要件
+1.  **他のウィンドウの表示**:
+    -   現在のウィンドウのタブリストの下に「他のウィンドウ」というタイトルの新しいセクションを表示します。
+    -   現在のアクティブなウィンドウを除く、開いているすべてのChromeウィンドウをリストアップします。
+    -   タブのないウィンドウは非表示になります。
+    -   各ウィンドウは「Window {index} ({tabCount})」というタイトルの折りたたみ可能なフォルダとして表示されます。
+
+2.  **タブとグループのレンダリング**:
+    -   各ウィンドウフォルダ内に、タブが垂直にリストされます。
+    -   **タブグループ**: タブグループに属するタブは、折りたたみ可能なグループヘッダーの下にネストされます。
+        -   グループヘッダーには、グループのタイトルと色が表示されます。
+        -   グループの折りたたみ/展開状態は独立しています。
+    -   **グループ化されていないタブ**: ウィンドウフォルダの直下に表示されます。
+
+3.  **読み取り専用インタラクション**:
+    -   **タブへの切り替え**: タブをクリックすると、即座にそのタブがアクティブになり、そのウィンドウが最前面に表示されます（`window.focused = true`）。
+    -   **折りたたみ/展開**:
+        -   ウィンドウフォルダをクリックして、内容の表示/非表示を切り替えることができます。
+        -   ウィンドウ内のタブグループも切り替え可能です。
+
+4.  **リアルタイム更新**:
+    -   ウィンドウが作成または削除されると、リストが自動的に更新されます（`chrome.windows.onCreated`, `chrome.windows.onRemoved`）。
+    -   タブやグループが変更された場合も更新されます（`updateTabList`内の既存のリスナー経由）。
+
+### 技術詳細
+-   **変更されたファイル**: `modules/ui/tabRenderer.js`、`sidepanel.js`、`sidepanel.html`、`messages.json`（多言語対応）。
+-   **使用API**: `chrome.windows.getAll`、`chrome.tabGroups.query`、`chrome.tabs.query`。
+
+---
+
+## 繁體中文
+
+### 概述
+此功能在側邊欄中引進了「其他視窗」區塊，允許使用者直接在當前側邊欄中檢視並存取其他開啟的 Chrome 視窗中的分頁。此區塊內容為**唯讀**，旨在提供快速導航。
+
+### 功能需求
+1.  **顯示其他視窗**：
+    -   在當前視窗的分頁列表下方顯示標題為「其他視窗」的新區塊。
+    -   列出除當前活動視窗外的所有開啟 Chrome 視窗。
+    -   隱藏沒有任何分頁的視窗。
+    -   每個視窗顯示為可折疊的資料夾，標題格式為「Window {index} ({tabCount})」。
+
+2.  **分頁與群組渲染**：
+    -   在每個視窗資料夾內，分頁垂直排列。
+    -   **分頁群組**：屬於分頁群組的分頁會巢狀顯示在可折疊的群組標題下方。
+        -   群組標題顯示群組名稱與顏色。
+        -   群組的折疊/展開狀態是獨立的。
+    -   **未群組分頁**：直接顯示在視窗資料夾下方。
+
+3.  **唯讀互動**：
+    -   **切換至分頁**：點擊分頁即會將該分頁設為活動狀態，並將其視窗帶至最上層 (`window.focused = true`)。
+    -   **折疊/展開**：
+        -   點擊視窗資料夾可切換顯示/隱藏其內容。
+        -   視窗內的分頁群組也可進行切換。
+
+4.  **即時更新**：
+    -   當視窗建立或移除時，列表會自動更新 (`chrome.windows.onCreated`, `chrome.windows.onRemoved`)。
+    -   當分頁或群組變更時也會更新 (透過 `updateTabList` 中既有的監聽器)。
+
+### 技術細節
+-   **修改檔案**：`modules/ui/tabRenderer.js`, `sidepanel.js`, `sidepanel.html`, `messages.json` (多語言支援)。
+-   **使用 API**：`chrome.windows.getAll`, `chrome.tabGroups.query`, `chrome.tabs.query`。

--- a/modules/dragDropManager.js
+++ b/modules/dragDropManager.js
@@ -34,7 +34,8 @@ function initializeTabSortable(updateTabList) {
         onAdd: (evt) => handleDragAdd(evt, updateTabList),
     };
     tabSortableInstances.push(new Sortable(ui.tabListContainer, sortableOptions));
-    document.querySelectorAll('.tab-group-content').forEach(groupContent => {
+    // Only initialize Sortable on tab groups within the main tab list
+    ui.tabListContainer.querySelectorAll('.tab-group-content').forEach(groupContent => {
         tabSortableInstances.push(new Sortable(groupContent, sortableOptions));
     });
 }
@@ -71,9 +72,9 @@ function initializeBookmarkSortable(refreshBookmarks, updateTabList) {
         },
     };
 
-    // Initialize Sortable on all folder-content containers, including empty ones,
-    // so users can drag items into empty folders.
-    const folderContents = Array.from(document.querySelectorAll('.folder-content'));
+    // Initialize Sortable on all folder-content containers within the bookmark section only.
+    // This excludes Other Windows section which should be read-only.
+    const folderContents = Array.from(ui.bookmarkListContainer.querySelectorAll('.folder-content'));
     const sortableContainers = [ui.bookmarkListContainer, ...folderContents];
 
     sortableContainers.forEach(container => {

--- a/usecase_tests/puppeteer_tests/other_windows.test.js
+++ b/usecase_tests/puppeteer_tests/other_windows.test.js
@@ -1,0 +1,110 @@
+const { setupBrowser, teardownBrowser } = require('./setup');
+
+describe('Other Windows Use Case', () => {
+    let browser;
+    let page;
+    let extensionId;
+    let sidePanelUrl;
+    let secondWindowId = null;
+    let createdTabIds = [];
+
+    beforeAll(async () => {
+        const setup = await setupBrowser();
+        browser = setup.browser;
+        page = setup.page;
+        extensionId = setup.extensionId;
+        sidePanelUrl = setup.sidePanelUrl;
+    });
+
+    afterAll(async () => {
+        await teardownBrowser(browser);
+    });
+
+    beforeEach(async () => {
+        // Create a second window with a known tab
+        const newWindow = await page.evaluate(() => {
+            return new Promise(resolve => {
+                chrome.windows.create({ url: 'https://example.com', focused: false }, resolve);
+            });
+        });
+        secondWindowId = newWindow.id;
+        if (newWindow.tabs && newWindow.tabs.length > 0) {
+            createdTabIds.push(newWindow.tabs[0].id);
+        }
+
+        // Add another tab to the second window
+        const newTab = await page.evaluate((windowId) => {
+            return new Promise(resolve => {
+                chrome.tabs.create({ windowId: windowId, url: 'https://www.google.com', active: false }, resolve);
+            });
+        }, secondWindowId);
+        createdTabIds.push(newTab.id);
+
+        // Wait for extension to register new window
+        await new Promise(r => setTimeout(r, 500));
+        await page.reload();
+        await page.waitForSelector('#other-windows-list');
+    });
+
+    afterEach(async () => {
+        // Close the second window
+        if (secondWindowId) {
+            await page.evaluate((id) => {
+                return new Promise(resolve => {
+                    chrome.windows.remove(id, resolve);
+                });
+            }, secondWindowId);
+            secondWindowId = null;
+        }
+        createdTabIds = [];
+    });
+
+    test('should display tabs from other windows in the Other Windows section', async () => {
+        // Wait for the Other Windows section to be present
+        await page.waitForSelector('#other-windows-list');
+
+        // Find the folder representing the second window
+        const otherWindowFolderSelector = '#other-windows-list .bookmark-folder';
+        await page.waitForSelector(otherWindowFolderSelector);
+
+        // Click to expand the folder
+        await page.click(otherWindowFolderSelector);
+        await new Promise(r => setTimeout(r, 300)); // Wait for expansion animation
+
+        // Verify tabs are visible inside the folder-content
+        const folderContentSelector = '#other-windows-list .folder-content';
+        const tabItems = await page.$$eval(`${folderContentSelector} .tab-item`, items => items.map(el => ({
+            title: el.querySelector('.tab-title')?.textContent || '',
+            url: el.dataset.url || ''
+        })));
+
+        // We created two tabs: example.com and google.com
+        const exampleTab = tabItems.find(t => t.url.includes('example.com'));
+        const googleTab = tabItems.find(t => t.url.includes('google.com'));
+
+        expect(exampleTab).toBeDefined();
+        expect(googleTab).toBeDefined();
+    }, 60000);
+
+    test('should NOT allow dragging tabs from Other Windows', async () => {
+        // Expand the folder
+        const otherWindowFolderSelector = '#other-windows-list .bookmark-folder';
+        await page.waitForSelector(otherWindowFolderSelector);
+        await page.click(otherWindowFolderSelector);
+        await new Promise(r => setTimeout(r, 300));
+
+        // Get a tab item from Other Windows
+        const folderContentSelector = '#other-windows-list .folder-content';
+        const tabItemSelector = `${folderContentSelector} .tab-item`;
+        await page.waitForSelector(tabItemSelector);
+
+        // Check that Sortable is NOT initialized on the folder content
+        const hasSortable = await page.$eval(folderContentSelector, el => {
+            if (typeof Sortable === 'undefined') return false;
+            const instance = Sortable.get(el);
+            return instance !== null && instance !== undefined;
+        });
+
+        expect(hasSortable).toBe(false);
+    }, 60000);
+});


### PR DESCRIPTION
新增 Other Windows 功能的規格書與測試，並修正拖曳行為。

詳細改動：
- **docs/feat-spec/002_other_windows_tabs.md**: 新增三語功能規格書，說明功能需求與唯讀限制。
- **modules/dragDropManager.js**: 限制 SortableJS 初始化範圍，確保 Other Windows 區塊為唯讀，不可拖曳。
- **usecase_tests/puppeteer_tests/other_windows.test.js**: 新增測試案例，驗證跨視窗分頁顯示及拖曳限制。

----

Add specification and tests for Other Windows feature, and fix drag behavior.

Details:
- **docs/feat-spec/002_other_windows_tabs.md**: Added a trilingual (three-language) specification document outlining functional requirements and read-only constraints.
- **modules/dragDropManager.js**: Restricted SortableJS initialization range to ensure the "Other Windows" section is read-only and prevents dragging.
- **usecase_tests/puppeteer_tests/other_windows.test.js**: Added new test cases to verify cross-window tab display and dragging restrictions.

----

Other Windows 機能の仕様書とテストの追加、およびドラッグ動作の修正。

詳細な変更内容:
- **docs/feat-spec/002_other_windows_tabs.md**: 3ヶ国語対応の機能仕様書を追加。機能要件と読み取り専用（Read-only）の制限について記述しました。
- **modules/dragDropManager.js**: SortableJS の初期化範囲を制限し、「Other Windows」セクションを読み取り専用にしてドラッグ不可となるよう修正しました。
- **usecase_tests/puppeteer_tests/other_windows.test.js**: 複数のウィンドウ間でのタブ表示およびドラッグ制限を検証するためのテストケースを追加しました。

----

chore for #2 