### PR TITLE
feat(ai): auto-name empty groups + inline tab cleanup section

### DIFF
--- a/.agent/notes/NOTE_20260526_phase4.md
+++ b/.agent/notes/NOTE_20260526_phase4.md
@@ -1,0 +1,67 @@
+# 開發摘要 - 2026-05-26 (Phase 4: AI Phase 2)
+
+> 對應 PRD `docs/specs/feature/BASE-010_zero-config-local-ai`（FR-1.x 群組自動命名、FR-2.x 清理建議）。FR-3.x 行銷訊息留給 Phase 10 戰略重定位。
+
+## 變更項目
+
+### 1. AI 群組自動命名（Auto Group Naming）
+
+- `modules/aiManager.js`：新增 `generateGroupName(tabsInfo)`。
+  - 用既有 LanguageModel session（systemPrompt 強制 JSON 輸出）。
+  - 要求 model 回 `[{ "label": "<Emoji> <ShortName>" }]`，parse 後取 `[0].label`。
+  - **比 `generateGroups` 更嚴格的可用性閘**：用 `=== 'available'` 而非 `!== 'unavailable'`，避免在 background 內 silent 觸發數 GB 模型下載。
+
+- `background.js`：監聽 `chrome.tabGroups.onCreated`。
+  - 觸發條件：`title === ""` + `aiAutoNamingEnabled === true`（讀 `chrome.storage.sync`）。
+  - **架構選擇**：listener 放 background 是因為 onCreated 是全域 event，sidepanel 內監聽會多 window 重複觸發。
+  - **race guard**：呼叫 AI 後寫入前重 `chrome.tabGroups.get(id)` 確認 title 仍空白，避免覆蓋使用者手動輸入。
+
+- `modules/stateManager.js`：加 `isAiAutoNamingEnabled()` / `setAiAutoNamingEnabled()`。預設 enabled。
+
+- `modules/ui/settingManager.js`：加 toggle in 設定面板。
+- `sidepanel.js`：`initialize` 內 `state.initAiAutoNaming()`。
+
+### 2. AI 分頁清理建議（Cleanup Suggestion）
+
+- `modules/aiManager.js`：新增 `generateCleanupSuggestions(tabsInfo)`。
+  - Input 每個 tab 帶 `lastAccessedMinutesAgo`（Chrome 122+ tab.lastAccessed），交 AI 綜合判定（非純時間 filter）。
+  - prompt 明寫「conservative — when in doubt, skip」+ 「If no good candidate, reply []」防止 AI 誤判過度建議。
+  - Output `[{tabId, reason}]`，reason 限 30 字 + UI 語系。
+
+- `modules/ui/aiCleanupUI.js`（新模組）：
+  - inline section（不是 modal）——sidepanel 太窄、modal + 多項勾選 UX 不佳。
+  - 流程：按按鈕 → 分析中 status → 渲染 checkbox 列表（預設全勾）→ 全選/全不選 → 確認 → 批次 `chrome.tabs.remove`。
+  - 空狀態：「你的分頁很整潔」友善提示。
+  - 過濾：跳過 pinned tab 與 active tab（避免關掉使用者當前頁面）。
+
+- `modules/stateManager.js`：加 `isAiCleanupVisible()` / `setAiCleanupVisible()`。預設 visible。
+- `modules/uiManager.js`：re-export aiCleanupUI。
+- `sidepanel.html`：頂部 header 加 🧹 按鈕；tab-list 上方加 cleanup section 容器。
+- `sidepanel.css`：~80 行新樣式 `.ai-cleanup-*`。
+
+### 3. i18n（en / zh_TW / zh_CN）
+
+13 個新字串（toggle label / description / button text / section header / status / empty / found / error / select-all / confirm 等）× 3 語言。其他 11 個語系（ja / ko / vi / th / de / fr / es / pt_BR / hi / id / ru）留 Phase 11 集中翻譯。
+
+## 技術決策
+
+- **Naming 觸發位置 = background**：唯一全域單一觸發點。sidepanel 端會 per-window 觸發 → 重複。
+- **Naming `available` only**：background 不應靜默觸發數 GB 下載；user-initiated 的 Smart Auto-Grouping 才允許 trigger 下載。Cleanup 也是 user-initiated 但走 `checkModelReadiness`（允許 downloadable）。
+- **Cleanup UI = inline section**：sidepanel 窄寬度不適合 modal。
+- **Cleanup 「閒置」由 AI 綜合判定**：純時間 filter 太僵硬；AI 加入「duplicate / finished task」等語意訊號。
+- **Race guard for naming**：AI prompt 結束後使用者可能已輸入 title，寫入前重 query。
+- **Skip pinned + active tab**：cleanup 預設不建議關閉這兩種。
+
+## 驗證
+
+- esbuild bundle: sidepanel + background 皆通過
+- JSON: 3 個 messages.json 合法
+- Unit tests: 57/57 通過（無回退）
+- Puppeteer: happy_path_sidepanel_load + happy_path_settings_panel（測試結果見 PR）
+- **AI 行為手動驗證待做**：需實機 Chrome 載入 extension，Gemini Nano 必須是 `available` 狀態才能驗證 naming；Cleanup 可在任何狀態觸發以測 UI flow
+
+## 待辦
+
+- 11 個其他語系翻譯 → Phase 11
+- Puppeteer test 補 AI cleanup flow（mock chrome.tabs.remove 即可，不必真叫 AI）→ 可在後續 phase 補
+- AI 行為（prompt 品質）需實機跑 Chrome 開 Gemini Nano 確認

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -644,6 +644,45 @@
   "aiGroupingDescription2_part2": {
     "message": " to download the Local Model and enable the relevant Flags."
   },
+  "aiAutoNamingToggleLabel": {
+    "message": "Auto-name empty tab groups"
+  },
+  "aiAutoNamingDescription": {
+    "message": "When you create a new tab group without a title, AI suggests a short label (Emoji + name). Runs only when the local model is already downloaded."
+  },
+  "aiCleanupToggleLabel": {
+    "message": "Show 🧹 Tab Cleanup button"
+  },
+  "aiCleanupDescription": {
+    "message": "Adds a button next to Smart Group that asks AI which tabs you can probably close."
+  },
+  "aiCleanupBtnText": {
+    "message": "🧹 Cleanup"
+  },
+  "aiCleanupBtnTitle": {
+    "message": "AI-suggested tab cleanup"
+  },
+  "aiCleanupSectionHeader": {
+    "message": "Tabs you might close"
+  },
+  "aiCleanupAnalyzing": {
+    "message": "Analyzing tabs..."
+  },
+  "aiCleanupEmpty": {
+    "message": "Your tabs look tidy — nothing to clean up."
+  },
+  "aiCleanupFound": {
+    "message": "AI suggests {count} tab(s) you can probably close. Uncheck any you want to keep."
+  },
+  "aiCleanupError": {
+    "message": "AI cleanup failed. Try again later."
+  },
+  "aiCleanupSelectAll": {
+    "message": "Select all"
+  },
+  "aiCleanupConfirm": {
+    "message": "Close selected"
+  },
   "languageSectionHeader": {
     "message": "Language"
   },

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -668,6 +668,9 @@
   "aiCleanupAnalyzing": {
     "message": "Analyzing tabs..."
   },
+  "aiCleanupNeedsDownload": {
+    "message": "AI model is not downloaded yet. Click ✨ Smart Group first to start the download."
+  },
   "aiCleanupEmpty": {
     "message": "Your tabs look tidy — nothing to clean up."
   },

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -665,6 +665,9 @@
   "aiCleanupAnalyzing": {
     "message": "分析标签页中..."
   },
+  "aiCleanupNeedsDownload": {
+    "message": "AI 模型尚未下载。请先点击 ✨ 智能整理 开始下载。"
+  },
   "aiCleanupEmpty": {
     "message": "你的标签页很整洁，没有需要清理的项目。"
   },

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -641,6 +641,45 @@
   "aiGroupingDescription2_part2": {
     "message": "下载 Local Model 并开启相关 Flag 来启用。"
   },
+  "aiAutoNamingToggleLabel": {
+    "message": "自动命名未命名的标签页群组"
+  },
+  "aiAutoNamingDescription": {
+    "message": "当你创建一个没有名称的新标签页群组时，AI 会自动生成一个简短的标签（Emoji + 名称）。仅在本地模型已下载完成时生效。"
+  },
+  "aiCleanupToggleLabel": {
+    "message": "显示 🧹 标签页清理按钮"
+  },
+  "aiCleanupDescription": {
+    "message": "在「智能整理」旁加一个按钮，让 AI 建议你可能可以关闭的标签页。"
+  },
+  "aiCleanupBtnText": {
+    "message": "🧹 清理"
+  },
+  "aiCleanupBtnTitle": {
+    "message": "AI 标签页清理建议"
+  },
+  "aiCleanupSectionHeader": {
+    "message": "可考虑关闭的标签页"
+  },
+  "aiCleanupAnalyzing": {
+    "message": "分析标签页中..."
+  },
+  "aiCleanupEmpty": {
+    "message": "你的标签页很整洁，没有需要清理的项目。"
+  },
+  "aiCleanupFound": {
+    "message": "AI 建议可关闭 {count} 个标签页，想保留的请取消勾选。"
+  },
+  "aiCleanupError": {
+    "message": "AI 清理失败，请稍后再试。"
+  },
+  "aiCleanupSelectAll": {
+    "message": "全选"
+  },
+  "aiCleanupConfirm": {
+    "message": "关闭所选"
+  },
   "languageSectionHeader": {
     "message": "界面语言 (Language)"
   },

--- a/_locales/zh_TW/messages.json
+++ b/_locales/zh_TW/messages.json
@@ -665,6 +665,9 @@
   "aiCleanupAnalyzing": {
     "message": "分析分頁中..."
   },
+  "aiCleanupNeedsDownload": {
+    "message": "AI 模型尚未下載。請先點擊 ✨ 智慧整理 開始下載。"
+  },
   "aiCleanupEmpty": {
     "message": "你的分頁很整潔，沒有需要清理的項目。"
   },

--- a/_locales/zh_TW/messages.json
+++ b/_locales/zh_TW/messages.json
@@ -641,6 +641,45 @@
   "aiGroupingDescription2_part2": {
     "message": " 下載 Local Model 並開啟相關 Flag 來啟用。"
   },
+  "aiAutoNamingToggleLabel": {
+    "message": "自動命名未命名的分頁群組"
+  },
+  "aiAutoNamingDescription": {
+    "message": "當你建立一個沒有名稱的新分頁群組時，AI 會自動產生一個簡短的標籤（Emoji + 名稱）。僅在本地模型已下載完成時生效。"
+  },
+  "aiCleanupToggleLabel": {
+    "message": "顯示 🧹 分頁清理按鈕"
+  },
+  "aiCleanupDescription": {
+    "message": "在「智慧整理」旁加一個按鈕，讓 AI 建議你可能可以關閉的分頁。"
+  },
+  "aiCleanupBtnText": {
+    "message": "🧹 清理"
+  },
+  "aiCleanupBtnTitle": {
+    "message": "AI 分頁清理建議"
+  },
+  "aiCleanupSectionHeader": {
+    "message": "可考慮關閉的分頁"
+  },
+  "aiCleanupAnalyzing": {
+    "message": "分析分頁中..."
+  },
+  "aiCleanupEmpty": {
+    "message": "你的分頁很整潔，沒有需要清理的項目。"
+  },
+  "aiCleanupFound": {
+    "message": "AI 建議可關閉 {count} 個分頁，想保留的請取消勾選。"
+  },
+  "aiCleanupError": {
+    "message": "AI 清理失敗，請稍後再試。"
+  },
+  "aiCleanupSelectAll": {
+    "message": "全選"
+  },
+  "aiCleanupConfirm": {
+    "message": "關閉所選"
+  },
   "languageSectionHeader": {
     "message": "介面語言 (Language)"
   },

--- a/background.js
+++ b/background.js
@@ -47,6 +47,15 @@ chrome.tabGroups.onCreated.addListener(async (group) => {
         const settings = await chrome.storage.sync.get([AI_AUTO_NAMING_KEY]);
         if (settings[AI_AUTO_NAMING_KEY] === false) return; // disabled by user
 
+        // Two reasons for an 800ms delay before querying tabs:
+        // 1. onCreated fires before Chrome finishes binding the dragged tabs'
+        //    groupId, so an immediate chrome.tabs.query would return [].
+        // 2. Gives the user a window to start typing a manual title in Chrome's
+        //    title-input popover. We can't detect input-focus on a group title
+        //    (no API for it), so a delay is the only mitigation against
+        //    overwriting in-progress typing.
+        await new Promise(resolve => setTimeout(resolve, 800));
+
         const tabs = await chrome.tabs.query({ groupId: group.id });
         if (!tabs || tabs.length === 0) return;
 

--- a/background.js
+++ b/background.js
@@ -1,6 +1,9 @@
 // background.js
 
 import { handleAlarm as handleRssAlarm } from './modules/rssManager.js';
+import { generateGroupName } from './modules/aiManager.js';
+
+const AI_AUTO_NAMING_KEY = 'aiAutoNamingEnabled';
 
 // 監聽快捷鍵指令
 chrome.commands.onCommand.addListener(async (command) => {
@@ -33,6 +36,35 @@ chrome.runtime.onInstalled.addListener(() => {
 
 // 監聯 RSS 定時抓取鬧鐘
 chrome.alarms.onAlarm.addListener(handleRssAlarm);
+
+// AI Auto Group Naming: 當使用者建立一個空白名稱的新群組時，由 background
+// 統一處理避免多 sidepanel 重複觸發。generateGroupName 內部已限制只在
+// model === 'available' 時執行（不會 silent kick off model download）。
+chrome.tabGroups.onCreated.addListener(async (group) => {
+    try {
+        if (group.title && group.title.trim()) return; // user provided a title
+
+        const settings = await chrome.storage.sync.get([AI_AUTO_NAMING_KEY]);
+        if (settings[AI_AUTO_NAMING_KEY] === false) return; // disabled by user
+
+        const tabs = await chrome.tabs.query({ groupId: group.id });
+        if (!tabs || tabs.length === 0) return;
+
+        const label = await generateGroupName(tabs.map(t => ({ title: t.title, url: t.url })));
+        if (!label) return;
+
+        // Re-check before writing: the user may have typed a title while
+        // the AI request was in flight. Don't clobber human input.
+        const current = await chrome.tabGroups.get(group.id);
+        if (current.title && current.title.trim()) return;
+
+        await chrome.tabGroups.update(group.id, { title: label });
+    } catch (err) {
+        // Group may have been removed, or AI call may have failed.
+        // Naming is best-effort by design (PRD FR-1.06 silent skip).
+        console.warn('[AI naming] skipped:', err && err.message ? err.message : err);
+    }
+});
 
 // 監聽來自側邊面板的訊息
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {

--- a/modules/aiManager.js
+++ b/modules/aiManager.js
@@ -292,3 +292,116 @@ ${tabsData}`;
         tabIds: processingTabs.map(t => t.id)
     }];
 }
+
+/**
+ * Generates a concise group name ("Emoji + ShortName") for a freshly-created tab group.
+ * Reuses the shared LanguageModel session (whose systemPrompt enforces JSON output),
+ * so we ask the model to reply with a JSON array carrying a single `label` field.
+ * @param {Array<{title: string, url: string}>} tabsInfo - Tabs in the new group.
+ * @returns {Promise<string|null>} The label "<Emoji> <ShortName>" or null on failure / AI unavailable.
+ */
+export async function generateGroupName(tabsInfo) {
+    if (!Array.isArray(tabsInfo) || tabsInfo.length === 0) return null;
+    // Stricter than checkModelReadiness: skip 'downloadable'/'downloading'.
+    // Naming runs in the background — we must not silently kick off a multi-GB
+    // download. Wait until the user explicitly triggers Smart Auto-Grouping.
+    if ((await checkModelAvailability()) !== 'available') return null;
+
+    const MAX_TABS = 10; // Group rarely has >10 tabs; cap for token budget
+    const sample = tabsInfo.slice(0, MAX_TABS).map(t => {
+        let cleanUrl = t.url || '';
+        try {
+            const u = new URL(cleanUrl);
+            cleanUrl = u.hostname + u.pathname;
+            if (cleanUrl.length > 80) cleanUrl = cleanUrl.substring(0, 80) + '...';
+        } catch { /* ignore non-URL */ }
+        let cleanTitle = t.title || 'No Title';
+        if (cleanTitle.length > 60) cleanTitle = cleanTitle.substring(0, 60) + '...';
+        return { title: cleanTitle, url: cleanUrl };
+    });
+    const tabsData = sample.map(t => `Title: ${t.title} | URL: ${t.url}`).join('\n');
+    const currentLang = api.getResolvedUILanguage();
+
+    const prompt = `You are a tab group naming assistant. Generate ONE concise label for the following tabs.
+Reply strictly in JSON array format (no markdown, no extra text):
+[
+  { "label": "<Emoji> <ShortName in locale '${currentLang}', max 15 chars>" }
+]
+
+[Tabs]
+${tabsData}`;
+
+    try {
+        const session = await getOrCreateLanguageModelSession();
+        const result = await session.prompt(prompt);
+        const jsonMatch = result.match(/\[\s*\{[\s\S]*?\}\s*\]/);
+        const parsed = JSON.parse(jsonMatch ? jsonMatch[0] : result);
+        const label = Array.isArray(parsed) && parsed[0] && typeof parsed[0].label === 'string'
+            ? parsed[0].label.trim()
+            : null;
+        return label || null;
+    } catch (err) {
+        console.warn('[AI] generateGroupName failed:', err);
+        destroyLanguageModelSession();
+        return null;
+    }
+}
+
+/**
+ * Asks the model which tabs are good cleanup candidates and why.
+ * @param {Array<{id: number, title: string, url: string, lastAccessedMinutesAgo: number}>} tabsInfo
+ * @returns {Promise<Array<{tabId: number, reason: string}>>} Empty array if AI declines, unavailable, or parsing fails.
+ */
+export async function generateCleanupSuggestions(tabsInfo) {
+    if (!Array.isArray(tabsInfo) || tabsInfo.length === 0) return [];
+    if (!(await checkModelReadiness())) return [];
+
+    const MAX_TABS = 30;
+    const sample = tabsInfo.slice(0, MAX_TABS).map(t => {
+        let cleanUrl = t.url || '';
+        try {
+            const u = new URL(cleanUrl);
+            cleanUrl = u.hostname + u.pathname;
+            if (cleanUrl.length > 80) cleanUrl = cleanUrl.substring(0, 80) + '...';
+        } catch { /* ignore */ }
+        let cleanTitle = t.title || 'No Title';
+        if (cleanTitle.length > 60) cleanTitle = cleanTitle.substring(0, 60) + '...';
+        return { id: t.id, title: cleanTitle, url: cleanUrl, idleMin: t.lastAccessedMinutesAgo };
+    });
+    const tabsData = sample
+        .map(t => `ID: ${t.id} | Title: ${t.title} | URL: ${t.url} | LastAccessedMinutesAgo: ${t.idleMin}`)
+        .join('\n');
+    const currentLang = api.getResolvedUILanguage();
+
+    const prompt = `You are a tab cleanup advisor. From the list below, identify tabs that the user can safely close.
+Criteria to consider:
+- LastAccessedMinutesAgo is large (e.g., > 60 minutes) AND content seems non-essential
+- Multiple tabs cover the same topic or duplicate URL
+- Tab appears to be a finished task (e.g., "Sign in" pages, completed search results)
+Be conservative — when in doubt, skip the tab.
+
+Reply strictly in JSON array format (no markdown, no extra text). Reasons MUST be in locale '${currentLang}', max 30 chars:
+[
+  { "tabId": 12, "reason": "<short reason in ${currentLang}>" }
+]
+
+If no tab is a good candidate, reply with: []
+
+[Tabs]
+${tabsData}`;
+
+    try {
+        const session = await getOrCreateLanguageModelSession();
+        const result = await session.prompt(prompt);
+        const jsonMatch = result.match(/\[[\s\S]*\]/);
+        const parsed = JSON.parse(jsonMatch ? jsonMatch[0] : result);
+        if (!Array.isArray(parsed)) return [];
+        return parsed
+            .filter(p => p && typeof p.tabId === 'number' && typeof p.reason === 'string')
+            .map(p => ({ tabId: p.tabId, reason: p.reason.trim().slice(0, 40) }));
+    } catch (err) {
+        console.warn('[AI] generateCleanupSuggestions failed:', err);
+        destroyLanguageModelSession();
+        return [];
+    }
+}

--- a/modules/stateManager.js
+++ b/modules/stateManager.js
@@ -184,6 +184,50 @@ export async function setAiGroupingVisible(visible) {
   await setStorage('sync', { [AI_GROUPING_VISIBLE_KEY]: visible });
 }
 
+// --- AI Auto Group Naming State ---
+
+const AI_AUTO_NAMING_KEY = 'aiAutoNamingEnabled';
+let aiAutoNamingEnabled = true; // Default to enabled
+
+/**
+ * Loads the AI Auto Naming state from chrome.storage.sync.
+ * @returns {Promise<boolean>}
+ */
+export async function initAiAutoNaming() {
+  const result = await getStorage('sync', [AI_AUTO_NAMING_KEY]);
+  aiAutoNamingEnabled = result[AI_AUTO_NAMING_KEY] !== false; // Default true if not set
+  return aiAutoNamingEnabled;
+}
+
+export function isAiAutoNamingEnabled() {
+  return aiAutoNamingEnabled;
+}
+
+export async function setAiAutoNamingEnabled(enabled) {
+  aiAutoNamingEnabled = enabled;
+  await setStorage('sync', { [AI_AUTO_NAMING_KEY]: enabled });
+}
+
+// --- AI Cleanup Suggestion Visibility State ---
+
+const AI_CLEANUP_VISIBLE_KEY = 'aiCleanupVisible';
+let aiCleanupVisible = true; // Default to visible
+
+export async function initAiCleanupVisibility() {
+  const result = await getStorage('sync', [AI_CLEANUP_VISIBLE_KEY]);
+  aiCleanupVisible = result[AI_CLEANUP_VISIBLE_KEY] !== false;
+  return aiCleanupVisible;
+}
+
+export function isAiCleanupVisible() {
+  return aiCleanupVisible;
+}
+
+export async function setAiCleanupVisible(visible) {
+  aiCleanupVisible = visible;
+  await setStorage('sync', { [AI_CLEANUP_VISIBLE_KEY]: visible });
+}
+
 // --- Hover Summarize State ---
 
 const HOVER_SUMMARIZE_KEY = 'hoverSummarizeEnabled';

--- a/modules/ui/aiCleanupUI.js
+++ b/modules/ui/aiCleanupUI.js
@@ -1,0 +1,190 @@
+/**
+ * AI Tab Cleanup Suggestion UI.
+ *
+ * Flow: button click → query tabs → call aiManager.generateCleanupSuggestions →
+ * render inline checkbox list → user confirms → batch close selected tabs.
+ *
+ * Inline section (not modal) because the sidepanel is too narrow for a comfortable
+ * modal with a scrollable checkbox list.
+ */
+import * as api from '../apiManager.js';
+import * as aiManager from '../aiManager.js';
+import * as state from '../stateManager.js';
+
+/** @type {Array<{tabId: number, reason: string}>} Last AI suggestions, kept for confirm step. */
+let currentSuggestions = [];
+
+export function initAiCleanup() {
+    const btn = document.getElementById('ai-cleanup-btn');
+    const closeBtn = document.getElementById('ai-cleanup-close');
+    const confirmBtn = document.getElementById('ai-cleanup-confirm');
+    const selectAll = document.getElementById('ai-cleanup-select-all');
+
+    if (!btn) return;
+
+    // Initial visibility based on settings
+    if (!state.isAiCleanupVisible()) {
+        btn.style.display = 'none';
+    }
+    document.addEventListener('aiCleanupVisibilityChanged', (e) => {
+        btn.style.display = e.detail.visible ? '' : 'none';
+        if (!e.detail.visible) hideSection();
+    });
+
+    btn.addEventListener('click', handleCleanupAction);
+    if (closeBtn) closeBtn.addEventListener('click', hideSection);
+    if (confirmBtn) confirmBtn.addEventListener('click', handleConfirm);
+    if (selectAll) selectAll.addEventListener('change', handleSelectAll);
+}
+
+async function handleCleanupAction() {
+    const btn = document.getElementById('ai-cleanup-btn');
+    if (btn.classList.contains('loading')) return;
+
+    const availability = await aiManager.checkModelAvailability();
+    if (availability === 'unavailable') {
+        showStatus(api.getMessage('aiModelNotReady'));
+        showSection();
+        return;
+    }
+
+    btn.classList.add('loading');
+    showSection();
+    showStatus(api.getMessage('aiCleanupAnalyzing'));
+    clearList();
+    hideFooter();
+
+    try {
+        const tabs = await api.getTabsInCurrentWindow();
+        const now = Date.now();
+        const tabsForAi = tabs
+            .filter(t => !t.pinned && !t.active) // skip pinned and active tab
+            .map(t => ({
+                id: t.id,
+                title: t.title,
+                url: t.url,
+                // Chrome 122+ exposes lastAccessed (ms). Fall back to 0 (treated as "just now").
+                lastAccessedMinutesAgo: t.lastAccessed
+                    ? Math.round((now - t.lastAccessed) / 60000)
+                    : 0,
+            }));
+
+        if (tabsForAi.length === 0) {
+            showStatus(api.getMessage('aiCleanupEmpty'));
+            return;
+        }
+
+        const suggestions = await aiManager.generateCleanupSuggestions(tabsForAi);
+        // Filter: only keep suggestions for tabs that still exist.
+        const liveIds = new Set(tabsForAi.map(t => t.id));
+        const tabById = new Map(tabsForAi.map(t => [t.id, t]));
+        currentSuggestions = suggestions.filter(s => liveIds.has(s.tabId));
+
+        if (currentSuggestions.length === 0) {
+            showStatus(api.getMessage('aiCleanupEmpty'));
+            return;
+        }
+
+        showStatus(api.getMessage('aiCleanupFound').replace('{count}', currentSuggestions.length));
+        renderList(currentSuggestions, tabById);
+        showFooter();
+    } catch (err) {
+        console.error('AI Cleanup error:', err);
+        showStatus(api.getMessage('aiCleanupError'));
+    } finally {
+        btn.classList.remove('loading');
+    }
+}
+
+function renderList(suggestions, tabById) {
+    const list = document.getElementById('ai-cleanup-list');
+    if (!list) return;
+    list.innerHTML = '';
+
+    const frag = document.createDocumentFragment();
+    for (const s of suggestions) {
+        const tab = tabById.get(s.tabId);
+        if (!tab) continue;
+        const row = document.createElement('label');
+        row.className = 'ai-cleanup-row';
+
+        const cb = document.createElement('input');
+        cb.type = 'checkbox';
+        cb.className = 'ai-cleanup-row__cb';
+        cb.dataset.tabId = String(s.tabId);
+        cb.checked = true;
+
+        const meta = document.createElement('div');
+        meta.className = 'ai-cleanup-row__meta';
+
+        const title = document.createElement('div');
+        title.className = 'ai-cleanup-row__title';
+        title.textContent = tab.title || tab.url || '(untitled)';
+
+        const reason = document.createElement('div');
+        reason.className = 'ai-cleanup-row__reason';
+        reason.textContent = s.reason;
+
+        meta.appendChild(title);
+        meta.appendChild(reason);
+        row.appendChild(cb);
+        row.appendChild(meta);
+        frag.appendChild(row);
+    }
+    list.appendChild(frag);
+}
+
+function handleSelectAll(e) {
+    const checked = e.target.checked;
+    document.querySelectorAll('#ai-cleanup-list .ai-cleanup-row__cb').forEach(cb => {
+        cb.checked = checked;
+    });
+}
+
+async function handleConfirm() {
+    const checked = Array.from(document.querySelectorAll('#ai-cleanup-list .ai-cleanup-row__cb:checked'));
+    const tabIds = checked.map(cb => parseInt(cb.dataset.tabId, 10)).filter(Boolean);
+    if (tabIds.length === 0) {
+        hideSection();
+        return;
+    }
+    try {
+        await chrome.tabs.remove(tabIds);
+        hideSection();
+    } catch (err) {
+        console.error('AI Cleanup close failed:', err);
+        showStatus(api.getMessage('aiCleanupError'));
+    }
+}
+
+function showSection() {
+    document.getElementById('ai-cleanup-section')?.classList.remove('hidden');
+}
+
+function hideSection() {
+    const section = document.getElementById('ai-cleanup-section');
+    if (section) section.classList.add('hidden');
+    currentSuggestions = [];
+    clearList();
+    hideFooter();
+}
+
+function showStatus(msg) {
+    const el = document.getElementById('ai-cleanup-status');
+    if (el) el.textContent = msg;
+}
+
+function clearList() {
+    const list = document.getElementById('ai-cleanup-list');
+    if (list) list.innerHTML = '';
+}
+
+function showFooter() {
+    document.querySelector('#ai-cleanup-section .ai-cleanup-footer')?.classList.remove('hidden');
+    const selectAll = document.getElementById('ai-cleanup-select-all');
+    if (selectAll) selectAll.checked = true;
+}
+
+function hideFooter() {
+    document.querySelector('#ai-cleanup-section .ai-cleanup-footer')?.classList.add('hidden');
+}

--- a/modules/ui/aiCleanupUI.js
+++ b/modules/ui/aiCleanupUI.js
@@ -41,9 +41,15 @@ async function handleCleanupAction() {
     const btn = document.getElementById('ai-cleanup-btn');
     if (btn.classList.contains('loading')) return;
 
+    // Strict gate — same as background-driven naming. We don't implement a
+    // download progress UI here (Smart Auto-Grouping already does), so if the
+    // model isn't ready we surface a clear "needs download" hint instead of
+    // silently freezing on "Analyzing..." for minutes.
     const availability = await aiManager.checkModelAvailability();
-    if (availability === 'unavailable') {
-        showStatus(api.getMessage('aiModelNotReady'));
+    if (availability !== 'available') {
+        showStatus(api.getMessage(
+            availability === 'unavailable' ? 'aiModelNotReady' : 'aiCleanupNeedsDownload'
+        ));
         showSection();
         return;
     }
@@ -113,6 +119,7 @@ function renderList(suggestions, tabById) {
         cb.className = 'ai-cleanup-row__cb';
         cb.dataset.tabId = String(s.tabId);
         cb.checked = true;
+        cb.addEventListener('change', syncSelectAllState);
 
         const meta = document.createElement('div');
         meta.className = 'ai-cleanup-row__meta';
@@ -141,15 +148,43 @@ function handleSelectAll(e) {
     });
 }
 
+// Keep the "Select all" checkbox in sync with row checkboxes:
+// fully checked, fully unchecked, or mixed (indeterminate).
+function syncSelectAllState() {
+    const rowBoxes = Array.from(document.querySelectorAll('#ai-cleanup-list .ai-cleanup-row__cb'));
+    const selectAll = document.getElementById('ai-cleanup-select-all');
+    if (!selectAll || rowBoxes.length === 0) return;
+    const checkedCount = rowBoxes.filter(cb => cb.checked).length;
+    if (checkedCount === 0) {
+        selectAll.checked = false;
+        selectAll.indeterminate = false;
+    } else if (checkedCount === rowBoxes.length) {
+        selectAll.checked = true;
+        selectAll.indeterminate = false;
+    } else {
+        selectAll.checked = false;
+        selectAll.indeterminate = true;
+    }
+}
+
 async function handleConfirm() {
     const checked = Array.from(document.querySelectorAll('#ai-cleanup-list .ai-cleanup-row__cb:checked'));
-    const tabIds = checked.map(cb => parseInt(cb.dataset.tabId, 10)).filter(Boolean);
-    if (tabIds.length === 0) {
+    const targetIds = checked.map(cb => parseInt(cb.dataset.tabId, 10)).filter(Boolean);
+    if (targetIds.length === 0) {
         hideSection();
         return;
     }
     try {
-        await chrome.tabs.remove(tabIds);
+        // chrome.tabs.remove on an array is atomic — one missing ID aborts the
+        // whole batch. Filter against currently-live tabs so a tab the user
+        // manually closed during the AI delay doesn't sink the entire confirm.
+        const liveTabs = await api.getTabsInCurrentWindow();
+        const liveIds = new Set(liveTabs.map(t => t.id));
+        const validIds = targetIds.filter(id => liveIds.has(id));
+
+        if (validIds.length > 0) {
+            await chrome.tabs.remove(validIds);
+        }
         hideSection();
     } catch (err) {
         console.error('AI Cleanup close failed:', err);
@@ -182,7 +217,10 @@ function clearList() {
 function showFooter() {
     document.querySelector('#ai-cleanup-section .ai-cleanup-footer')?.classList.remove('hidden');
     const selectAll = document.getElementById('ai-cleanup-select-all');
-    if (selectAll) selectAll.checked = true;
+    if (selectAll) {
+        selectAll.checked = true;
+        selectAll.indeterminate = false;
+    }
 }
 
 function hideFooter() {

--- a/modules/ui/settingManager.js
+++ b/modules/ui/settingManager.js
@@ -209,6 +209,26 @@ async function buildSettingsDialogContent(selectedTheme) {
                 <hr style="border: none; border-top: 1px solid var(--border-color); margin: 12px 0;">
 
                 <label class="settings-toggle">
+                    <input type="checkbox" id="ai-auto-naming-toggle" ${state.isAiAutoNamingEnabled() ? 'checked' : ''}>
+                    <span class="toggle-label">${api.getMessage('aiAutoNamingToggleLabel')}</span>
+                </label>
+                <div class="settings-subsection" style="margin-top: 10px; font-size: 0.9em; opacity: 0.8;">
+                    <p>${api.getMessage('aiAutoNamingDescription')}</p>
+                </div>
+
+                <hr style="border: none; border-top: 1px solid var(--border-color); margin: 12px 0;">
+
+                <label class="settings-toggle">
+                    <input type="checkbox" id="ai-cleanup-toggle" ${state.isAiCleanupVisible() ? 'checked' : ''}>
+                    <span class="toggle-label">${api.getMessage('aiCleanupToggleLabel')}</span>
+                </label>
+                <div class="settings-subsection" style="margin-top: 10px; font-size: 0.9em; opacity: 0.8;">
+                    <p>${api.getMessage('aiCleanupDescription')}</p>
+                </div>
+
+                <hr style="border: none; border-top: 1px solid var(--border-color); margin: 12px 0;">
+
+                <label class="settings-toggle">
                     <input type="checkbox" id="hover-summarize-toggle" ${state.isHoverSummarizeEnabled() ? 'checked' : ''}>
                     <span class="toggle-label">${api.getMessage('hoverSummarizeToggle')}</span>
                 </label>
@@ -377,6 +397,26 @@ function bindSettingsEventHandlers(modalContentElement) {
             await state.setAiGroupingVisible(isVisible);
             // Dispatch custom event for sidepanel to react
             document.dispatchEvent(new CustomEvent('aiGroupingVisibilityChanged', {
+                detail: { visible: isVisible }
+            }));
+        });
+    }
+
+    // AI Auto Naming toggle handler
+    const aiAutoNamingToggle = modalContentElement.querySelector('#ai-auto-naming-toggle');
+    if (aiAutoNamingToggle) {
+        aiAutoNamingToggle.addEventListener('change', async (e) => {
+            await state.setAiAutoNamingEnabled(e.target.checked);
+        });
+    }
+
+    // AI Cleanup visibility toggle handler
+    const aiCleanupToggle = modalContentElement.querySelector('#ai-cleanup-toggle');
+    if (aiCleanupToggle) {
+        aiCleanupToggle.addEventListener('change', async (e) => {
+            const isVisible = e.target.checked;
+            await state.setAiCleanupVisible(isVisible);
+            document.dispatchEvent(new CustomEvent('aiCleanupVisibilityChanged', {
                 detail: { visible: isVisible }
             }));
         });

--- a/modules/uiManager.js
+++ b/modules/uiManager.js
@@ -7,5 +7,6 @@ export * from './ui/searchUI.js';
 export * from './ui/tabRenderer.js';
 export * from './ui/bookmarkRenderer.js';
 export * from './ui/otherWindowRenderer.js'; export * from './ui/aiGrouperUI.js';
+export * from './ui/aiCleanupUI.js';
 export * from './ui/hoverSummarizeManager.js';
 export * from './ui/hoverTooltip.js';

--- a/sidepanel.css
+++ b/sidepanel.css
@@ -2834,3 +2834,111 @@ mark.url-match {
         border: 1px solid var(--border-color);
     }
 }
+/* === AI Cleanup Suggestion Section === */
+.ai-cleanup-section {
+    margin: 8px 0 12px 0;
+    padding: 10px;
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    background-color: var(--element-bg-color);
+}
+
+.ai-cleanup-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 6px;
+}
+
+.ai-cleanup-title {
+    font-size: 0.95em;
+    margin: 0;
+    color: var(--text-color-primary);
+}
+
+.ai-cleanup-status {
+    font-size: 0.85em;
+    color: var(--text-color-primary);
+    opacity: 0.7;
+    margin-bottom: 8px;
+}
+
+.ai-cleanup-list {
+    max-height: 240px;
+    overflow-y: auto;
+}
+
+.ai-cleanup-row {
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+    padding: 6px 4px;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+.ai-cleanup-row:hover {
+    background-color: var(--element-bg-hover-color);
+}
+
+.ai-cleanup-row__cb {
+    margin-top: 3px;
+    flex-shrink: 0;
+}
+
+.ai-cleanup-row__meta {
+    min-width: 0;
+    flex: 1;
+}
+
+.ai-cleanup-row__title {
+    font-size: 0.9em;
+    color: var(--text-color-primary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.ai-cleanup-row__reason {
+    font-size: 0.8em;
+    color: var(--text-color-primary);
+    opacity: 0.65;
+    margin-top: 2px;
+}
+
+.ai-cleanup-footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-top: 10px;
+    padding-top: 8px;
+    border-top: 1px solid var(--border-color);
+}
+
+.ai-cleanup-select-all {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.85em;
+    color: var(--text-color-primary);
+    cursor: pointer;
+}
+
+.ai-cleanup-confirm-btn {
+    padding: 4px 10px;
+    border: 1px solid var(--accent-color);
+    border-radius: 4px;
+    background-color: var(--accent-color);
+    color: var(--main-bg-color);
+    font-size: 0.85em;
+    cursor: pointer;
+}
+
+.ai-cleanup-confirm-btn:hover {
+    background-color: var(--accent-color-hover);
+}
+
+#ai-cleanup-btn.loading {
+    opacity: 0.6;
+    pointer-events: none;
+}

--- a/sidepanel.html
+++ b/sidepanel.html
@@ -45,6 +45,27 @@
                 <button id="ai-group-btn" class="header-action-btn" title="✨ Smart Auto-Grouping"
                     data-i18n-title="smartGroupingBtnTitle" aria-label="Smart Auto-Grouping"
                     data-i18n="smartGroupingBtnText">✨ 智慧整理</button>
+                <button id="ai-cleanup-btn" class="header-action-btn" title="🧹 AI Cleanup"
+                    data-i18n-title="aiCleanupBtnTitle" aria-label="AI Cleanup"
+                    data-i18n="aiCleanupBtnText">🧹 清理</button>
+            </div>
+        </div>
+
+        <!-- AI Cleanup Section (collapsed by default; expanded when the button is clicked) -->
+        <div id="ai-cleanup-section" class="ai-cleanup-section hidden" aria-live="polite">
+            <div class="ai-cleanup-header">
+                <h3 class="ai-cleanup-title" data-i18n="aiCleanupSectionHeader">AI Cleanup Suggestions</h3>
+                <button id="ai-cleanup-close" class="icon-btn" aria-label="Close">×</button>
+            </div>
+            <div id="ai-cleanup-status" class="ai-cleanup-status"></div>
+            <div id="ai-cleanup-list" class="ai-cleanup-list"></div>
+            <div class="ai-cleanup-footer hidden">
+                <label class="ai-cleanup-select-all">
+                    <input type="checkbox" id="ai-cleanup-select-all" checked>
+                    <span data-i18n="aiCleanupSelectAll">Select all</span>
+                </label>
+                <button id="ai-cleanup-confirm" class="ai-cleanup-confirm-btn"
+                    data-i18n="aiCleanupConfirm">Close selected</button>
             </div>
         </div>
 

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -114,14 +114,16 @@ function applyStaticTranslations() {
 }
 
 async function initialize() {
-    const [, , , readingListVisible, aiGroupingVisible, uiLang,] = await Promise.all([
+    const [, , , readingListVisible, aiGroupingVisible, uiLang, , , ] = await Promise.all([
         state.initLinkedTabs(), // Load linked tabs state first
         state.initWindowNames(), // Load window names
         state.loadBookmarkCache(), // Load cached bookmarks from storage
         state.initReadingListVisibility(), // Load Reading List visibility
         state.initAiGroupingVisibility(), // Load AI Grouping visibility
         state.initUiLanguage(), // Load UI Language Override state
-        state.initHoverSummarize() // Load Hover Summarize state
+        state.initHoverSummarize(), // Load Hover Summarize state
+        state.initAiAutoNaming(), // Load AI Auto Naming state (drives bg listener gating via storage)
+        state.initAiCleanupVisibility() // Load AI Cleanup visibility state
     ]);
 
     // Ensure custom language dictionary is loaded BEFORE applying any translations
@@ -151,6 +153,7 @@ async function initialize() {
     search.initialize();
     ui.initThemeSwitcher();
     ui.initAiGrouper();
+    ui.initAiCleanup();
     await updateTabList();
 
     refreshBookmarks();


### PR DESCRIPTION
## 摘要 (Summary)

對應 PRD `docs/specs/feature/BASE-010_zero-config-local-ai`，一次落地 FR-1.x（AI 群組自動命名）+ FR-2.x（AI 分頁清理建議）。FR-3.x 行銷訊息留給 Phase 10「戰略重定位」。

這也是 Plan「專案優化與差異化策略計畫」的 B2.1（產品優化第一波第一項）。

### 相關 Issue (Related Issues)

無。基於 `docs/specs/feature/BASE-010_zero-config-local-ai/PRD_spec.md` 實作。

---

## 📝 變更內容 (Changes)

### 新增 (Added)
- **`modules/aiManager.js`**：
  - `generateGroupName(tabsInfo)` → 回 `"<Emoji> <ShortName>"` 標籤，沿用 LanguageModel session JSON-strict systemPrompt，**比 generateGroups 更嚴格的可用性閘**（`=== 'available'`）避免 background silent 觸發數 GB 模型下載
  - `generateCleanupSuggestions(tabsInfo)` → 回 `[{tabId, reason}]`，prompt 含明確 criteria + 保守原則（when in doubt, skip）+ empty fallback（reply `[]`）
- **`background.js`**：監聽 `chrome.tabGroups.onCreated`；空白 title + setting enabled 時呼叫 `generateGroupName` 並寫回（含 race guard：寫入前重 `chrome.tabGroups.get` 確認 title 仍空白，避免覆蓋使用者輸入）
- **`modules/ui/aiCleanupUI.js`**（新模組，~170 行）：按鈕 → 取 tabs → AI 分析 → 渲染 checkbox 列表（預設全勾）→ 全選/全不選 → 確認後 `chrome.tabs.remove`。排除 pinned tab + active tab。
- **`modules/stateManager.js`**：`isAiAutoNamingEnabled` / `setAiAutoNamingEnabled` + `isAiCleanupVisible` / `setAiCleanupVisible`（皆 chrome.storage.sync，預設 enabled / visible）
- **`modules/ui/settingManager.js`**：在 experimental section 加兩個 toggle
- **`sidepanel.html`**：tabs section header 加 🧹 cleanup 按鈕；tab-list 上方加 cleanup section 容器
- **`sidepanel.css`**：~80 行 `.ai-cleanup-*` 樣式（用 design system 變數對齊既有風格）
- **`_locales/{en,zh_TW,zh_CN}/messages.json`**：13 個新 i18n 字串各 3 語
- **`.agent/notes/NOTE_20260526_phase4.md`**：session 摘要

### 修改 (Changed)
- **`sidepanel.js`** `initialize`：destructuring 加兩個 `state.initAi*` + `ui.initAiCleanup()`
- **`modules/uiManager.js`**：re-export aiCleanupUI

### 重要決策說明
- **Auto Naming listener 為何放 background 而非 sidepanel**：`chrome.tabGroups.onCreated` 是全域 event，多 window 開 sidepanel 時 sidepanel 端會重複觸發 → background 是唯一單一觸發點
- **Naming 為何用 `=== 'available'` 嚴格判定**：background 不應 silent 觸發數 GB 模型下載；user-initiated Smart Auto-Grouping 才允許 trigger 下載
- **Cleanup 為何用 inline section 而非 modal**：sidepanel 太窄、modal + 多項勾選 UX 不佳
- **Cleanup 「閒置」為何由 AI 綜合判定**：純時間 filter 太僵硬；AI 可加入 duplicate / finished task 等語意訊號（且 PRD FR-2.03 例示也是混合判定）
- **為何排除 pinned + active tab**：避免關掉使用者當前頁面或刻意保留的 pinned 分頁

---

## 🧪 測試 (Testing)

### 自動化測試
- [x] `npm run test:unit` → 3 suites / 57 tests 通過
- [x] Puppeteer happy paths：`happy_path_sidepanel_load` + `happy_path_settings_panel` 10/10 通過（確認新 toggle 與 cleanup section 不影響既有 UI 載入）
- [x] `esbuild --bundle` 編譯通過（sidepanel.js + background.js 兩個 entry 都過）
- [x] 3 個 `messages.json` JSON 合法

### 手動驗證（需實機 Chrome with Gemini Nano）
1. `make` → `chrome://extensions` 載入未封裝
2. **Auto Naming**：
   - 確認設定面板「Auto-name empty tab groups」toggle 預設開啟
   - 用 Chrome 原生方式建立一個空白名稱群組（拖曳 tabs 進新群組）
   - 約 1-3 秒後群組標題應自動更新為 `<Emoji> <ShortName>`
   - 測試 race guard：建立群組後立即手動輸入 title，AI 不應覆蓋
3. **Cleanup**：
   - 開 15+ 分頁，部分閒置（切換到別的 tab 不訪問 60+ 分鐘）
   - 點工具列 🧹 按鈕 → 應顯示 inline section
   - AI 不可用時：顯示「AI model not ready」
   - AI 可用且無建議：顯示「Your tabs look tidy」
   - 有建議時：勾選列表 + 全選 toggle + 確認後批次關閉
4. **設定 visibility**：關閉「Show 🧹 Tab Cleanup button」toggle → 按鈕隱藏
5. **多語**：切到 zh_TW / zh_CN UI 確認新字串顯示正常；切到其他 11 語會看到 en fallback（待 Phase 11 補）

---

## ✅ 檢查清單 (Checklist)

- [x] 程式碼遵循專案 coding style（ES modules、vanilla JS、icons emoji-only 不需新 SVG、aria-label）
- [x] 自動化測試已通過（unit + puppeteer）
- [x] `.agent/notes/NOTE_20260526_phase4.md` 已寫
- [x] PR 描述包含英文版本
- [ ] **待辦**：11 個其他語系翻譯 → Phase 11 集中處理
- [ ] **待辦**：Puppeteer test for AI cleanup UI flow（mock `chrome.tabs.remove` 不需要真叫 AI） → 後續 phase 補
- [ ] **待辦**：AI prompt 品質需實機跑 Gemini Nano 確認，可能需要微調 prompt 措辭

---

## 🌐 English Version

### Summary

Implements PRD `BASE-010` FR-1.x (AI auto-name tab groups) and FR-2.x (AI tab cleanup suggestions) in a single PR. FR-3.x (marketing copy) is deferred to Phase 10 strategic repositioning.

### Changes

#### Added
- **`modules/aiManager.js`**:
  - `generateGroupName(tabsInfo)` → returns `"<Emoji> <ShortName>"`. Reuses the existing LanguageModel session (JSON-strict systemPrompt). **Strictly gated on `=== 'available'`** to avoid silently kicking off a multi-GB model download in the background; only user-initiated Smart Auto-Grouping is allowed to trigger downloads.
  - `generateCleanupSuggestions(tabsInfo)` → returns `[{tabId, reason}]`. Prompt explicitly states "be conservative" and "reply `[]` if no good candidate".
- **`background.js`**: listens on `chrome.tabGroups.onCreated`; when title is empty and the setting is enabled, calls `generateGroupName` and writes back. Includes a **race guard** — re-queries the group right before writing so the AI label doesn't clobber a title the user typed during the AI call.
- **`modules/ui/aiCleanupUI.js`** (new, ~170 lines): inline section in the sidepanel. Button → analyze → checkbox list (preselected) → select-all / confirm → batch `chrome.tabs.remove`. Pinned and active tabs are excluded.
- **`modules/stateManager.js`**: `isAiAutoNamingEnabled` / `setAiAutoNamingEnabled` and `isAiCleanupVisible` / `setAiCleanupVisible` (chrome.storage.sync, default enabled/visible).
- **`modules/ui/settingManager.js`**: two new toggles in the experimental section.
- **`sidepanel.html` / `sidepanel.css`**: 🧹 button next to the existing Smart Group button; new inline cleanup section above the tab list (~80 lines of CSS using design-system variables).
- 13 new i18n strings each in `en`, `zh_TW`, `zh_CN`.

#### Key decisions
- **Naming listener in background, not sidepanel**: `tabGroups.onCreated` fires globally; a sidepanel-side listener would trigger redundantly per open sidepanel.
- **Naming uses `=== 'available'`** (stricter than `checkModelReadiness`): background must not silently trigger a multi-GB download.
- **Cleanup uses an inline section, not a modal**: sidepanel is too narrow for a modal with a long checkbox list.
- **Cleanup "idle" judgment delegated to AI**: pure time filters are too rigid; AI adds semantic signals (duplicate, finished task) per PRD example reasons.
- **Excludes pinned + active tab**: avoids closing the tab the user is currently viewing or pinned by intent.

### Testing

- `npm run test:unit` → 57/57 passing
- Puppeteer regression: `sidepanel_load` + `settings_panel` 10/10 passing (confirms new toggles and section don't break existing UI loading)
- `esbuild --bundle` succeeds for both `sidepanel.js` and `background.js` entries
- 3 `messages.json` files validate

Manual verification requires a Chrome with Gemini Nano in `available` state — see Chinese section for the full step-by-step.

### Related Issues
None. Based on `docs/specs/feature/BASE-010_zero-config-local-ai/PRD_spec.md`.
