### PR TITLE
chore: add Claude Code support and refine skill catalog

### DIFF
--- a/.agent/skills/cleanup-merged-branches/SKILL.md
+++ b/.agent/skills/cleanup-merged-branches/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cleanup-merged-branches
-description: "Deletes local and remote git branches that have been merged into main."
+description: 清理已合併進 main 的本地與遠端 git 分支。本專案採 squash merge，PR 合併後特性分支可直接刪除。當使用者提到「清理分支、cleanup branches、刪除舊分支、清掉已合併分支、整理 branch」時觸發。
 ---
 
 # Cleanup Merged Branches
@@ -40,3 +40,11 @@ git push origin --delete <branch-name>
 - **Never delete `main`** - the grep filters exclude it
 - **Confirm with user** before deleting remote branches (destructive action)
 - **Protected branches** - some branches may be protected on GitHub
+
+## 本專案約定
+
+- **Main branch**：`main`（不是 `master`）。
+- **Merge 策略**：採 **squash merge**，PR 合併後特性分支歷史會被壓縮，特性分支可立即刪除。
+- **GitHub 自動刪除**：若 repo 設定已啟用 "Automatically delete head branches"，遠端分支會在 squash merge 後自動清除，本 skill 主要處理「本機殘留」與「未啟用自動刪除時的補救」。
+- **SOP 對照**：詳細流程參考 `.agent/workflows/cleanup-branches.md`（含 cherry-pick 與 cleanup 衝突處理）。
+- **與其他 worktree 共存**：執行前先 `git worktree list`，避免刪除仍在使用中的分支。

--- a/.agent/skills/code-review/SKILL.md
+++ b/.agent/skills/code-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: code-review
-description: Reviews code changes for bugs, style issues, and best practices. Use when reviewing PRs or checking code quality.
+description: 審查本專案 (Manifest V3 Chrome extension) 的程式碼變更，含 Chrome API 用法、權限最小化、Puppeteer 測試 race condition、scripts/lint-check.sh 自動化檢查、references/{security-checklist,performance-patterns,style-guide}.md。當使用者提到「review PR、審查、code review、程式碼審查、檢查 PR、看一下這個 PR」時觸發。
 ---
 
 # Code Review Skill

--- a/.agent/skills/commit-message-helper/SKILL.md
+++ b/.agent/skills/commit-message-helper/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: commit-message-helper
-description: Helps write Git commit messages following the Conventional Commits specification. Use this skill when the user asks to commit changes, write commit messages, or mentions git commits.
+description: 本專案 (Manifest V3 Chrome extension) 的 commit 規範與範例：subject 使用英文 Conventional Commits、body 使用繁中說明背景與原因。當使用者提到「commit、提交訊息、commit message、寫 commit、commit 規範」時觸發。
 ---
 
 # Commit Message Helper
@@ -59,3 +59,11 @@ refactor: 模組化側邊欄邏輯以提升清晰度與可維護性
 
 Bad:
 updated stuff
+
+## 本專案約定
+
+- **Subject 語言**：英文（沿用 `GEMINI.md` 既有規範），body 繁中。subject 50 字內、imperative mood、不加句號。
+- **Scope 命名建議**：`sidepanel`、`modules/ui`、`modules/utils`、`modules/api`、`background`、`manifest`、`i18n`、`tests`、`makefile`、`docs`。
+- **Body 內容**：說明「為什麼改」與「實作關鍵」，不要只寫「what」。改動到 `key_files`（如 `sidepanel.js`、`modules/ui/elements.js`）時，body 提醒一句「同步更新 GEMINI.md key_files 描述」。
+- **Footer**：若對應 Issue / PR，加 `Closes #123` 或 `Refs #123`。
+- **多 commit 一份 PR**：合併採 squash merge，PR title 仍要遵守同規範（會成為最終 commit subject）。

--- a/.agent/skills/image-master/SKILL.md
+++ b/.agent/skills/image-master/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: image-master
-description: Specialized knowledge and workflows for handling images. Use this skill when the user asks about image processing, formats, color theory, imaging science, or verifying image quality. Includes references for upload/download, filters, and color grading.
+description: 影像處理知識：格式 (WebP/PNG/SVG/AVIF)、壓縮、色彩理論、無障礙對比度 (WCAG)、imaging science。對應本專案的 modules/utils/imageUtils.js (WebP 轉換 / 壓縮)、sidepanel 圖示、modules/ui/backgroundImageManager 的自訂背景圖場景。當使用者提到「圖片格式、影像處理、WebP、色彩理論、icon 設計、背景圖、圖片壓縮」時觸發。
 ---
 
 # Image Master Skill
@@ -41,3 +41,21 @@ Detailed knowledge is organized into the following reference files:
 ### 4. Imaging Science
 -   **File**: [imaging-science.md](references/imaging-science.md)
 -   **Contents**: Digital image fundamentals (Pixels, Resolution/DPI, Bit Depth), Histograms, Aliasing, and compression artifacts.
+
+## 本專案場景對應
+
+本 skill 在這個 Chrome extension 內最常被觸發的具體場景：
+
+| 場景 | 模組 / 檔案 | 重點 |
+|---|---|---|
+| 使用者上傳自訂背景圖 | `modules/ui/backgroundImageManager.js` | 壓縮 + WebP 轉換、CSS 變數套用、容量 quota |
+| 縮圖 / favicon 抓取 | `modules/utils/imageUtils.js` | URL 抓取、resize、WebP 轉換 |
+| Extension icons | `icons/` (16/32/48/128 PNG)、`manifest.json` | retina 友善、透明背景、Chrome Web Store 提交 |
+| sidepanel UI 圖示 | `modules/icons.js`（SVG 常數） | 優先 SVG (inline)，避免 raster |
+| Chrome Web Store 截圖 | `docs/chrome-web-store/screenshots/` | 1280×800 / 640×400、PNG/JPG |
+
+### 本專案常用決策
+
+- **格式選擇**：UI 圖示用 inline SVG（`modules/icons.js`）；使用者上傳圖用 WebP（quality 80）；extension icons 用 PNG with transparency。
+- **壓縮策略**：`imageUtils.js` 已實作 WebP 轉換 + 等比 resize，新需求優先沿用既有 util。
+- **對比度**：sidepanel 文字與背景的 contrast 需符合 WCAG AA（4.5:1），參考 `color-theory.md`。`modules/utils/colorUtils.js` 已實作 WCAG 對比度計算可重用。

--- a/.agent/skills/prd/SKILL.md
+++ b/.agent/skills/prd/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: prd
-description: "Guidelines and templates for creating effective Product Requirement Documents (PRD), bridging the gap between business goals and technical implementation."
+description: 撰寫本專案的 PRD (產品需求文件)，位置為 /docs/specs/{type}/{ID-PREFIX}_{desc}/PRD_spec.md。當使用者提到「PRD、產品需求、需求文件、寫規格、新功能規劃、acceptance criteria」時觸發。SDD 流程的 Phase 1，產出物提供給 sa skill 銜接。
 ---
 
 # Product Requirement Document (PRD) Skill
@@ -39,3 +39,20 @@ description: "Guidelines and templates for creating effective Product Requiremen
 *   **使用清晰的語言**: 避免 "可能"、"應該" 等模糊詞彙，使用 "必須" (Shall/Must)、"可以" (Can) 等明確用語。
 *   **圖文並茂**: 盡量使用流程圖 (Mermaid) 來輔助文字說明。
 *   **保持更新**: PRD 是活的文件 (Living Document)，若需求變更，務必更新 PRD。
+
+## 本專案 PRD 慣例（呼應 sdd skill）
+
+- **檔案位置**：`/docs/specs/{type}/{ID-PREFIX}_{desc}/PRD_spec.md`
+  - `type`：`feature` / `fix` / `refactor` / `chore`
+  - `ID_PREFIX`：`ISSUE-{n}`（一般功能／bug，對應 GitHub Issue）／`PR-{n}`（外部貢獻無 Issue）／`BASE-{n}`（歷史補規格）
+- **Functional Requirements**：建議使用 **EARS syntax**（Event-driven / Unwanted / State / Optional / Complex）。
+- **Acceptance Criteria**：必須使用 **Given-When-Then** 三段式，每條 AC 都要可驗證。
+- **Out of Scope**：明確列出「這次不做」的項目，避免 scope creep；後續若補做，另立 PRD 版本。
+- **Living Document**：Frozen 後變更須 bump 版本（v1.0 → v1.1），在 Revision History 記原因。
+
+## Chrome Extension 專案的 PRD 重點
+
+- **使用者介面類型**：明確標註是 sidepanel / popup / content script / new tab override / context menu。
+- **權限申請**：列出新功能要 manifest.json 加哪些 `permissions` / `host_permissions`，並說明最小化策略。
+- **跨裝置同步**：若涉及 `chrome.storage.sync`，要評估 quota（每項 8KB，總計 100KB）。
+- **多語系影響**：若新增 UI 文案，要在 PRD 提醒「同步觸發 update-multilingual-docs」。

--- a/.agent/skills/pull-request/SKILL.md
+++ b/.agent/skills/pull-request/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pull-request
-description: "Guidelines and tools for creating high-quality Pull Requests using the gh CLI. Includes bilingual templates (zh-TW/en) and validation scripts."
+description: 建立本專案的 Pull Request：雙語描述 (zh-TW/en)、gh CLI、scripts/check-pr.sh 預驗證、references/pr_template.md 與 checklist.md。當使用者提到「開 PR、建 PR、create PR、pull request、提交變更、發 PR、新建 PR」時觸發。
 ---
 
 # Pull Request Skill

--- a/.agent/skills/puppeteer-test/SKILL.md
+++ b/.agent/skills/puppeteer-test/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: puppeteer-test
-description: Guide for writing Puppeteer-based end-to-end tests for Chrome Extensions. Use this skill when creating automated tests for extension popup, side panel, service worker, content scripts, or testing service worker termination. Covers Jest integration, browser launch configuration, and extension-specific testing patterns.
+description: 本專案 Puppeteer + Jest E2E 測試指南，涵蓋 side panel、service worker、content script、service worker termination、Chrome Extension 載入配置 (--load-extension)。當使用者提到「Puppeteer 測試、E2E 測試、寫測試、自動化測試、寫 puppeteer、test extension」時觸發。
 ---
 
 # Puppeteer Testing for Chrome Extensions

--- a/.agent/skills/refactoring/SKILL.md
+++ b/.agent/skills/refactoring/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: refactoring
-description: "Guidelines and techniques for identifying code smells and refactoring code, based on Refactoring.guru principles and adapted for Vanilla JS Chrome Extensions."
+description: 本專案 (vanilla JS Chrome extension) 的重構指南：辨識 code smell、應用 Refactoring.guru 原則於 ES Modules、Side Panel、modules/ui Facade 模式等場景。當使用者提到「refactor、重構、改善程式碼、code smell、拆模組」時觸發。
 ---
 
 # Refactoring Skill

--- a/.agent/skills/release-notes/SKILL.md
+++ b/.agent/skills/release-notes/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: release-notes
-description: "Generates bilingual (zh-TW/en) RELEASE_NOTE.md for GitHub releases."
+description: 產生本專案的雙語 RELEASE_NOTE.md (zh-TW/en)，沿用 .github/release.yml 的「✨ 新功能 / 🚀 改善與錯誤修復」區塊結構，含 contributor 標註。RELEASE_NOTE.md 為暫存預覽不入版控。當使用者提到「release note、發版說明、寫 release note、版本說明、出版本」時觸發。
 ---
 
 # Release Notes Generation

--- a/.agent/skills/sa/SKILL.md
+++ b/.agent/skills/sa/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sa
-description: "Methodologies for System Analysis (SA), focusing on technical architecture, data flow modeling, and API design."
+description: 撰寫本專案 (vanilla JS Chrome extension) 的 SA (系統分析) 文件，重點為模組架構、chrome.storage schema、message passing、Test Impact Analysis。本專案無 backend / 無 DB，SA 聚焦前端 module 切分與狀態流。當使用者提到「SA、系統分析、技術方案、架構設計、模組規劃、Test Impact」時觸發。SDD 流程的 Phase 2。
 ---
 
 # System Analysis (SA) Skill
@@ -48,3 +48,30 @@ description: "Methodologies for System Analysis (SA), focusing on technical arch
 *   [ ] 是否符合現有的程式碼風格與架構模式？
 *   [ ] 是否評估了性能影響 (Performance Impact)？
 *   [ ] **[Must]** 是否已識別所有受影響的測試案例，並規劃了與程式碼變更同步的測試修正？
+
+## 本專案 SA 重點（vanilla JS Chrome extension，無 backend）
+
+本專案沒有伺服器、沒有資料庫、沒有 REST API。SA 文件的「資料建模 / 介面設計」需轉譯為前端等價物：
+
+| 通用 SA 概念 | 本專案對應 |
+|---|---|
+| Database Schema | `chrome.storage.local` / `chrome.storage.sync` 的 key-value schema |
+| REST API | `chrome.runtime.sendMessage` / `onMessage` 的訊息協定 (Message Passing) |
+| Function Signatures | `modules/` 下各 module 的 export interface（JSDoc 標型） |
+| 後端服務切分 | `modules/{apiManager, stateManager, dragDropManager, ...}` 的職責劃分 |
+
+### 必填章節（本專案 SA_spec.md）
+
+1. **Module Impact Map**：列出受影響的 `modules/` 子模組（apiManager / stateManager / ui/* / utils/* / aiManager / rssManager / readingListManager）。
+2. **Message Flow**：若涉及 background ↔ sidepanel ↔ content script 通訊，畫 Mermaid sequence diagram。
+3. **Storage Schema Diff**：若改動 `chrome.storage` 結構，列出「before / after」JSON shape 與 migration 策略。
+4. **Manifest Diff**：若新增 permissions / host_permissions / commands，明確列出 manifest.json 變更。
+5. **Test Impact Analysis** ⭐：
+   - `tests/`（Jest 單元測試）：列出哪些檔案的測試需要修改。
+   - `usecase_tests/`（Puppeteer E2E）：列出 DOM 選擇器（`.tab-item[data-tab-id]` 等）若變動會影響哪些 E2E。
+   - `scripts/__tests__/`（build/script 測試）：列出 Makefile 或建置流程的測試影響。
+
+### 工具
+
+*   **Mermaid**：流程圖、sequence diagram、state diagram。詳見 `references/diagram_guide.md`。
+*   **JSDoc**：本專案無 TypeScript，型別契約靠 JSDoc 標註（`@typedef`、`@param`、`@returns`）。

--- a/.agent/skills/sdd/SKILL.md
+++ b/.agent/skills/sdd/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sdd
-description: "Spec-Driven Development (SDD): A structured workflow (Requirement -> Analysis -> Implementation) enforcing explicit documentation before coding."
+description: 本專案標準開發流程：Spec-Driven Development (SDD) — Phase 1 PRD → Phase 2 SA → Phase 3 實作。產出物放 /docs/specs/{type}/{ID-PREFIX}_{desc}/，目錄前綴採 ISSUE-/PR-/BASE- 三類。當使用者提到「新功能、修 bug、重構、SDD、規格驅動、要做一個 X、開新功能」時觸發；遵守 "No Spec, No Code"。
 ---
 
 # Spec-Driven Development (SDD) Skill

--- a/.agent/skills/ui-ux-pro-max/SKILL.md
+++ b/.agent/skills/ui-ux-pro-max/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ui-ux-pro-max
-description: UI/UX design intelligence. 50 styles, 21 palettes, 50 font pairings, 20 charts, 9 stacks.
+description: UI/UX 設計參考資料庫 (CSV-based)：67 styles、96 palettes、56 font pairings、98 UX guidelines、25 chart types。對本專案 sidepanel UI 最相關的查詢是 colors.csv / typography.csv / ui-reasoning.csv / styles.csv。需 Python 3 跑 scripts/search.py。當使用者提到「配色、字型、palette、design system、UI 設計風格挑選」時觸發。
 ---
 # ui-ux-pro-max
 

--- a/.agent/skills/update-multilingual-docs/SKILL.md
+++ b/.agent/skills/update-multilingual-docs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: update-multilingual-docs
-description: "Updates documentation (README and store descriptions) across multiple languages."
+description: 同步本專案多語系文件：.github/i18n/{lang}/{README,CONTRIBUTING}.md（根目錄為 symlink 指向 en/）與 docs/chrome-web-store/store_description_*.md (14 種語言)。當使用者提到「多語系、i18n 文件、翻譯文件、更新 README 多語、store description、Chrome Web Store 描述」時觸發。
 ---
 
 # Update Multilingual Documentation

--- a/.agent/skills/vercel-react-best-practices
+++ b/.agent/skills/vercel-react-best-practices
@@ -1,1 +1,0 @@
-../../.agents/skills/vercel-react-best-practices

--- a/.agents/skills/web-design-guidelines/SKILL.md
+++ b/.agents/skills/web-design-guidelines/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: web-design-guidelines
-description: Review UI code for Web Interface Guidelines compliance. Use when asked to "review my UI", "check accessibility", "audit design", "review UX", or "check my site against best practices".
+description: 依 Vercel Web Interface Guidelines 審查本專案 sidepanel UI 程式碼。對 sidepanel 窄寬度 (~300-400px)、scrollable 列表、Chrome theme 配色、鍵盤導航、aria 標籤特別關注。當使用者提到「審查 UI、check accessibility、audit design、review UX、檢查無障礙、檢查設計、UI review」時觸發。
 metadata:
   author: vercel
   version: "1.0.0"
@@ -9,31 +9,72 @@ metadata:
 
 # Web Interface Guidelines
 
-Review files for compliance with Web Interface Guidelines.
+依 Vercel Web Interface Guidelines 審查本專案的 UI 程式碼，並以本 Chrome extension sidepanel 的場景做額外加強。
 
 ## How It Works
 
-1. Fetch the latest guidelines from the source URL below
-2. Read the specified files (or prompt user for files/pattern)
-3. Check against all rules in the fetched guidelines
-4. Output findings in the terse `file:line` format
+1. 從以下來源抓取最新 guidelines
+2. 讀取使用者指定的檔案（或詢問檔案 / pattern）
+3. 對照所有規則 + 本專案 sidepanel-specific 注意事項
+4. 以 `file:line` 簡明格式輸出問題
 
 ## Guidelines Source
 
-Fetch fresh guidelines before each review:
+每次審查前 fetch 最新版：
 
 ```
 https://raw.githubusercontent.com/vercel-labs/web-interface-guidelines/main/command.md
 ```
 
-Use WebFetch to retrieve the latest rules. The fetched content contains all the rules and output format instructions.
+用 WebFetch 抓取，回傳內容含完整規則與輸出格式說明。
 
 ## Usage
 
-When a user provides a file or pattern argument:
-1. Fetch guidelines from the source URL above
-2. Read the specified files
-3. Apply all rules from the fetched guidelines
-4. Output findings using the format specified in the guidelines
+使用者給檔案或 pattern：
+1. 從上方 URL 抓 guidelines
+2. Read 指定檔案
+3. 套用 guidelines 內所有規則 + 下方 sidepanel-specific 加強檢查
+4. 依 guidelines 規定的格式輸出
 
-If no files specified, ask the user which files to review.
+若未指定檔案，詢問要審哪些。
+
+## 本專案 Sidepanel-Specific 加強檢查
+
+通用 Web Interface Guidelines 沒涵蓋的 Chrome extension sidepanel 特殊情境：
+
+### Layout & Density
+- **寬度約束**：sidepanel 預設 ~320px，使用者可拖到 ~700px。所有 layout 不可預設 desktop 寬度。檢查是否有 hardcoded `width: 800px` 之類；改用 `max-width` 或彈性布局。
+- **垂直 scroll 是主互動**：列表項目間距不宜過大；`flex-shrink-0` 避免 header / footer 被擠。
+- **避免水平 scroll**：長文字用 `text-overflow: ellipsis`、`word-break: break-word`、`min-width: 0` 處理。
+
+### Chrome Theme 整合
+- **繼承 Chrome theme 配色**：sidepanel 應透過 `chrome.theme` API 或 CSS 變數讀系統 dark mode（`prefers-color-scheme`）。檢查是否硬編碼 `#fff` / `#000`。
+- **自訂主題不可破壞無障礙**：`modules/ui/customThemeManager.js` 提供自訂配色，但須通過 `modules/utils/colorUtils.js` 的 WCAG 4.5:1 對比度檢查（refs `image-master` skill）。
+
+### Keyboard Navigation（sidepanel 重點）
+- **Tab order**：分頁、書籤、閱讀清單、設定按鈕的 tab 順序須符合視覺順序。
+- **Focus ring**：純圖示按鈕（`modules/icons.js` 的 SVG）必須有 `:focus-visible` 樣式。
+- **Drag-drop 替代方案**：拖曳分頁 / 書籤的 SortableJS 操作須有鍵盤替代方式（上下方向鍵 + Enter 確認）或至少 ARIA 提示。
+
+### ARIA / Semantics
+- **純圖示按鈕**：必須有 `aria-label`，並建議加 `title` 提供 tooltip（沿用 AGENTS.md "Memory Tips" 規範）。
+- **動態列表 announcement**：書籤展開 / 閱讀清單新增 / Toast 訊息應使用 `aria-live="polite"` 區域。
+- **Modal**：`modules/modalManager.js` 的 prompt / confirm dialog 必須有 `role="dialog"` 與 `aria-modal="true"`，並把 focus trap 在 modal 內。
+
+### Performance（sidepanel 常駐 → 對效能更敏感）
+- **避免每次重繪整棵 list**：書籤 / 分頁列表變化時用 diff render，不要 `innerHTML = ''` 重畫。
+- **DocumentFragment 批次更新**（AGENTS.md "Memory Tips" 已列）。
+- **避免在 list 內塞大尺寸圖片**：favicon 用 16-32px 即可；自訂背景圖請 WebP 壓縮。
+
+### 安全
+- **嚴禁 `innerHTML` 處理 user input**：使用 `textContent` 或 `modules/utils/textUtils.js` 的 `escapeHtml`。
+- **CSP 相容**：sidepanel 受 extension CSP 限制，不可使用 `eval` / inline scripts / 外部 CDN。
+
+## 輸出格式範例
+
+```
+sidepanel.html:42  純圖示按鈕缺少 aria-label
+modules/ui/tabRenderer.js:88  使用 innerHTML 渲染來自 chrome.tabs API 的標題，未經 escapeHtml
+modules/ui/customThemeManager.js:130  自訂背景色與 foreground 對比度低於 WCAG AA (3.2:1)
+```
+

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,38 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(make)",
+      "Bash(make:*)",
+      "Bash(npm test)",
+      "Bash(npm test:*)",
+      "Bash(npm run:*)",
+      "Bash(npm ci)",
+      "Bash(npm install)",
+      "Bash(npm install:*)",
+      "Bash(npx:*)",
+      "Bash(node:*)",
+      "Bash(jq:*)",
+      "Bash(git status)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(git show:*)",
+      "Bash(git branch:*)",
+      "Bash(git fetch:*)",
+      "Bash(git pull:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)",
+      "Bash(git push:*)",
+      "Bash(git checkout:*)",
+      "Bash(git switch:*)",
+      "Bash(git restore:*)",
+      "Bash(git stash:*)",
+      "Bash(/opt/homebrew/bin/gh:*)",
+      "Bash(ls:*)",
+      "Bash(cat:*)",
+      "Bash(grep:*)",
+      "Bash(rg:*)",
+      "Bash(find:*)",
+      "Bash(readlink:*)"
+    ]
+  }
+}

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agent/skills

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ tmp/
 jest-storage
 .vscode/settings.json
 scripts/action-runner/.env
+.envrc

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,12 @@ make clean
 | `refactoring` | 重構技巧與程式碼異味辨識 | 程式碼改善時 |
 | `release-notes` | 雙語 Release Note 產生 | 發布版本時 |
 | `update-multilingual-docs` | 多語系文件更新 | 文件翻譯時 |
+| `puppeteer-test` | Puppeteer + Jest E2E 測試指南 | 撰寫 / 修 E2E 測試時 |
+| `cleanup-merged-branches` | 清理已合併的本地 / 遠端分支 | merge 後清理分支時 |
+| `image-master` | 影像格式 / WebP / 色彩 / WCAG 對比度 | 處理圖示 / 自訂背景圖 / Web Store 截圖時 |
+| `web-design-guidelines` | sidepanel UI 與無障礙審查 | 審查 UI 程式碼 / 檢查 accessibility 時 |
+| `ui-ux-pro-max` | UI/UX 設計參考資料庫 (CSV + Python) | 挑選配色 / 字型 / design pattern 時 |
+| `skill-creator` | 撰寫新 skill 的 meta 指南 | 新增 / 更新 skill 時 |
 
 ### 📝 Workflows (工作流程)
 位於 `.agent/workflows/`，定義標準化操作步驟。
@@ -69,6 +75,8 @@ make clean
 | `create-release-note.md` | `/create-release-note` | 產生 Release Note |
 | `update-docs.md` | `/update-docs` | 更新多語系文件 |
 | `cleanup-branches.md` | `/cleanup-branches` | 清理已合併分支 |
+| `puppeteer-test.md` | `/puppeteer-test` | 撰寫 E2E 測試流程 |
+| `create-skill.md` | `/create-skill` | 建立新 skill 的流程 |
 
 ### 📜 Rules (最高遵循方針)
 位於 `.agent/rules/`，**必須嚴格遵守**。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,56 @@
+# Claude Code Project Guide — arc-like-chrome-extension
+
+> **主要文件指向**：請先讀 `AGENTS.md`（含 Quick Start、Skill / Workflow / Rules 索引）
+> 與 `.agent/rules/RULE_002_ARCHITECTURE.md`、`.agent/rules/RULE_006_PR_REVIEW_GUIDELINES.md`。
+> 本檔僅補充 Claude Code 環境專屬的操作慣例，不重複 AGENTS.md 已有內容。
+
+---
+
+## 0. Claude Code 工作慣例
+
+- **對話語言**：繁體中文（zh-TW），程式碼識別字保留英文。
+- **`gh` CLI 路徑**：本機 `gh` 安裝於 `/opt/homebrew/bin/gh`。當 PATH 解析有問題時請使用絕對路徑。
+- **建置與測試**：
+  - 開發版：`make`（產生 `arc-sidebar-vX.X.X-dev.zip`）
+  - 發布版：`make release`
+  - 清理：`make clean`
+  - 測試：`npm test`（Jest + Puppeteer）
+  - 需要 `jq` 才能自動讀取版本號
+- **預覽方式**：`chrome://extensions` → 開發人員模式 → 載入未封裝的項目 → 選擇本專案根目錄。
+- **Skill 自動觸發**：使用者提到下列關鍵字時，主動 invoke 對應的 `.claude/skills/<name>/SKILL.md`：
+  - 「SDD / 新功能 / 修 bug」→ `sdd`
+  - 「PRD / 產品需求」→ `prd`
+  - 「SA / 系統分析」→ `sa`
+  - 「review PR / 審查 / 程式碼審查」→ `code-review`
+  - 「建 PR / pull request」→ `pull-request`
+  - 「commit message / 提交訊息」→ `commit-message-helper`
+  - 「refactor / 重構」→ `refactoring`
+  - 「release note / 發版說明」→ `release-notes`
+  - 「多語系 / i18n 文件」→ `update-multilingual-docs`
+  - 「Puppeteer 測試 / E2E」→ `puppeteer-test`
+  - 「圖片格式 / WebP / 圖示處理 / 自訂背景圖」→ `image-master`
+  - 「清理分支 / cleanup branches」→ `cleanup-merged-branches`
+  - 「配色 / 字型 / palette / design system」→ `ui-ux-pro-max`
+  - 「審查 UI / 檢查無障礙 / accessibility / UI review」→ `web-design-guidelines`
+  - 「建立新 skill / 寫 skill」→ `skill-creator`
+- **Session 收尾**：沿用既有 Context Engineering 慣例 — 收斂變更摘要寫入 `.agent/notes/NOTE_YYYYMMDD.md`，作為未來開發脈絡參考。
+
+## 1. Commit / PR / Release Note 規範
+
+- **Commit**：遵循 `.agent/skills/commit-message-helper/SKILL.md`（Conventional Commits；subject 英文、body 繁中說明背景／原因／實作細節）。
+- **PR**：遵循 `.agent/skills/pull-request/SKILL.md` 與 `.agent/rules/RULE_006_PR_REVIEW_GUIDELINES.md`。
+  - 使用 `gh` CLI 進行 review，語言用 zh-TW。
+- **Release Note**：遵循 `.agent/skills/release-notes/SKILL.md`，沿用 `.github/release.yml` 的區塊結構（✨ 新功能、🚀 改善與錯誤修復）。產出的 `RELEASE_NOTE.md` 為暫存預覽，**不入版控**。
+
+## 2. 與 GEMINI.md 的關係
+
+- `GEMINI.md` 為 gemini-cli 專屬設定檔，**保留供雙工具並存**。
+- `AGENTS.md` 為 cross-tool 真實來源；`CLAUDE.md` / `GEMINI.md` 各自寫工具專屬補充。
+- **不雙寫同步、不設 drift CI**：三份檔案分別維護，AGENTS.md 結構大改時手動更新各副本。
+- 若改動到 key file 用途或新增模組，**仍需同步更新 `GEMINI.md` 內的 `key_files` 描述**（這是 GEMINI.md 獨有的、AGENTS.md 沒有的資訊；屬於專案歷史約定）。
+
+## 3. 開發紀律（沿用 .agent/rules/）
+
+- **SDD-first**：新功能或非 trivial 修復前先讀 `sdd` skill；無 spec 不寫 code。
+- **連動影響**：改動 `manifest.json` / `sidepanel.js` / `modules/ui/elements.js` 等核心檔案時，需同步檢視相依模組（參考 `AGENTS.md` Skill Index 與 `RULE_002_ARCHITECTURE.md`）。
+- **`.claude/skills/` 來源**：實際指向 `../.agent/skills/`（軟連結）。更新 skill 內容請編輯 `.agent/skills/<name>/SKILL.md`，Claude Code 與 gemini-cli 會同步看到變更。


### PR DESCRIPTION
## 摘要 / Summary

本 PR 同時做兩件事：

1. **新增 Claude Code 環境支援，與既有 gemini-cli 並存** / **Add Claude Code support alongside existing gemini-cli**
   - `CLAUDE.md`（51 行）：指向 `AGENTS.md` 為主來源，補 Claude 專屬工作慣例
     （繁中對話、`gh` 全路徑、skill 自動觸發詞、與 GEMINI.md 不雙寫同步）
   - `.claude/skills` → `../.agent/skills` 軟連結（與 `.gemini/skills` 同 pattern）
   - `.claude/settings.json`：放行 make / npm / gh / git / jq 等常用指令，減少 permission prompt

2. **優化 `.agent/skills/` 的 skill 描述與內容** / **Refine `.agent/skills/` descriptions and content**
   - 14 個 `SKILL.md` 重寫 frontmatter description：加入中文觸發詞與 Chrome extension / vanilla JS / Manifest V3 等專案上下文，提升 AI agent 觸發精準度
   - 6 個 `SKILL.md` 補強「本專案場景」章節（`prd` / `sa` / `image-master` / `commit-message-helper` / `cleanup-merged-branches` / `web-design-guidelines`）
   - 刪除 `.agent/skills/vercel-react-best-practices`：React/Next.js 內容與本專案 vanilla JS Chrome extension 完全錯位
   - 刪除 `.agent/skills/jules`：空殼目錄無 `SKILL.md`
   - `AGENTS.md` Skill Index 由 9 條補到 15 條、Workflows 由 6 條補到 8 條

3. **雜項 / Misc**
   - `.gitignore` 新增 `.envrc`（搭配 direnv，避免誤 commit 本機 `GH_TOKEN`）

## 動機 / Motivation

讓 Claude Code 與 gemini-cli 都能在此 repo 開機時自動讀規則、觸發對應 skill、知道 build/test/deploy 指令；並使所有 skill 描述精準對齊 Chrome extension 場景（避免誤觸發或給出泛泛建議）。

## Test Plan

- [ ] `ls -la .claude/skills && readlink .claude/skills` → 軟連結指向 `../.agent/skills`
- [ ] `ls .claude/skills/ | wc -l` → 15
- [ ] 用 Claude Code 在此 repo 啟動，確認 `CLAUDE.md` 自動載入
- [ ] 對 Claude 說「review PR」→ 觸發 `code-review` skill
- [ ] 對 Claude 說「新功能」→ 觸發 `sdd` skill
- [ ] `make` 與 `npm test` 可正常執行（settings.json 已放行）
- [ ] gemini-cli 不受影響：`.gemini/skills` 軟連結仍可用、`GEMINI.md` 內容未變

## Follow-up（不在本 PR）

`.agents/`（複數 typo 目錄）仍含 `vercel-react-best-practices/` 與 `web-design-guidelines/` 副本。本 PR 已透過 hardlink 將 `web-design-guidelines` 的修改寫入該路徑；整體 typo 清理留待另開 PR。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)