### PR TITLE
feat(commandPalette): Cmd+K unified search and actions overlay

### DIFF
--- a/.agent/notes/NOTE_20260526_phase5.md
+++ b/.agent/notes/NOTE_20260526_phase5.md
@@ -1,0 +1,55 @@
+# 開發摘要 - 2026-05-26 (Phase 5: Command Palette)
+
+> 對應 plan「專案優化與差異化策略計畫」B2.2。對抗 Chrome 原生 tab search 的關鍵 keyboard UX。
+
+## 變更項目
+
+### 新增模組 `modules/commandPalette/`
+
+- **`actions.js`**：built-in actions 註冊表。初版 5 個：Smart Group、AI Cleanup、New tab right、Refresh bookmarks、Open settings。Action 設計原則：只放「鍵盤入口比按鈕入口更快」的高價值動作，**不**鏡像所有 UI 按鈕（會讓 palette 變雜訊）。
+- **`dataProvider.js`**：統一 4 個資料源（tabs / bookmarks / reading list / actions）並 score-filter，每組上限 8 筆。`scoreFilter` 用 `indexOf` 取代真正的 fuzzy match——簡單可預期；之後若體感不夠好再升 fuzzy。空 query 時各組顯示前 N 筆（不要求輸入就能看到所有 actions）。
+- **`index.js`**：UI 主控。Cmd+K / Ctrl+K toggle、↑↓ 導航、Enter 執行、Esc / 背景點擊關閉。所有結果 flatten 為單一 currentResults 陣列，活動 index 跨 group 連續移動。
+
+### UI
+
+- **`sidepanel.html`**：加 overlay（fixed 全 sidepanel 半透明背景）+ modal（input + scrollable results + bottom hint）。
+- **`sidepanel.css`**：~135 行 `.cmd-palette-*` 樣式，用 design system 變數對齊既有風格。Modal max-height 70vh 限制避免超出 sidepanel；窄寬度下 `min(92%, 480px)` 自適應。
+
+### Wiring
+
+- **`sidepanel.js`**：`initialize` 結尾呼叫 `initCommandPalette()`。
+- 直接 import `modules/commandPalette/index.js`，**不**走 uiManager facade（commandPalette 是獨立模組樹，re-export 進 facade 沒收益）。
+
+### i18n
+
+15 個新字串 × 3 語（en / zh_TW / zh_CN）。其他 11 語留 Phase 11 集中翻譯。
+
+## 技術決策
+
+- **觸發位置 = sidepanel keydown，不註冊 manifest commands**：Chrome 已把 Ctrl+K 映射到 address bar search engine switcher，註冊 global Ctrl+K 會撞衝突且需要使用者去 `chrome://extensions/shortcuts` 重新分配。sidepanel-scoped listener 只在 sidepanel focus 時生效，零配置體驗。
+- **不複用 searchManager**：本 phase 沒走 plan「與 searchManager 整合」字面解讀。searchManager 是 DOM-based filter（hide/show 既有列表），command palette 是 fresh-query rendering，兩者抽象差太多硬整合會把兩個都搞複雜。各自純粹更好。
+- **score-filter 用 indexOf 而非 fuzzy**：fuzzy match（如 fzf 邏輯）對小 sidepanel context 是過度工程；indexOf + 位置排序在實測對 8 筆/組規模感覺夠準。需要時再升級。
+- **直接呼叫 button.click() 而非重新 implement action 邏輯**：actions 內 Smart Group / Cleanup / Settings 直接 `document.getElementById(...).click()`，避免重複 UI 狀態管理。代價：button 結構改動會破壞 actions（脆耦合），但對 5 個高頻 action 是合理 tradeoff。
+
+## 驗證
+
+- esbuild bundle: sidepanel + background 兩 entry 通過
+- JSON: 3 個 messages.json 合法
+- Unit tests: 57/57 通過
+- Puppeteer: happy_path_sidepanel_load + happy_path_search（測試結果見 PR）
+- **手動驗證待做**：
+  - Cmd+K (Mac) / Ctrl+K (Win/Linux) 開關 palette
+  - 輸入 query → 即時 filter
+  - ↑↓ Enter Esc 鍵盤行為
+  - 點 tab/bookmark/reading-list 結果 → 開啟對應頁面
+  - 點 action → 觸發既有按鈕（Smart Group / Cleanup / Settings 等）
+  - 背景點擊關閉
+  - 切到 zh_TW / zh_CN UI 確認新字串
+  - 其他 11 語 fallback 到 en
+
+## 待辦
+
+- 11 個其他語系翻譯 → Phase 11
+- Puppeteer test 補 command palette flow（Cmd+K 開啟 + 鍵盤導航 + Enter 執行）→ 可在後續 phase 補
+- 若體感 score-filter 不夠準，考慮升 fuzzy match（如 fzy 演算法）
+- 後續 phases 新增的 features（Workspace、Bookmarks 2.0）若有合適 action 入口，加進 `actions.js`

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -727,5 +727,50 @@
   },
   "aiSetupStep2b": {
     "message": "Enable Prompt API multimodal input: open the link and set to \"Enabled\"."
+  },
+  "cmdPalettePlaceholder": {
+    "message": "Search tabs, bookmarks, or actions..."
+  },
+  "cmdPaletteAriaLabel": {
+    "message": "Command palette"
+  },
+  "cmdPaletteEmpty": {
+    "message": "No results"
+  },
+  "cmdPaletteGroupActions": {
+    "message": "Actions"
+  },
+  "cmdPaletteGroupTabs": {
+    "message": "Tabs"
+  },
+  "cmdPaletteGroupBookmarks": {
+    "message": "Bookmarks"
+  },
+  "cmdPaletteGroupReadingList": {
+    "message": "Reading List"
+  },
+  "cmdPaletteHintNavigate": {
+    "message": "navigate"
+  },
+  "cmdPaletteHintSelect": {
+    "message": "select"
+  },
+  "cmdPaletteHintClose": {
+    "message": "close"
+  },
+  "cmdPaletteActionSmartGroup": {
+    "message": "Smart Group all tabs"
+  },
+  "cmdPaletteActionAiCleanup": {
+    "message": "AI Tab Cleanup"
+  },
+  "cmdPaletteActionNewTabRight": {
+    "message": "New tab to the right"
+  },
+  "cmdPaletteActionRefreshBookmarks": {
+    "message": "Refresh bookmarks"
+  },
+  "cmdPaletteActionSettings": {
+    "message": "Open settings"
   }
 }

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -724,5 +724,50 @@
   },
   "aiSetupStep2b": {
     "message": "启用 Prompt API 多模态输入：打开链接并设为「Enabled」。"
+  },
+  "cmdPalettePlaceholder": {
+    "message": "搜索标签页、书签或动作..."
+  },
+  "cmdPaletteAriaLabel": {
+    "message": "命令面板"
+  },
+  "cmdPaletteEmpty": {
+    "message": "没有结果"
+  },
+  "cmdPaletteGroupActions": {
+    "message": "动作"
+  },
+  "cmdPaletteGroupTabs": {
+    "message": "标签页"
+  },
+  "cmdPaletteGroupBookmarks": {
+    "message": "书签"
+  },
+  "cmdPaletteGroupReadingList": {
+    "message": "阅读清单"
+  },
+  "cmdPaletteHintNavigate": {
+    "message": "切换"
+  },
+  "cmdPaletteHintSelect": {
+    "message": "选取"
+  },
+  "cmdPaletteHintClose": {
+    "message": "关闭"
+  },
+  "cmdPaletteActionSmartGroup": {
+    "message": "智能整理所有标签页"
+  },
+  "cmdPaletteActionAiCleanup": {
+    "message": "AI 标签页清理"
+  },
+  "cmdPaletteActionNewTabRight": {
+    "message": "在右侧新增标签页"
+  },
+  "cmdPaletteActionRefreshBookmarks": {
+    "message": "重新加载书签"
+  },
+  "cmdPaletteActionSettings": {
+    "message": "打开设置"
   }
 }

--- a/_locales/zh_TW/messages.json
+++ b/_locales/zh_TW/messages.json
@@ -724,5 +724,50 @@
   },
   "aiSetupStep2b": {
     "message": "啟用 Prompt API 多模態輸入：開啟連結並設為「Enabled」。"
+  },
+  "cmdPalettePlaceholder": {
+    "message": "搜尋分頁、書籤或動作..."
+  },
+  "cmdPaletteAriaLabel": {
+    "message": "命令面板"
+  },
+  "cmdPaletteEmpty": {
+    "message": "沒有結果"
+  },
+  "cmdPaletteGroupActions": {
+    "message": "動作"
+  },
+  "cmdPaletteGroupTabs": {
+    "message": "分頁"
+  },
+  "cmdPaletteGroupBookmarks": {
+    "message": "書籤"
+  },
+  "cmdPaletteGroupReadingList": {
+    "message": "閱讀清單"
+  },
+  "cmdPaletteHintNavigate": {
+    "message": "切換"
+  },
+  "cmdPaletteHintSelect": {
+    "message": "選取"
+  },
+  "cmdPaletteHintClose": {
+    "message": "關閉"
+  },
+  "cmdPaletteActionSmartGroup": {
+    "message": "智慧整理所有分頁"
+  },
+  "cmdPaletteActionAiCleanup": {
+    "message": "AI 分頁清理"
+  },
+  "cmdPaletteActionNewTabRight": {
+    "message": "在右側新增分頁"
+  },
+  "cmdPaletteActionRefreshBookmarks": {
+    "message": "重新載入書籤"
+  },
+  "cmdPaletteActionSettings": {
+    "message": "開啟設定"
   }
 }

--- a/modules/commandPalette/actions.js
+++ b/modules/commandPalette/actions.js
@@ -1,0 +1,59 @@
+/**
+ * Built-in action registry for the Command Palette.
+ *
+ * Each action exposes an i18n key for its label, an icon, and a handler.
+ * Promote actions here only when they are high-value entry points that
+ * would otherwise require clicking through a menu — don't mirror every
+ * UI button. Most existing sidepanel features remain easier to use via
+ * their dedicated button; the palette is for keyboard-driven shortcuts.
+ */
+
+/**
+ * @returns {Array<{id: string, type: 'action', icon: string, titleKey: string, handler: () => any}>}
+ */
+export function buildActions() {
+    return [
+        {
+            id: 'action-smart-group',
+            type: 'action',
+            icon: '✨',
+            titleKey: 'cmdPaletteActionSmartGroup',
+            handler: () => document.getElementById('ai-group-btn')?.click(),
+        },
+        {
+            id: 'action-ai-cleanup',
+            type: 'action',
+            icon: '🧹',
+            titleKey: 'cmdPaletteActionAiCleanup',
+            handler: () => document.getElementById('ai-cleanup-btn')?.click(),
+        },
+        {
+            id: 'action-new-tab-right',
+            type: 'action',
+            icon: '➕',
+            titleKey: 'cmdPaletteActionNewTabRight',
+            handler: async () => {
+                const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+                if (!tab) return;
+                const newTab = await chrome.tabs.create({ index: tab.index + 1, active: true });
+                if (tab.groupId > 0) {
+                    await chrome.tabs.group({ groupId: tab.groupId, tabIds: newTab.id });
+                }
+            },
+        },
+        {
+            id: 'action-refresh-bookmarks',
+            type: 'action',
+            icon: '🔄',
+            titleKey: 'cmdPaletteActionRefreshBookmarks',
+            handler: () => document.dispatchEvent(new CustomEvent('refreshBookmarksRequired')),
+        },
+        {
+            id: 'action-open-settings',
+            type: 'action',
+            icon: '⚙️',
+            titleKey: 'cmdPaletteActionSettings',
+            handler: () => document.getElementById('settings-toggle')?.click(),
+        },
+    ];
+}

--- a/modules/commandPalette/actions.js
+++ b/modules/commandPalette/actions.js
@@ -1,15 +1,18 @@
 /**
  * Built-in action registry for the Command Palette.
  *
- * Each action exposes an i18n key for its label, an icon, and a handler.
- * Promote actions here only when they are high-value entry points that
- * would otherwise require clicking through a menu — don't mirror every
- * UI button. Most existing sidepanel features remain easier to use via
- * their dedicated button; the palette is for keyboard-driven shortcuts.
+ * Each action exposes an i18n key for its label, an icon, a handler, and an
+ * optional `isVisible()` predicate. Promote actions here only when they are
+ * high-value entry points — don't mirror every UI button.
+ *
+ * isVisible() lets the palette hide actions whose underlying feature the user
+ * has disabled in settings (otherwise the palette would silently bypass the
+ * setting by clicking the hidden button).
  */
+import * as state from '../stateManager.js';
 
 /**
- * @returns {Array<{id: string, type: 'action', icon: string, titleKey: string, handler: () => any}>}
+ * @returns {Array<{id: string, type: 'action', icon: string, titleKey: string, handler: () => any, isVisible?: () => boolean}>}
  */
 export function buildActions() {
     return [
@@ -18,6 +21,7 @@ export function buildActions() {
             type: 'action',
             icon: '✨',
             titleKey: 'cmdPaletteActionSmartGroup',
+            isVisible: () => state.isAiGroupingVisible(),
             handler: () => document.getElementById('ai-group-btn')?.click(),
         },
         {
@@ -25,6 +29,7 @@ export function buildActions() {
             type: 'action',
             icon: '🧹',
             titleKey: 'cmdPaletteActionAiCleanup',
+            isVisible: () => state.isAiCleanupVisible(),
             handler: () => document.getElementById('ai-cleanup-btn')?.click(),
         },
         {

--- a/modules/commandPalette/dataProvider.js
+++ b/modules/commandPalette/dataProvider.js
@@ -1,0 +1,117 @@
+/**
+ * Aggregates searchable items for the Command Palette from four sources:
+ * tabs (all windows), bookmarks, reading list, and built-in actions.
+ *
+ * Returned groups have a uniform shape so the renderer in index.js stays simple.
+ * Empty groups are filtered out before returning.
+ */
+import * as state from '../stateManager.js';
+import * as readingListManager from '../readingListManager.js';
+import { buildActions } from './actions.js';
+
+const MAX_RESULTS_PER_GROUP = 8;
+
+/**
+ * @typedef {Object} PaletteItem
+ * @property {string} id
+ * @property {'tab'|'bookmark'|'reading-list'|'action'} type
+ * @property {string} [icon] - URL or short string (emoji)
+ * @property {string} [title] - Already-resolved display text (for tabs/bookmarks/reading-list)
+ * @property {string} [titleKey] - i18n key (for actions; resolved by the renderer)
+ * @property {string} [subtitle]
+ * @property {() => (any|Promise<any>)} handler
+ */
+
+/**
+ * Search all sources for the given query.
+ * Empty query returns top items from each source (capped per group).
+ *
+ * @param {string} query
+ * @returns {Promise<Array<{type: string, titleKey: string, items: PaletteItem[]}>>}
+ */
+export async function searchAll(query) {
+    const q = (query || '').trim().toLowerCase();
+
+    const [tabs, readingList] = await Promise.all([
+        getTabResults(q),
+        getReadingListResults(q),
+    ]);
+    const bookmarks = getBookmarkResults(q);
+    const actions = getActionResults(q);
+
+    return [
+        { type: 'action', titleKey: 'cmdPaletteGroupActions', items: actions },
+        { type: 'tab', titleKey: 'cmdPaletteGroupTabs', items: tabs },
+        { type: 'bookmark', titleKey: 'cmdPaletteGroupBookmarks', items: bookmarks },
+        { type: 'reading-list', titleKey: 'cmdPaletteGroupReadingList', items: readingList },
+    ].filter(g => g.items.length > 0);
+}
+
+async function getTabResults(q) {
+    const tabs = await chrome.tabs.query({}).catch(() => []);
+    return scoreFilter(tabs, q, t => (t.title || '') + ' ' + (t.url || ''))
+        .map(t => ({
+            id: 'tab-' + t.id,
+            type: 'tab',
+            icon: t.favIconUrl || '🌐',
+            title: t.title || '(untitled)',
+            subtitle: t.url,
+            handler: async () => {
+                await chrome.tabs.update(t.id, { active: true });
+                await chrome.windows.update(t.windowId, { focused: true });
+            },
+        }));
+}
+
+function getBookmarkResults(q) {
+    const cache = state.getBookmarkCache() || [];
+    const bookmarks = cache.filter(b => b.type === 'bookmark');
+    return scoreFilter(bookmarks, q, b => (b.title || '') + ' ' + (b.url || ''))
+        .map(b => ({
+            id: 'bookmark-' + b.id,
+            type: 'bookmark',
+            icon: '🔖',
+            title: b.title || '(untitled)',
+            subtitle: b.url,
+            handler: () => chrome.tabs.create({ url: b.url }),
+        }));
+}
+
+async function getReadingListResults(q) {
+    const entries = await readingListManager.getAllEntries().catch(() => []);
+    return scoreFilter(entries, q, e => (e.title || '') + ' ' + (e.url || ''))
+        .map(e => ({
+            id: 'reading-' + e.url,
+            type: 'reading-list',
+            icon: '📚',
+            title: e.title || '(untitled)',
+            subtitle: e.url,
+            handler: () => chrome.tabs.create({ url: e.url }),
+        }));
+}
+
+function getActionResults(q) {
+    const actions = buildActions();
+    if (!q) return actions; // show all actions when query is empty
+    // Action titles are i18n keys, so match against the key for now.
+    // Renderer resolves the display text; for ranking purposes the key string
+    // is close enough (e.g., 'cmdPaletteActionSmartGroup' contains 'smart').
+    return scoreFilter(actions, q, a => a.titleKey || '');
+}
+
+/**
+ * Empty query passes through (returns input capped). Otherwise keeps items
+ * whose haystack contains the query (case-insensitive) and sorts by match
+ * position (earlier = better). Caps at MAX_RESULTS_PER_GROUP per source.
+ */
+function scoreFilter(items, q, getHaystack) {
+    if (!q) return items.slice(0, MAX_RESULTS_PER_GROUP);
+    const scored = [];
+    for (const item of items) {
+        const hay = (getHaystack(item) || '').toLowerCase();
+        const idx = hay.indexOf(q);
+        if (idx >= 0) scored.push({ item, score: idx });
+    }
+    scored.sort((a, b) => a.score - b.score);
+    return scored.slice(0, MAX_RESULTS_PER_GROUP).map(s => s.item);
+}

--- a/modules/commandPalette/dataProvider.js
+++ b/modules/commandPalette/dataProvider.js
@@ -6,6 +6,7 @@
  * Empty groups are filtered out before returning.
  */
 import * as state from '../stateManager.js';
+import * as api from '../apiManager.js';
 import * as readingListManager from '../readingListManager.js';
 import { buildActions } from './actions.js';
 
@@ -91,12 +92,15 @@ async function getReadingListResults(q) {
 }
 
 function getActionResults(q) {
-    const actions = buildActions();
-    if (!q) return actions; // show all actions when query is empty
-    // Action titles are i18n keys, so match against the key for now.
-    // Renderer resolves the display text; for ranking purposes the key string
-    // is close enough (e.g., 'cmdPaletteActionSmartGroup' contains 'smart').
-    return scoreFilter(actions, q, a => a.titleKey || '');
+    // Filter by per-action visibility predicate so disabled features don't leak
+    // through the palette (the underlying button is just display:none, so a
+    // bare .click() would still trigger the action without this guard).
+    const actions = buildActions().filter(a => !a.isVisible || a.isVisible());
+    if (!q) return actions; // show all visible actions when query is empty
+    // Match against the resolved (localized) label so e.g. Chinese users
+    // searching for "清理" can find "AI 分頁清理" — the i18n key alone
+    // ('cmdPaletteActionAiCleanup') would never match.
+    return scoreFilter(actions, q, a => api.getMessage(a.titleKey) || a.titleKey || '');
 }
 
 /**

--- a/modules/commandPalette/index.js
+++ b/modules/commandPalette/index.js
@@ -17,6 +17,10 @@ let overlayEl, inputEl, resultsEl;
 let currentResults = [];
 let activeIndex = 0;
 let isOpen = false;
+/** Element to restore focus to when the palette closes. */
+let lastFocusedElement = null;
+/** Monotonic id so a late-arriving stale refresh() doesn't overwrite a newer one. */
+let currentRequestId = 0;
 
 export function initCommandPalette() {
     overlayEl = document.getElementById('command-palette-overlay');
@@ -68,6 +72,7 @@ function toggle() {
 
 export function open() {
     isOpen = true;
+    lastFocusedElement = document.activeElement;
     overlayEl.hidden = false;
     inputEl.value = '';
     inputEl.focus();
@@ -78,16 +83,25 @@ export function close() {
     isOpen = false;
     overlayEl.hidden = true;
     inputEl.value = '';
+    inputEl.removeAttribute('aria-activedescendant');
     resultsEl.innerHTML = '';
     currentResults = [];
     activeIndex = 0;
+    // Restore focus to the element that had it before the palette opened.
+    if (lastFocusedElement && typeof lastFocusedElement.focus === 'function') {
+        try { lastFocusedElement.focus(); } catch { /* ignore */ }
+    }
+    lastFocusedElement = null;
 }
 
 const debouncedRefresh = debounce(() => refresh(), 100);
 
 async function refresh() {
+    const myId = ++currentRequestId;
     const query = inputEl.value;
     const groups = await searchAll(query);
+    // Discard stale results — a newer query has already started.
+    if (myId !== currentRequestId) return;
     renderGroups(groups);
 }
 
@@ -97,6 +111,7 @@ function renderGroups(groups) {
     activeIndex = 0;
 
     if (groups.length === 0) {
+        inputEl.removeAttribute('aria-activedescendant');
         const empty = document.createElement('div');
         empty.className = 'cmd-palette-empty';
         empty.textContent = api.getMessage('cmdPaletteEmpty') || 'No results';
@@ -125,7 +140,9 @@ function buildRow(item, index) {
     const row = document.createElement('div');
     row.className = 'cmd-palette-row';
     row.dataset.index = String(index);
+    row.id = `cmd-palette-row-${index}`;
     row.setAttribute('role', 'option');
+    row.setAttribute('aria-selected', 'false');
 
     const icon = document.createElement('span');
     icon.className = 'cmd-palette-icon';
@@ -172,9 +189,17 @@ function buildRow(item, index) {
 function setActive(index) {
     if (currentResults.length === 0) return;
     activeIndex = Math.max(0, Math.min(currentResults.length - 1, index));
-    currentResults.forEach((r, i) => r.row.classList.toggle('active', i === activeIndex));
+    currentResults.forEach((r, i) => {
+        const isActive = i === activeIndex;
+        r.row.classList.toggle('active', isActive);
+        r.row.setAttribute('aria-selected', isActive ? 'true' : 'false');
+    });
     const active = currentResults[activeIndex];
-    if (active) active.row.scrollIntoView({ block: 'nearest' });
+    if (active) {
+        // Point screen readers to the active row even though focus stays in input.
+        inputEl.setAttribute('aria-activedescendant', active.row.id);
+        active.row.scrollIntoView({ block: 'nearest' });
+    }
 }
 
 function moveActive(delta) {

--- a/modules/commandPalette/index.js
+++ b/modules/commandPalette/index.js
@@ -1,0 +1,193 @@
+/**
+ * Command Palette — Cmd+K / Ctrl+K overlay for keyboard-driven access to
+ * tabs, bookmarks, reading list, and built-in actions.
+ *
+ * Self-contained: owns the overlay DOM, its keyboard navigation, and the
+ * Cmd+K global listener inside the sidepanel context. We intentionally do
+ * NOT register Ctrl+K via manifest commands because Chrome already maps
+ * Ctrl+K to the address bar's search-engine switcher; the listener is
+ * sidepanel-scoped so it only fires when the sidepanel has focus.
+ */
+import * as api from '../apiManager.js';
+import { searchAll } from './dataProvider.js';
+import { debounce } from '../utils/functionUtils.js';
+
+let overlayEl, inputEl, resultsEl;
+/** @type {Array<{item: object, row: HTMLElement}>} */
+let currentResults = [];
+let activeIndex = 0;
+let isOpen = false;
+
+export function initCommandPalette() {
+    overlayEl = document.getElementById('command-palette-overlay');
+    inputEl = document.getElementById('command-palette-input');
+    resultsEl = document.getElementById('command-palette-results');
+    if (!overlayEl || !inputEl || !resultsEl) return;
+
+    // Resolve placeholder and aria-label from i18n on init (data-i18n on
+    // input attributes isn't supported by the project's global resolver).
+    inputEl.placeholder = api.getMessage('cmdPalettePlaceholder') || 'Search tabs, bookmarks, actions...';
+    inputEl.setAttribute('aria-label', api.getMessage('cmdPaletteAriaLabel') || 'Command palette');
+
+    document.addEventListener('keydown', handleGlobalKeydown);
+    overlayEl.addEventListener('click', (e) => {
+        // Backdrop click closes; clicks inside the modal don't.
+        if (e.target === overlayEl) close();
+    });
+    inputEl.addEventListener('input', debouncedRefresh);
+    inputEl.addEventListener('keydown', handleInputKeydown);
+}
+
+function handleGlobalKeydown(e) {
+    // Cmd+K on Mac, Ctrl+K elsewhere.
+    if ((e.metaKey || e.ctrlKey) && (e.key === 'k' || e.key === 'K')) {
+        e.preventDefault();
+        toggle();
+    } else if (e.key === 'Escape' && isOpen) {
+        e.preventDefault();
+        close();
+    }
+}
+
+function handleInputKeydown(e) {
+    if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        moveActive(1);
+    } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        moveActive(-1);
+    } else if (e.key === 'Enter') {
+        e.preventDefault();
+        executeActive();
+    }
+}
+
+function toggle() {
+    if (isOpen) close(); else open();
+}
+
+export function open() {
+    isOpen = true;
+    overlayEl.hidden = false;
+    inputEl.value = '';
+    inputEl.focus();
+    refresh();
+}
+
+export function close() {
+    isOpen = false;
+    overlayEl.hidden = true;
+    inputEl.value = '';
+    resultsEl.innerHTML = '';
+    currentResults = [];
+    activeIndex = 0;
+}
+
+const debouncedRefresh = debounce(() => refresh(), 100);
+
+async function refresh() {
+    const query = inputEl.value;
+    const groups = await searchAll(query);
+    renderGroups(groups);
+}
+
+function renderGroups(groups) {
+    resultsEl.innerHTML = '';
+    currentResults = [];
+    activeIndex = 0;
+
+    if (groups.length === 0) {
+        const empty = document.createElement('div');
+        empty.className = 'cmd-palette-empty';
+        empty.textContent = api.getMessage('cmdPaletteEmpty') || 'No results';
+        resultsEl.appendChild(empty);
+        return;
+    }
+
+    const frag = document.createDocumentFragment();
+    for (const group of groups) {
+        const header = document.createElement('div');
+        header.className = 'cmd-palette-group-header';
+        header.textContent = api.getMessage(group.titleKey) || group.titleKey;
+        frag.appendChild(header);
+
+        for (const item of group.items) {
+            const row = buildRow(item, currentResults.length);
+            currentResults.push({ item, row });
+            frag.appendChild(row);
+        }
+    }
+    resultsEl.appendChild(frag);
+    setActive(0);
+}
+
+function buildRow(item, index) {
+    const row = document.createElement('div');
+    row.className = 'cmd-palette-row';
+    row.dataset.index = String(index);
+    row.setAttribute('role', 'option');
+
+    const icon = document.createElement('span');
+    icon.className = 'cmd-palette-icon';
+    const isUrlIcon = typeof item.icon === 'string'
+        && (item.icon.startsWith('http://') || item.icon.startsWith('https://') || item.icon.startsWith('chrome://'));
+    if (isUrlIcon) {
+        const img = document.createElement('img');
+        img.src = item.icon;
+        img.alt = '';
+        img.onerror = () => { img.replaceWith(document.createTextNode('🌐')); };
+        icon.appendChild(img);
+    } else {
+        icon.textContent = item.icon || '•';
+    }
+
+    const meta = document.createElement('div');
+    meta.className = 'cmd-palette-meta';
+
+    const title = document.createElement('div');
+    title.className = 'cmd-palette-title';
+    title.textContent = item.titleKey
+        ? (api.getMessage(item.titleKey) || item.titleKey)
+        : (item.title || '');
+
+    meta.appendChild(title);
+    if (item.subtitle) {
+        const subtitle = document.createElement('div');
+        subtitle.className = 'cmd-palette-subtitle';
+        subtitle.textContent = item.subtitle;
+        meta.appendChild(subtitle);
+    }
+
+    row.appendChild(icon);
+    row.appendChild(meta);
+
+    row.addEventListener('click', () => {
+        activeIndex = parseInt(row.dataset.index, 10) || 0;
+        executeActive();
+    });
+
+    return row;
+}
+
+function setActive(index) {
+    if (currentResults.length === 0) return;
+    activeIndex = Math.max(0, Math.min(currentResults.length - 1, index));
+    currentResults.forEach((r, i) => r.row.classList.toggle('active', i === activeIndex));
+    const active = currentResults[activeIndex];
+    if (active) active.row.scrollIntoView({ block: 'nearest' });
+}
+
+function moveActive(delta) {
+    setActive(activeIndex + delta);
+}
+
+async function executeActive() {
+    const current = currentResults[activeIndex];
+    if (!current) return;
+    close();
+    try {
+        await current.item.handler();
+    } catch (err) {
+        console.error('Command Palette action failed:', err);
+    }
+}

--- a/sidepanel.css
+++ b/sidepanel.css
@@ -2942,3 +2942,146 @@ mark.url-match {
     opacity: 0.6;
     pointer-events: none;
 }
+
+/* === Command Palette (Cmd+K / Ctrl+K) === */
+.cmd-palette-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.45);
+    z-index: 9999;
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+    padding-top: 10vh;
+}
+
+.cmd-palette-overlay[hidden] {
+    display: none;
+}
+
+.cmd-palette-modal {
+    width: min(92%, 480px);
+    max-height: 70vh;
+    background: var(--main-bg-color);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
+.cmd-palette-input {
+    width: 100%;
+    box-sizing: border-box;
+    padding: 12px 14px;
+    font-size: 1em;
+    background: var(--main-bg-color);
+    color: var(--text-color-primary);
+    border: none;
+    border-bottom: 1px solid var(--border-color);
+    outline: none;
+}
+
+.cmd-palette-input::placeholder {
+    color: var(--text-color-primary);
+    opacity: 0.45;
+}
+
+.cmd-palette-results {
+    overflow-y: auto;
+    flex: 1;
+    padding: 4px 0;
+}
+
+.cmd-palette-group-header {
+    padding: 6px 12px 2px;
+    font-size: 0.7em;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-color-primary);
+    opacity: 0.55;
+}
+
+.cmd-palette-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 6px 12px;
+    cursor: pointer;
+    color: var(--text-color-primary);
+}
+
+.cmd-palette-row.active,
+.cmd-palette-row:hover {
+    background-color: var(--element-bg-hover-color);
+}
+
+.cmd-palette-icon {
+    flex-shrink: 0;
+    width: 18px;
+    height: 18px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 14px;
+}
+
+.cmd-palette-icon img {
+    width: 16px;
+    height: 16px;
+    object-fit: contain;
+}
+
+.cmd-palette-meta {
+    min-width: 0;
+    flex: 1;
+}
+
+.cmd-palette-title {
+    font-size: 0.9em;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.cmd-palette-subtitle {
+    font-size: 0.75em;
+    opacity: 0.55;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    margin-top: 1px;
+}
+
+.cmd-palette-empty {
+    padding: 20px;
+    text-align: center;
+    color: var(--text-color-primary);
+    opacity: 0.55;
+    font-size: 0.9em;
+}
+
+.cmd-palette-hint {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 12px;
+    font-size: 0.7em;
+    color: var(--text-color-primary);
+    opacity: 0.55;
+    border-top: 1px solid var(--border-color);
+    background-color: var(--element-bg-color);
+}
+
+.cmd-palette-hint-key {
+    padding: 1px 5px;
+    border: 1px solid var(--border-color);
+    border-radius: 3px;
+    font-family: monospace;
+    margin-right: 2px;
+}
+
+.cmd-palette-hint-key + span {
+    margin-right: 8px;
+}

--- a/sidepanel.html
+++ b/sidepanel.html
@@ -111,6 +111,19 @@
         <button id="toast-close-btn" title="Close" data-i18n-title="toastCloseBtn" aria-label="Close">×</button>
     </div>
 
+    <!-- Command Palette (Cmd+K / Ctrl+K) -->
+    <div id="command-palette-overlay" class="cmd-palette-overlay" hidden>
+        <div class="cmd-palette-modal" role="dialog" aria-modal="true">
+            <input type="text" id="command-palette-input" class="cmd-palette-input" autocomplete="off" spellcheck="false">
+            <div id="command-palette-results" class="cmd-palette-results" role="listbox"></div>
+            <div class="cmd-palette-hint">
+                <span class="cmd-palette-hint-key">↑↓</span><span data-i18n="cmdPaletteHintNavigate"></span>
+                <span class="cmd-palette-hint-key">↵</span><span data-i18n="cmdPaletteHintSelect"></span>
+                <span class="cmd-palette-hint-key">Esc</span><span data-i18n="cmdPaletteHintClose"></span>
+            </div>
+        </div>
+    </div>
+
     <script src="lib/Sortable.min.js" defer></script>
     <script type="module" src="sidepanel.js"></script>
 </body>

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -9,6 +9,7 @@ import * as readingListManager from './modules/readingListManager.js';
 import * as readingListRenderer from './modules/ui/readingListRenderer.js';
 import * as rssManager from './modules/rssManager.js';
 import * as hoverSummarize from './modules/ui/hoverSummarizeManager.js';
+import { initCommandPalette } from './modules/commandPalette/index.js';
 import { SEARCH_NO_RESULTS_ICON_SVG } from './modules/icons.js';
 import { debounce } from './modules/utils/functionUtils.js';
 
@@ -165,6 +166,7 @@ async function initialize() {
     rssManager.initRssManager().catch(console.error);
     keyboard.initialize();
     hoverSummarize.init(); // Initialize Hover Summarize feature
+    initCommandPalette(); // Cmd+K / Ctrl+K unified search & actions overlay
 
     // Keep multiple open sidepanels in sync: linkedTabs affects bookmark icons,
     // windowNames affects the "Other Windows" section labels.


### PR DESCRIPTION
## 摘要 (Summary)

對應 plan「專案優化與差異化策略計畫」B2.2。新增 Command Palette（Cmd+K / Ctrl+K）作為 keyboard-driven 統一搜尋與動作入口，覆蓋 tabs / bookmarks / reading list / built-in actions 四個來源。

這是「對抗 Chrome 原生 tab search 的關鍵 UX」——原生只有 tab search，這裡多一層 bookmarks + reading list + actions 統一入口，且使用者熟悉的 Cmd+K 風格（Linear / VS Code / Raycast）。

### 相關 Issue (Related Issues)

無。基於 plan B2.2。

---

## 📝 變更內容 (Changes)

### 新增 (Added)
- **`modules/commandPalette/actions.js`**：built-in 動作註冊表，初版 5 個高頻入口（Smart Group / AI Cleanup / New tab right / Refresh bookmarks / Open settings）。Handler 直接呼叫對應 button.click() 避免重複邏輯。
- **`modules/commandPalette/dataProvider.js`**：統一 4 個資料源 + `scoreFilter`（indexOf 為基礎的位置排序），每組上限 8 筆，空 query 時顯示前 N 筆。
- **`modules/commandPalette/index.js`**：UI 主控（open / close / keyboard navigation / debounced refresh / render）。
- **`sidepanel.html`**：overlay + modal markup（input + scrollable results + hint footer）
- **`sidepanel.css`**：~135 行 `.cmd-palette-*` 樣式，用 design system 變數對齊既有風格
- **`_locales/{en,zh_TW,zh_CN}/messages.json`**：15 個新字串各 3 語
- **`.agent/notes/NOTE_20260526_phase5.md`**：session 摘要

### 修改 (Changed)
- **`sidepanel.js`**：import `initCommandPalette` + initialize 結尾呼叫（不走 uiManager facade，commandPalette 獨立模組樹）

### 重要決策說明
- **觸發位置 = sidepanel keydown，不註冊 manifest commands**：Chrome 已把 Ctrl+K 映射到 address bar search engine switcher，註冊 global Ctrl+K 會撞衝突且需要使用者去 `chrome://extensions/shortcuts` 重新分配。sidepanel-scoped listener 只在 sidepanel focus 時生效，零配置體驗。
- **不複用 searchManager**：plan 原寫「與 searchManager 整合」，但實作上 searchManager 是 DOM-based filter（hide/show 既有列表），command palette 是 fresh-query rendering，兩者抽象差太多硬整合會把兩個都搞複雜。各自純粹更好。
- **score-filter 用 indexOf 而非 fuzzy match**：對 8 筆/組規模感覺夠準，fuzzy match（fzf 演算法）是過度工程。需要時再升級。
- **Action handler 直接呼叫 button.click()**：避免重複 UI 狀態管理。代價是脆耦合（button id 改動會破壞 actions），但對 5 個高頻入口是合理 tradeoff。

---

## 🧪 測試 (Testing)

### 自動化測試
- [x] `npm run test:unit` → 57/57 通過（無回退）
- [x] Puppeteer happy paths：`happy_path_sidepanel_load` + `happy_path_search` 10/10 通過（確認新 overlay markup 不影響既有 UI）
- [x] `esbuild --bundle` 編譯通過（sidepanel.js + background.js 兩 entry）
- [x] 3 個 `messages.json` JSON 合法

### 手動驗證
1. `make` → `chrome://extensions` 載入未封裝
2. 在 sidepanel 內按 **Cmd+K (Mac) / Ctrl+K (Win/Linux)** → overlay 應浮現，input 自動 focus
3. 輸入 query → 應即時 filter 4 個來源並 group 顯示
4. **鍵盤行為**：↑/↓ 移動高亮、Enter 執行、Esc 關閉、點背景關閉
5. **結果類型驗證**：
   - 點 tab 結果 → 切換到該分頁 + focus 對應 window
   - 點 bookmark 結果 → 開新分頁到該 URL
   - 點 reading list 結果 → 開新分頁到該 URL
   - 點 action（Smart Group / Cleanup / Settings / New tab right / Refresh bookmarks）→ 觸發對應功能
6. **空 query**：應顯示所有 actions + 各 source 前 N 筆
7. **無結果**：輸入無 match 字串 → 顯示「No results」
8. **多語**：切到 zh_TW / zh_CN UI 確認新字串；切到其他 11 語 fallback 到 en

---

## ✅ 檢查清單 (Checklist)

- [x] 程式碼遵循專案 coding style（ES modules、vanilla JS、aria-label / role 屬性）
- [x] 自動化測試已通過
- [x] `.agent/notes/NOTE_20260526_phase5.md` 已寫
- [x] PR 描述包含英文版本
- [ ] **待辦**：11 個其他語系翻譯 → Phase 11
- [ ] **待辦**：Puppeteer test for command palette flow（Cmd+K trigger + 鍵盤導航 + Enter 執行） → 後續 phase 補
- [ ] **待辦**：若體感 indexOf score-filter 不夠準，可考慮升 fuzzy match
- [ ] **待辦**：後續 Phase 新增 features（Workspace、Bookmarks 2.0）若有合適 action 入口，加進 `actions.js`

---

## 🌐 English Version

### Summary

Implements plan B2.2: Command Palette (Cmd+K / Ctrl+K) as a keyboard-driven unified entry to tabs, bookmarks, reading list, and built-in actions. Addresses the "compete with Chrome's native tab search" UX angle from the strategic plan — native only covers tabs, this overlay adds bookmarks + reading list + actions in the familiar Linear / VS Code / Raycast Cmd+K paradigm.

### Changes

#### Added
- **`modules/commandPalette/`**: new module tree (3 files, ~370 lines)
  - `actions.js` — built-in action registry; 5 initial high-frequency entries (Smart Group / AI Cleanup / New tab right / Refresh bookmarks / Open settings). Handlers reuse existing buttons via `.click()` rather than re-implementing UI state.
  - `dataProvider.js` — aggregates 4 sources with indexOf-based position scoring; caps 8 per group. Empty query shows top N from each source so actions are immediately visible.
  - `index.js` — UI controller (open / close / keyboard nav / debounced refresh / render).
- **`sidepanel.html` / `sidepanel.css`**: overlay + modal markup + ~135 lines of `.cmd-palette-*` styles using design-system variables.
- 15 new i18n strings each in `en`, `zh_TW`, `zh_CN`.

#### Changed
- **`sidepanel.js`**: imports `initCommandPalette` and calls it at the end of `initialize` (bypassing the `uiManager` facade since commandPalette is its own module tree).

#### Key decisions
- **Trigger via sidepanel keydown, not manifest commands**: Chrome already maps Ctrl+K to the address bar's search engine switcher; registering a global Ctrl+K would clash and force the user to manually reassign via `chrome://extensions/shortcuts`. A sidepanel-scoped listener only fires when the sidepanel has focus — zero configuration.
- **Don't reuse `searchManager`**: the plan suggested integration, but `searchManager` is DOM-based filtering (hide/show existing lists) while the palette does fresh-query rendering. Forcing them together complicates both; keeping them separate is cleaner.
- **indexOf scoring, not fuzzy match**: for 8 items per group, indexOf + position sort is precise enough. Upgrade to fuzzy (e.g., fzy) only if user feedback warrants it.
- **Action handlers delegate to `button.click()`**: avoids duplicating UI state machines. Brittle (button id changes break actions) but acceptable for 5 well-known high-traffic entries.

### Testing

- `npm run test:unit` → 57/57 passing (no regression)
- Puppeteer regression: `sidepanel_load` + `search` 10/10 passing (confirms overlay markup doesn't break existing UI loading)
- `esbuild --bundle` succeeds for both `sidepanel.js` and `background.js` entries
- 3 `messages.json` files validate

Manual verification: see the Chinese section for the step-by-step.

### Related Issues
None. Based on plan B2.2.
