### PR TITLE
feat(workspace): hibernate-restore Workspace with switcher and palette

### DIFF
--- a/.agent/notes/NOTE_20260527_phase6.md
+++ b/.agent/notes/NOTE_20260527_phase6.md
@@ -1,0 +1,76 @@
+# 開發摘要 - 2026-05-27 (Phase 6: Workspace)
+
+> 對應 plan「專案優化與差異化策略計畫」B2.3。把既有 windowNames（per-window 字串標籤）升級為含 snapshot 的 Workspace（可 hibernate + restore）。
+
+## 變更項目
+
+### 新模組 `modules/workspace/`
+
+- **`workspaceManager.js`**（~210 行）
+  - Schema: `Workspace = { id, name, color, icon, bookmarkFolderId?, tabSnapshot[], lastActiveAt }`
+  - Storage: `chrome.storage.local.workspaces` (Map) + `windowWorkspaceMap` (windowId → wsId)
+  - CRUD: `createWorkspace` / `updateWorkspace` / `deleteWorkspace` / `snapshotIntoWorkspace`
+  - 核心切換邏輯 `switchWorkspace(targetId, windowId)`：
+    1. snapshot 當前 window tabs → 寫入離開的 workspace
+    2. open 目標 workspace 的 tabSnapshot（**先 open 才 close**，避免關掉最後一個 tab 導致 window 關閉）
+    3. close 原本 tabs
+    4. bind window → target workspace
+  - 過濾 chrome:// / about: tabs 不入 snapshot（無法 re-open 反而吵）
+  - Tab 順序：sequential `chrome.tabs.create` 保證順序穩定（~30ms/tab × 30 = 1s worst case，user-initiated 可接受）
+
+- **`workspaceUI.js`**（~200 行）
+  - 頂部 switcher select + manage button
+  - 切換時走 `modal.showConfirm` 顯示「將關閉 N 個分頁」
+  - Manage dialog（用 modalManager.showCustomDialog）列出所有 workspaces，每行有 rename + delete
+  - 「+ New from current tabs」按鈕：prompt name → snapshot + setActive
+  - rename / delete 後 **inline** 更新 row（不關 dialog reopen，避免 modal stack）
+  - 監聽 `chrome.storage.onChanged` 讓多 sidepanel 同步（沿用 Phase 2 同樣模式）
+
+### Command Palette 整合
+
+- `modules/commandPalette/dataProvider.js` 加第 5 group `workspaces`，每個 workspace 變一個 row，handler 走 `requestSwitchTo()`（會 trigger confirm）
+- `modules/commandPalette/actions.js` 加 2 個 action：「Create workspace from current tabs」+「Manage workspaces」
+- 動態 lazy-import `workspaceUI` 避免 commandPalette ↔ workspace 循環依賴
+
+### UI / wiring
+
+- `sidepanel.html` 頂部新增 workspace row（select + ⚙️ button），位於 search container 之上（visual hierarchy：workspace > 全域工作上下文，search 是工作內篩選）
+- `sidepanel.css` ~95 行 `.workspace-*` 樣式
+- `sidepanel.js` `initialize` 結尾加 `workspaceManager.initWorkspaces()` + `initWorkspaceUI()`
+
+### i18n
+
+16 個新字串 × 3 語（en / zh_TW / zh_CN）。其他 11 語留 Phase 11。
+
+## 技術決策
+
+- **Storage in `local` 不在 `sync`**：tabSnapshot 可達數十筆遠超 sync 的 8KB/key 預算。Phase 9 會再加 opt-in sync 變體（只 sync metadata 不 sync snapshot）。
+- **switch 語意 = close-and-restore 不是 discard**：`chrome.tabs.discard` 保留 history 但 tab 仍在 strip 上，不符合「切換工作區」的視覺；採 close + 重開新 tab 從 snapshot。失去 scroll position 與 form state 是 trade-off，配 confirm dialog 讓 user 決定。
+- **不 snapshot tab group 結構（v1）**：重建 group 需要 chrome.tabGroups 順序穩定的 restore 邏輯，留 v2。Tab 仍 restore 但無 group 結構。
+- **rename/delete 採 inline 更新**：避免 close dialog + reopen 的 modal stack 問題。
+- **workspace row 在 sidepanel 最頂**：是「全域工作上下文」概念，視覺上應在 search box 之上。
+- **switch 按鈕 vs 整合 select**：switch 是高頻動作（每天可能多次），用 `<select>` 一個 click 就切；rename/delete/create 等低頻動作藏 manage dialog 內。
+- **v1 不做 theme 綁定 / reading list filter**：兩者增加複雜度但邊際價值低，留 v2（plan B2.3 提到但可延後）。
+
+## 驗證
+
+- esbuild bundle: sidepanel + background 兩 entry 通過
+- JSON: 3 個 messages.json 合法
+- Unit tests: 57/57 通過（無回退）
+- Puppeteer: happy_path_sidepanel_load + happy_path_search + happy_path_settings_panel（結果見 PR）
+- **手動驗證待做**：
+  - workspace switcher 顯示在頂部
+  - 「+ New from current tabs」prompt name → 應建出 workspace + 該 workspace tab count = 當前
+  - Switcher 選 workspace → confirm 「將關閉 N 個分頁」→ tabs 切換
+  - Rename / delete 在 manage dialog 內
+  - Cmd+K 開 palette → workspaces group 顯示所有 workspace + 兩個 workspace action
+  - 多 sidepanel 同步：在 window A 建 workspace，window B 的 switcher 應即時看到
+
+## 待辦
+
+- 11 個其他語系翻譯 → Phase 11
+- v2：tab group 結構 snapshot / restore
+- v2：theme 綁定（切 workspace 自動套對應 theme）
+- v2：reading list filter 綁定
+- Phase 9 將補：workspace metadata sync (sync area, 不含 snapshot)
+- Puppeteer test for workspace switch flow（mock chrome.tabs.create / remove） → 後續 phase

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -772,5 +772,53 @@
   },
   "cmdPaletteActionSettings": {
     "message": "Open settings"
+  },
+  "cmdPaletteGroupWorkspaces": {
+    "message": "Workspaces"
+  },
+  "cmdPaletteActionCreateWorkspace": {
+    "message": "Create workspace from current tabs"
+  },
+  "cmdPaletteActionManageWorkspaces": {
+    "message": "Manage workspaces"
+  },
+  "workspaceSwitcherAriaLabel": {
+    "message": "Active workspace"
+  },
+  "workspaceManageTitle": {
+    "message": "Manage workspaces"
+  },
+  "workspaceNoActive": {
+    "message": "— no workspace —"
+  },
+  "workspaceSwitchConfirmTitle": {
+    "message": "Switch workspace"
+  },
+  "workspaceSwitchConfirmMessage": {
+    "message": "Switching to \"{ws}\" will close {n} tab(s) in this window and open the saved tabs."
+  },
+  "workspaceSwitchConfirmBtn": {
+    "message": "Switch"
+  },
+  "workspaceManageEmpty": {
+    "message": "No workspaces yet."
+  },
+  "workspaceCreateFromCurrent": {
+    "message": "+ New from current tabs"
+  },
+  "workspaceRename": {
+    "message": "Rename"
+  },
+  "workspaceDelete": {
+    "message": "Delete"
+  },
+  "workspaceDeleteConfirmTitle": {
+    "message": "Delete workspace"
+  },
+  "workspaceDeleteConfirmMessage": {
+    "message": "Delete \"{ws}\"? This cannot be undone."
+  },
+  "workspaceCreatePromptTitle": {
+    "message": "Name this workspace"
   }
 }

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -797,6 +797,15 @@
   "workspaceSwitchConfirmMessage": {
     "message": "Switching to \"{ws}\" will close {n} tab(s) in this window and open the saved tabs."
   },
+  "workspaceSwitchConfirmMessageUnbound": {
+    "message": "Switching to \"{ws}\" — your current {n} tab(s) aren't in any workspace yet. They will be auto-saved to a new \"Untitled\" workspace before the switch."
+  },
+  "workspaceSwitchFailedTitle": {
+    "message": "Switch failed"
+  },
+  "workspaceSwitchFailedMessage": {
+    "message": "Could not switch workspace. Your current tabs were not changed."
+  },
   "workspaceSwitchConfirmBtn": {
     "message": "Switch"
   },

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -794,6 +794,15 @@
   "workspaceSwitchConfirmMessage": {
     "message": "切换到「{ws}」会关闭这个窗口当前的 {n} 个标签页，并打开已保存的标签页。"
   },
+  "workspaceSwitchConfirmMessageUnbound": {
+    "message": "切换到「{ws}」— 当前的 {n} 个标签页尚未存于任何工作区，将先自动保存为「Untitled」工作区再切换。"
+  },
+  "workspaceSwitchFailedTitle": {
+    "message": "切换失败"
+  },
+  "workspaceSwitchFailedMessage": {
+    "message": "无法切换工作区，当前的标签页未被更改。"
+  },
   "workspaceSwitchConfirmBtn": {
     "message": "切换"
   },

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -769,5 +769,53 @@
   },
   "cmdPaletteActionSettings": {
     "message": "打开设置"
+  },
+  "cmdPaletteGroupWorkspaces": {
+    "message": "工作区"
+  },
+  "cmdPaletteActionCreateWorkspace": {
+    "message": "从当前标签页创建工作区"
+  },
+  "cmdPaletteActionManageWorkspaces": {
+    "message": "管理工作区"
+  },
+  "workspaceSwitcherAriaLabel": {
+    "message": "当前工作区"
+  },
+  "workspaceManageTitle": {
+    "message": "管理工作区"
+  },
+  "workspaceNoActive": {
+    "message": "— 无工作区 —"
+  },
+  "workspaceSwitchConfirmTitle": {
+    "message": "切换工作区"
+  },
+  "workspaceSwitchConfirmMessage": {
+    "message": "切换到「{ws}」会关闭这个窗口当前的 {n} 个标签页，并打开已保存的标签页。"
+  },
+  "workspaceSwitchConfirmBtn": {
+    "message": "切换"
+  },
+  "workspaceManageEmpty": {
+    "message": "尚无工作区。"
+  },
+  "workspaceCreateFromCurrent": {
+    "message": "+ 从当前标签页创建"
+  },
+  "workspaceRename": {
+    "message": "重命名"
+  },
+  "workspaceDelete": {
+    "message": "删除"
+  },
+  "workspaceDeleteConfirmTitle": {
+    "message": "删除工作区"
+  },
+  "workspaceDeleteConfirmMessage": {
+    "message": "删除「{ws}」？此操作无法撤销。"
+  },
+  "workspaceCreatePromptTitle": {
+    "message": "为此工作区命名"
   }
 }

--- a/_locales/zh_TW/messages.json
+++ b/_locales/zh_TW/messages.json
@@ -794,6 +794,15 @@
   "workspaceSwitchConfirmMessage": {
     "message": "切換到「{ws}」會關閉這個視窗目前的 {n} 個分頁，並開啟已儲存的分頁。"
   },
+  "workspaceSwitchConfirmMessageUnbound": {
+    "message": "切換到「{ws}」— 目前的 {n} 個分頁尚未存於任何工作區，將先自動儲存為「Untitled」工作區再切換。"
+  },
+  "workspaceSwitchFailedTitle": {
+    "message": "切換失敗"
+  },
+  "workspaceSwitchFailedMessage": {
+    "message": "無法切換工作區，目前的分頁未被變更。"
+  },
   "workspaceSwitchConfirmBtn": {
     "message": "切換"
   },

--- a/_locales/zh_TW/messages.json
+++ b/_locales/zh_TW/messages.json
@@ -769,5 +769,53 @@
   },
   "cmdPaletteActionSettings": {
     "message": "開啟設定"
+  },
+  "cmdPaletteGroupWorkspaces": {
+    "message": "工作區"
+  },
+  "cmdPaletteActionCreateWorkspace": {
+    "message": "從當前分頁建立工作區"
+  },
+  "cmdPaletteActionManageWorkspaces": {
+    "message": "管理工作區"
+  },
+  "workspaceSwitcherAriaLabel": {
+    "message": "目前工作區"
+  },
+  "workspaceManageTitle": {
+    "message": "管理工作區"
+  },
+  "workspaceNoActive": {
+    "message": "— 無工作區 —"
+  },
+  "workspaceSwitchConfirmTitle": {
+    "message": "切換工作區"
+  },
+  "workspaceSwitchConfirmMessage": {
+    "message": "切換到「{ws}」會關閉這個視窗目前的 {n} 個分頁，並開啟已儲存的分頁。"
+  },
+  "workspaceSwitchConfirmBtn": {
+    "message": "切換"
+  },
+  "workspaceManageEmpty": {
+    "message": "尚無工作區。"
+  },
+  "workspaceCreateFromCurrent": {
+    "message": "+ 從當前分頁建立"
+  },
+  "workspaceRename": {
+    "message": "重新命名"
+  },
+  "workspaceDelete": {
+    "message": "刪除"
+  },
+  "workspaceDeleteConfirmTitle": {
+    "message": "刪除工作區"
+  },
+  "workspaceDeleteConfirmMessage": {
+    "message": "刪除「{ws}」？此動作無法復原。"
+  },
+  "workspaceCreatePromptTitle": {
+    "message": "為這個工作區命名"
   }
 }

--- a/modules/commandPalette/actions.js
+++ b/modules/commandPalette/actions.js
@@ -60,5 +60,22 @@ export function buildActions() {
             titleKey: 'cmdPaletteActionSettings',
             handler: () => document.getElementById('settings-toggle')?.click(),
         },
+        {
+            id: 'action-create-workspace',
+            type: 'action',
+            icon: '💼',
+            titleKey: 'cmdPaletteActionCreateWorkspace',
+            handler: async () => {
+                const { createWorkspaceFromCurrent } = await import('../workspace/workspaceUI.js');
+                await createWorkspaceFromCurrent();
+            },
+        },
+        {
+            id: 'action-manage-workspaces',
+            type: 'action',
+            icon: '📦',
+            titleKey: 'cmdPaletteActionManageWorkspaces',
+            handler: () => document.getElementById('workspace-manage-btn')?.click(),
+        },
     ];
 }

--- a/modules/commandPalette/dataProvider.js
+++ b/modules/commandPalette/dataProvider.js
@@ -8,6 +8,7 @@
 import * as state from '../stateManager.js';
 import * as api from '../apiManager.js';
 import * as readingListManager from '../readingListManager.js';
+import * as wsManager from '../workspace/workspaceManager.js';
 import { buildActions } from './actions.js';
 
 const MAX_RESULTS_PER_GROUP = 8;
@@ -39,13 +40,31 @@ export async function searchAll(query) {
     ]);
     const bookmarks = getBookmarkResults(q);
     const actions = getActionResults(q);
+    const workspaces = getWorkspaceResults(q);
 
     return [
         { type: 'action', titleKey: 'cmdPaletteGroupActions', items: actions },
+        { type: 'workspace', titleKey: 'cmdPaletteGroupWorkspaces', items: workspaces },
         { type: 'tab', titleKey: 'cmdPaletteGroupTabs', items: tabs },
         { type: 'bookmark', titleKey: 'cmdPaletteGroupBookmarks', items: bookmarks },
         { type: 'reading-list', titleKey: 'cmdPaletteGroupReadingList', items: readingList },
     ].filter(g => g.items.length > 0);
+}
+
+function getWorkspaceResults(q) {
+    const workspaces = wsManager.getAllWorkspaces();
+    return scoreFilter(workspaces, q, w => w.name || '').map(w => ({
+        id: 'workspace-' + w.id,
+        type: 'workspace',
+        icon: w.icon,
+        title: w.name,
+        subtitle: `${(w.tabSnapshot || []).length} tab(s)`,
+        handler: async () => {
+            // Lazy-import to avoid circular dep with workspaceUI.
+            const { requestSwitchTo } = await import('../workspace/workspaceUI.js');
+            await requestSwitchTo(w.id);
+        },
+    }));
 }
 
 async function getTabResults(q) {

--- a/modules/workspace/workspaceManager.js
+++ b/modules/workspace/workspaceManager.js
@@ -159,19 +159,21 @@ async function snapshotWindowTabs(windowId) {
 
 /**
  * Hibernate-then-restore switch:
- *   1) snapshot current window tabs into the outgoing workspace (so they
- *      can be restored later);
+ *   1) ensure the outgoing tabs are saved somewhere — either the currently-
+ *      bound workspace, or (if the window is unbound) a fresh auto-created
+ *      "Untitled <timestamp>" workspace. NEVER discard unbound tabs silently;
  *   2) open the target workspace's snapshot in the same window;
- *   3) close the original tabs;
+ *   3) close the original tabs IFF we successfully opened at least one new
+ *      tab, otherwise abort to avoid emptying the window;
  *   4) bind window → target workspace.
  *
- * We open new tabs BEFORE closing old ones so Chrome doesn't auto-close the
- * window when the last tab is removed. Empty target snapshot opens one
- * blank tab for the same reason.
+ * Open before close: removing the last tab in a window auto-closes the
+ * window. Empty target snapshot opens one blank tab for the same reason.
  *
  * @param {string} targetId
  * @param {number} windowId
- * @returns {Promise<boolean>} true if switched, false if no-op or invalid.
+ * @returns {Promise<boolean>} true if switched.
+ * @throws if no target tab could be opened (window left untouched).
  */
 export async function switchWorkspace(targetId, windowId) {
     if (!workspaces[targetId]) return false;
@@ -180,6 +182,18 @@ export async function switchWorkspace(targetId, windowId) {
 
     if (currentActiveId) {
         await snapshotIntoWorkspace(currentActiveId, windowId);
+    } else {
+        // Unbound window: auto-save current tabs to a recovery workspace before
+        // we close them. Without this, the user's tabs would vanish on every
+        // first switch after a browser restart (windowWorkspaceMap uses
+        // ephemeral window ids and is not rebuilt on startup).
+        const oldTabs = await chrome.tabs.query({ windowId }).catch(() => []);
+        if (oldTabs.length > 0) {
+            await createWorkspace({
+                name: 'Untitled ' + formatTimestamp(),
+                snapshotWindowId: windowId,
+            });
+        }
     }
 
     const target = workspaces[targetId];
@@ -190,6 +204,7 @@ export async function switchWorkspace(targetId, windowId) {
     const oldTabs = await chrome.tabs.query({ windowId }).catch(() => []);
     const oldTabIds = oldTabs.map(t => t.id);
 
+    let createdCount = 0;
     // Sequential create keeps the restored tab order stable. ~30ms/tab × 30 tabs
     // ≈ 1s worst case, acceptable for an explicit user action behind a confirm.
     for (let i = 0; i < snapshotTabs.length; i++) {
@@ -201,9 +216,16 @@ export async function switchWorkspace(targetId, windowId) {
                 active: i === 0,
                 pinned: s.pinned || false,
             });
+            createdCount++;
         } catch (err) {
             console.warn('[workspace] failed to restore tab', s.url, err);
         }
+    }
+
+    if (createdCount === 0) {
+        // Don't close old tabs if we have nothing to replace them with —
+        // would leave the window empty and Chrome would auto-close it.
+        throw new Error('Could not open any tab from the target workspace snapshot.');
     }
 
     if (oldTabIds.length > 0) {
@@ -216,6 +238,29 @@ export async function switchWorkspace(targetId, windowId) {
 
     await setActiveWorkspace(windowId, targetId);
     return true;
+}
+
+/**
+ * Removes window→workspace entries for windows that no longer exist.
+ * Called on init to clean up ephemeral ids that pile up across sessions.
+ */
+export async function pruneWindowWorkspaceMap() {
+    const allWindows = await chrome.windows.getAll().catch(() => []);
+    const aliveIds = new Set(allWindows.map(w => String(w.id)));
+    let changed = false;
+    for (const wid of Object.keys(windowWorkspaceMap)) {
+        if (!aliveIds.has(wid)) {
+            delete windowWorkspaceMap[wid];
+            changed = true;
+        }
+    }
+    if (changed) await persistWindowMap();
+}
+
+function formatTimestamp() {
+    const d = new Date();
+    const pad = n => String(n).padStart(2, '0');
+    return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
 }
 
 function persistWorkspaces() {

--- a/modules/workspace/workspaceManager.js
+++ b/modules/workspace/workspaceManager.js
@@ -1,0 +1,227 @@
+/**
+ * Workspace Manager
+ *
+ * A Workspace is a saved bundle of (tabs + optional bookmark folder hint) that
+ * the user can hibernate and restore as a unit. Storage layout:
+ *
+ *   chrome.storage.local.workspaces            → { [id]: Workspace }
+ *   chrome.storage.local.windowWorkspaceMap    → { [windowId]: workspaceId }
+ *
+ * @typedef {Object} Workspace
+ * @property {string} id
+ * @property {string} name
+ * @property {string} color      - 8 preset colors (matches tab group palette)
+ * @property {string} icon       - single emoji
+ * @property {string} [bookmarkFolderId]  - optional Chrome bookmark folder hint
+ * @property {TabSnapshot[]} tabSnapshot
+ * @property {number} lastActiveAt
+ *
+ * @typedef {Object} TabSnapshot
+ * @property {string} url
+ * @property {string} title
+ * @property {boolean} [pinned]
+ *
+ * Design choices:
+ * - Storage in `local` not `sync`: snapshots can hold dozens of tabs, far
+ *   exceeding sync's 8KB-per-key budget. Phase 9 will add an opt-in sync
+ *   variant for the workspace metadata (without snapshots).
+ * - In-memory cache mirrors storage; CRUD writes through. Other sidepanels
+ *   pick up changes via the cross-sidepanel storage subscriber (Phase 2).
+ * - Group membership is intentionally NOT snapshotted in v1. Restoring group
+ *   structure requires recreating chrome.tabGroups in a stable order, which
+ *   we'll add in a follow-up if user feedback asks for it.
+ */
+import { getStorage, setStorage } from '../apiManager.js';
+
+const WORKSPACES_KEY = 'workspaces';
+const WINDOW_WORKSPACE_MAP_KEY = 'windowWorkspaceMap';
+
+const PRESET_COLORS = ['grey', 'blue', 'red', 'yellow', 'green', 'pink', 'purple', 'cyan'];
+const PRESET_ICONS = ['💼', '📚', '🎯', '🧪', '🎨', '🚀', '🏠', '🛒'];
+
+/** @type {Object<string, Workspace>} In-memory mirror of storage. */
+let workspaces = {};
+/** @type {Object<string, string>} windowId → workspaceId. */
+let windowWorkspaceMap = {};
+
+export async function initWorkspaces() {
+    const result = await getStorage('local', [WORKSPACES_KEY, WINDOW_WORKSPACE_MAP_KEY]);
+    workspaces = result[WORKSPACES_KEY] || {};
+    windowWorkspaceMap = result[WINDOW_WORKSPACE_MAP_KEY] || {};
+}
+
+export function getAllWorkspaces() {
+    // Returned sorted by lastActiveAt desc so the switcher's most-recent entries
+    // surface first. Newly created workspaces (lastActiveAt = now) lead.
+    return Object.values(workspaces).sort((a, b) => (b.lastActiveAt || 0) - (a.lastActiveAt || 0));
+}
+
+export function getWorkspace(id) {
+    return workspaces[id] || null;
+}
+
+export function getActiveWorkspaceId(windowId) {
+    return windowWorkspaceMap[String(windowId)] || null;
+}
+
+export function getPresetColors() { return [...PRESET_COLORS]; }
+export function getPresetIcons() { return [...PRESET_ICONS]; }
+
+/**
+ * Creates a Workspace. Optionally snapshots the current window's tabs into it.
+ * @param {{name: string, color?: string, icon?: string, bookmarkFolderId?: string, snapshotWindowId?: number}} args
+ * @returns {Promise<Workspace>}
+ */
+export async function createWorkspace(args) {
+    const id = 'ws_' + Date.now().toString(36) + Math.random().toString(36).slice(2, 6);
+    const ws = {
+        id,
+        name: (args.name || 'Workspace').trim().slice(0, 60),
+        color: PRESET_COLORS.includes(args.color) ? args.color : 'blue',
+        icon: (args.icon && args.icon.length <= 4) ? args.icon : '💼',
+        bookmarkFolderId: args.bookmarkFolderId || undefined,
+        tabSnapshot: [],
+        lastActiveAt: Date.now(),
+    };
+    if (typeof args.snapshotWindowId === 'number') {
+        ws.tabSnapshot = await snapshotWindowTabs(args.snapshotWindowId);
+    }
+    workspaces[id] = ws;
+    await persistWorkspaces();
+    return ws;
+}
+
+/**
+ * @param {string} id
+ * @param {Partial<Workspace>} updates
+ */
+export async function updateWorkspace(id, updates) {
+    const ws = workspaces[id];
+    if (!ws) return null;
+    if (updates.name !== undefined) ws.name = updates.name.trim().slice(0, 60);
+    if (updates.color !== undefined && PRESET_COLORS.includes(updates.color)) ws.color = updates.color;
+    if (updates.icon !== undefined && updates.icon.length <= 4) ws.icon = updates.icon;
+    if (updates.bookmarkFolderId !== undefined) ws.bookmarkFolderId = updates.bookmarkFolderId || undefined;
+    await persistWorkspaces();
+    return ws;
+}
+
+export async function deleteWorkspace(id) {
+    delete workspaces[id];
+    // Detach any window currently bound to it.
+    for (const wid of Object.keys(windowWorkspaceMap)) {
+        if (windowWorkspaceMap[wid] === id) delete windowWorkspaceMap[wid];
+    }
+    await Promise.all([persistWorkspaces(), persistWindowMap()]);
+}
+
+/**
+ * Replaces the workspace's tabSnapshot with the current state of `windowId`.
+ * Pinned and chrome:// tabs are kept (we re-open them on restore).
+ * @param {string} id
+ * @param {number} windowId
+ */
+export async function snapshotIntoWorkspace(id, windowId) {
+    const ws = workspaces[id];
+    if (!ws) return null;
+    ws.tabSnapshot = await snapshotWindowTabs(windowId);
+    ws.lastActiveAt = Date.now();
+    await persistWorkspaces();
+    return ws;
+}
+
+export async function setActiveWorkspace(windowId, workspaceId) {
+    if (workspaceId === null || workspaceId === undefined) {
+        delete windowWorkspaceMap[String(windowId)];
+    } else {
+        windowWorkspaceMap[String(windowId)] = workspaceId;
+        const ws = workspaces[workspaceId];
+        if (ws) {
+            ws.lastActiveAt = Date.now();
+            await persistWorkspaces();
+        }
+    }
+    await persistWindowMap();
+}
+
+async function snapshotWindowTabs(windowId) {
+    const tabs = await chrome.tabs.query({ windowId }).catch(() => []);
+    return tabs
+        // Don't snapshot chrome:// or about: pages — they often can't be
+        // re-opened in normal tabs and would clutter the restore set.
+        .filter(t => t.url && /^(https?|file|ftp):/i.test(t.url))
+        .map(t => ({
+            url: t.url,
+            title: t.title || '',
+            pinned: Boolean(t.pinned),
+        }));
+}
+
+/**
+ * Hibernate-then-restore switch:
+ *   1) snapshot current window tabs into the outgoing workspace (so they
+ *      can be restored later);
+ *   2) open the target workspace's snapshot in the same window;
+ *   3) close the original tabs;
+ *   4) bind window → target workspace.
+ *
+ * We open new tabs BEFORE closing old ones so Chrome doesn't auto-close the
+ * window when the last tab is removed. Empty target snapshot opens one
+ * blank tab for the same reason.
+ *
+ * @param {string} targetId
+ * @param {number} windowId
+ * @returns {Promise<boolean>} true if switched, false if no-op or invalid.
+ */
+export async function switchWorkspace(targetId, windowId) {
+    if (!workspaces[targetId]) return false;
+    const currentActiveId = getActiveWorkspaceId(windowId);
+    if (currentActiveId === targetId) return false;
+
+    if (currentActiveId) {
+        await snapshotIntoWorkspace(currentActiveId, windowId);
+    }
+
+    const target = workspaces[targetId];
+    const snapshotTabs = (target.tabSnapshot && target.tabSnapshot.length > 0)
+        ? target.tabSnapshot
+        : [{ url: 'chrome://newtab/', title: '', pinned: false }];
+
+    const oldTabs = await chrome.tabs.query({ windowId }).catch(() => []);
+    const oldTabIds = oldTabs.map(t => t.id);
+
+    // Sequential create keeps the restored tab order stable. ~30ms/tab × 30 tabs
+    // ≈ 1s worst case, acceptable for an explicit user action behind a confirm.
+    for (let i = 0; i < snapshotTabs.length; i++) {
+        const s = snapshotTabs[i];
+        try {
+            await chrome.tabs.create({
+                windowId,
+                url: s.url,
+                active: i === 0,
+                pinned: s.pinned || false,
+            });
+        } catch (err) {
+            console.warn('[workspace] failed to restore tab', s.url, err);
+        }
+    }
+
+    if (oldTabIds.length > 0) {
+        try {
+            await chrome.tabs.remove(oldTabIds);
+        } catch (err) {
+            console.warn('[workspace] failed to close old tabs', err);
+        }
+    }
+
+    await setActiveWorkspace(windowId, targetId);
+    return true;
+}
+
+function persistWorkspaces() {
+    return setStorage('local', { [WORKSPACES_KEY]: workspaces });
+}
+
+function persistWindowMap() {
+    return setStorage('local', { [WINDOW_WORKSPACE_MAP_KEY]: windowWorkspaceMap });
+}

--- a/modules/workspace/workspaceUI.js
+++ b/modules/workspace/workspaceUI.js
@@ -1,0 +1,243 @@
+/**
+ * Workspace Switcher UI
+ *
+ * Top-of-sidepanel select for active workspace + a manage button that opens
+ * a list dialog (rename / delete + "create from current tabs"). v1 deliberately
+ * skips inline color/icon editing — that's two more dialog layers for low value;
+ * users can delete and recreate if they want a different look.
+ */
+import * as wsManager from './workspaceManager.js';
+import * as modal from '../modalManager.js';
+import * as api from '../apiManager.js';
+
+let currentWindowId = null;
+
+export async function initWorkspaceUI() {
+    try {
+        const win = await chrome.windows.getCurrent();
+        currentWindowId = win.id;
+    } catch {
+        currentWindowId = chrome.windows.WINDOW_ID_CURRENT;
+    }
+
+    const switcher = document.getElementById('workspace-switcher');
+    const manageBtn = document.getElementById('workspace-manage-btn');
+    if (!switcher) return;
+
+    switcher.setAttribute('aria-label', api.getMessage('workspaceSwitcherAriaLabel') || 'Active workspace');
+    if (manageBtn) {
+        const manageLabel = api.getMessage('workspaceManageTitle') || 'Manage workspaces';
+        manageBtn.title = manageLabel;
+        manageBtn.setAttribute('aria-label', manageLabel);
+    }
+
+    renderSwitcher();
+
+    switcher.addEventListener('change', handleSwitch);
+    manageBtn?.addEventListener('click', openManageDialog);
+
+    // Re-render switcher when another sidepanel mutates the workspace list
+    // (Phase 2 cross-sidepanel sync uses chrome.storage.onChanged).
+    chrome.storage.onChanged.addListener((changes, area) => {
+        if (area !== 'local') return;
+        if (changes.workspaces || changes.windowWorkspaceMap) {
+            // Re-init the in-memory cache before re-render, otherwise we'd
+            // render against stale data.
+            wsManager.initWorkspaces().then(renderSwitcher);
+        }
+    });
+}
+
+function renderSwitcher() {
+    const switcher = document.getElementById('workspace-switcher');
+    if (!switcher) return;
+    const activeId = wsManager.getActiveWorkspaceId(currentWindowId);
+    const all = wsManager.getAllWorkspaces();
+
+    switcher.innerHTML = '';
+
+    const blank = document.createElement('option');
+    blank.value = '';
+    blank.textContent = api.getMessage('workspaceNoActive') || '— no workspace —';
+    if (!activeId) blank.selected = true;
+    switcher.appendChild(blank);
+
+    for (const ws of all) {
+        const opt = document.createElement('option');
+        opt.value = ws.id;
+        opt.textContent = `${ws.icon} ${ws.name}`;
+        if (ws.id === activeId) opt.selected = true;
+        switcher.appendChild(opt);
+    }
+}
+
+async function handleSwitch(e) {
+    const targetId = e.target.value;
+    if (!targetId) {
+        renderSwitcher();
+        return;
+    }
+    const target = wsManager.getWorkspace(targetId);
+    if (!target) {
+        renderSwitcher();
+        return;
+    }
+    const currentTabs = await chrome.tabs.query({ windowId: currentWindowId });
+
+    const ok = await modal.showConfirm({
+        title: api.getMessage('workspaceSwitchConfirmTitle') || 'Switch workspace',
+        message: (api.getMessage('workspaceSwitchConfirmMessage')
+            || 'Switching to "{ws}" will close {n} tab(s) in this window and open the saved tabs.')
+            .replace('{ws}', target.name)
+            .replace('{n}', String(currentTabs.length)),
+        confirmButtonText: api.getMessage('workspaceSwitchConfirmBtn') || 'Switch',
+    });
+    if (!ok) {
+        renderSwitcher();
+        return;
+    }
+    try {
+        await wsManager.switchWorkspace(targetId, currentWindowId);
+        // tabs are about to be replaced; renderSwitcher will run from the
+        // storage.onChanged subscriber once setActiveWorkspace persists.
+    } catch (err) {
+        console.error('[workspace] switch failed:', err);
+        renderSwitcher();
+    }
+}
+
+/**
+ * Manage dialog: lists all workspaces with rename + delete, plus a button
+ * to create a new one from the current window's tabs.
+ */
+function openManageDialog() {
+    const all = wsManager.getAllWorkspaces();
+    const activeId = wsManager.getActiveWorkspaceId(currentWindowId);
+
+    const container = document.createElement('div');
+    container.className = 'workspace-manage';
+
+    const list = document.createElement('div');
+    list.className = 'workspace-manage__list';
+    if (all.length === 0) {
+        const empty = document.createElement('div');
+        empty.className = 'workspace-manage__empty';
+        empty.textContent = api.getMessage('workspaceManageEmpty') || 'No workspaces yet.';
+        list.appendChild(empty);
+    } else {
+        for (const ws of all) {
+            list.appendChild(buildManageRow(ws, ws.id === activeId, list));
+        }
+    }
+    container.appendChild(list);
+
+    const createBtn = document.createElement('button');
+    createBtn.className = 'workspace-manage__create';
+    createBtn.textContent = api.getMessage('workspaceCreateFromCurrent') || '+ New from current tabs';
+    createBtn.addEventListener('click', async () => {
+        const ws = await handleCreateFromCurrent();
+        if (ws) {
+            // Replace the "empty" placeholder if present, then append new row.
+            const empty = list.querySelector('.workspace-manage__empty');
+            if (empty) empty.remove();
+            list.appendChild(buildManageRow(ws, true, list));
+            renderSwitcher();
+        }
+    });
+    container.appendChild(createBtn);
+
+    modal.showCustomDialog({
+        title: api.getMessage('workspaceManageTitle') || 'Manage workspaces',
+        content: container,
+    });
+}
+
+function buildManageRow(ws, isActive, listEl) {
+    const row = document.createElement('div');
+    row.className = 'workspace-manage__row';
+
+    const label = document.createElement('span');
+    label.className = 'workspace-manage__label';
+    const updateLabel = () => {
+        const tabCount = ws.tabSnapshot ? ws.tabSnapshot.length : 0;
+        label.textContent = `${ws.icon} ${ws.name} — ${tabCount} tab(s)`;
+    };
+    updateLabel();
+    if (isActive) label.classList.add('active');
+    row.appendChild(label);
+
+    const renameBtn = document.createElement('button');
+    renameBtn.className = 'workspace-manage__btn';
+    renameBtn.title = api.getMessage('workspaceRename') || 'Rename';
+    renameBtn.textContent = '✏️';
+    renameBtn.addEventListener('click', async () => {
+        const newName = await modal.showPrompt({
+            title: api.getMessage('workspaceRename') || 'Rename workspace',
+            defaultValue: ws.name,
+        });
+        if (newName && newName.trim()) {
+            await wsManager.updateWorkspace(ws.id, { name: newName.trim() });
+            // Mutate the in-place snapshot used by closures and refresh just this row.
+            ws.name = newName.trim();
+            updateLabel();
+            renderSwitcher();
+        }
+    });
+    row.appendChild(renameBtn);
+
+    const deleteBtn = document.createElement('button');
+    deleteBtn.className = 'workspace-manage__btn';
+    deleteBtn.title = api.getMessage('workspaceDelete') || 'Delete';
+    deleteBtn.textContent = '🗑️';
+    deleteBtn.addEventListener('click', async () => {
+        const ok = await modal.showConfirm({
+            title: api.getMessage('workspaceDeleteConfirmTitle') || 'Delete workspace',
+            message: (api.getMessage('workspaceDeleteConfirmMessage') || 'Delete "{ws}"? This cannot be undone.')
+                .replace('{ws}', ws.name),
+            confirmButtonText: api.getMessage('workspaceDelete') || 'Delete',
+            confirmButtonClass: 'danger',
+        });
+        if (ok) {
+            await wsManager.deleteWorkspace(ws.id);
+            row.remove();
+            // If we just removed the last row, show the empty hint again.
+            if (listEl && listEl.querySelectorAll('.workspace-manage__row').length === 0) {
+                const empty = document.createElement('div');
+                empty.className = 'workspace-manage__empty';
+                empty.textContent = api.getMessage('workspaceManageEmpty') || 'No workspaces yet.';
+                listEl.appendChild(empty);
+            }
+            renderSwitcher();
+        }
+    });
+    row.appendChild(deleteBtn);
+
+    return row;
+}
+
+async function handleCreateFromCurrent() {
+    const name = await modal.showPrompt({
+        title: api.getMessage('workspaceCreatePromptTitle') || 'Name this workspace',
+        defaultValue: '',
+    });
+    if (!name || !name.trim()) return null;
+    const ws = await wsManager.createWorkspace({
+        name: name.trim(),
+        snapshotWindowId: currentWindowId,
+    });
+    await wsManager.setActiveWorkspace(currentWindowId, ws.id);
+    return ws;
+}
+
+/** Exposed so the Command Palette can trigger creation without going through the manage dialog. */
+export async function createWorkspaceFromCurrent() {
+    return handleCreateFromCurrent();
+}
+
+/** Exposed so the Command Palette can prompt switch to a workspace by id. */
+export async function requestSwitchTo(workspaceId) {
+    const switcher = document.getElementById('workspace-switcher');
+    if (!switcher) return;
+    switcher.value = workspaceId;
+    handleSwitch({ target: switcher });
+}

--- a/modules/workspace/workspaceUI.js
+++ b/modules/workspace/workspaceUI.js
@@ -42,8 +42,73 @@ export async function initWorkspaceUI() {
         if (area !== 'local') return;
         if (changes.workspaces || changes.windowWorkspaceMap) {
             // Re-init the in-memory cache before re-render, otherwise we'd
-            // render against stale data.
-            wsManager.initWorkspaces().then(renderSwitcher);
+            // render against stale data. .catch so a transient storage error
+            // doesn't surface as an unhandled rejection.
+            wsManager.initWorkspaces()
+                .then(renderSwitcher)
+                .catch(err => console.warn('[workspace] sync reload failed:', err));
+        }
+    });
+
+    installAutoSnapshot();
+    installWindowCleanup();
+
+    // Prune entries for windows that no longer exist (id reuse across sessions
+    // would otherwise let a new window inherit a stale workspace binding).
+    wsManager.pruneWindowWorkspaceMap().catch(err =>
+        console.warn('[workspace] prune failed:', err));
+}
+
+/**
+ * Continuously snapshot the active workspace as the user opens/closes/navigates
+ * tabs in the current window. Without this, the workspace snapshot would only
+ * be updated at switch time — closing the window directly (or browser quit)
+ * would lose all changes since the last switch.
+ *
+ * 1.5s debounce: aggressive enough that a quick window-close still catches
+ * recent changes, gentle enough to avoid hammering chrome.storage on rapid
+ * navigation. There's still a race against the last ~1.5s before window close,
+ * but Chrome offers no "window about to close" hook, so this is the best we
+ * can do without persisting on every event.
+ */
+function installAutoSnapshot() {
+    let snapshotTimer = null;
+    const trigger = () => {
+        clearTimeout(snapshotTimer);
+        snapshotTimer = setTimeout(async () => {
+            const activeId = wsManager.getActiveWorkspaceId(currentWindowId);
+            if (!activeId) return;
+            try {
+                await wsManager.snapshotIntoWorkspace(activeId, currentWindowId);
+            } catch (err) {
+                console.warn('[workspace] auto-snapshot failed:', err);
+            }
+        }, 1500);
+    };
+    chrome.tabs.onCreated.addListener(tab => {
+        if (tab.windowId === currentWindowId) trigger();
+    });
+    chrome.tabs.onRemoved.addListener((_id, info) => {
+        if (info.windowId === currentWindowId) trigger();
+    });
+    chrome.tabs.onUpdated.addListener((_id, changeInfo, tab) => {
+        // Only URL changes matter for snapshot fidelity; title flicker and
+        // favicon updates would otherwise debounce-spam storage.
+        if (changeInfo.url && tab.windowId === currentWindowId) trigger();
+    });
+    chrome.tabs.onMoved.addListener((_id, info) => {
+        if (info.windowId === currentWindowId) trigger();
+    });
+}
+
+function installWindowCleanup() {
+    chrome.windows.onRemoved.addListener(async (closedWindowId) => {
+        // Clear that window's binding so the id (Chrome reuses them) can't
+        // resurrect a stale active workspace on a future, unrelated window.
+        try {
+            await wsManager.setActiveWorkspace(closedWindowId, null);
+        } catch (err) {
+            console.warn('[workspace] cleanup on window close failed:', err);
         }
     });
 }
@@ -83,11 +148,21 @@ async function handleSwitch(e) {
         return;
     }
     const currentTabs = await chrome.tabs.query({ windowId: currentWindowId });
+    const isUnbound = !wsManager.getActiveWorkspaceId(currentWindowId);
+
+    // Unbound windows would silently lose their tabs without an explicit hint.
+    // We auto-save them as "Untitled <ts>" in workspaceManager, but the user
+    // deserves to know that's happening before they confirm.
+    const messageKey = isUnbound && currentTabs.length > 0
+        ? 'workspaceSwitchConfirmMessageUnbound'
+        : 'workspaceSwitchConfirmMessage';
+    const fallback = isUnbound && currentTabs.length > 0
+        ? 'Switching to "{ws}" — your current {n} tab(s) aren\'t in any workspace yet. They will be auto-saved to a new "Untitled" workspace before the switch.'
+        : 'Switching to "{ws}" will close {n} tab(s) in this window and open the saved tabs.';
 
     const ok = await modal.showConfirm({
         title: api.getMessage('workspaceSwitchConfirmTitle') || 'Switch workspace',
-        message: (api.getMessage('workspaceSwitchConfirmMessage')
-            || 'Switching to "{ws}" will close {n} tab(s) in this window and open the saved tabs.')
+        message: (api.getMessage(messageKey) || fallback)
             .replace('{ws}', target.name)
             .replace('{n}', String(currentTabs.length)),
         confirmButtonText: api.getMessage('workspaceSwitchConfirmBtn') || 'Switch',
@@ -102,6 +177,13 @@ async function handleSwitch(e) {
         // storage.onChanged subscriber once setActiveWorkspace persists.
     } catch (err) {
         console.error('[workspace] switch failed:', err);
+        // Show the failure to the user so they know the window wasn't changed.
+        await modal.showConfirm({
+            title: api.getMessage('workspaceSwitchFailedTitle') || 'Switch failed',
+            message: api.getMessage('workspaceSwitchFailedMessage')
+                || 'Could not switch workspace. Your current tabs were not changed.',
+            confirmButtonText: api.getMessage('closeButton') || 'OK',
+        });
         renderSwitcher();
     }
 }

--- a/sidepanel.css
+++ b/sidepanel.css
@@ -3085,3 +3085,100 @@ mark.url-match {
 .cmd-palette-hint-key + span {
     margin-right: 8px;
 }
+
+/* === Workspace Switcher (top of sidepanel) === */
+.workspace-row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 8px;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.workspace-switcher {
+    flex: 1;
+    min-width: 0;
+    padding: 4px 6px;
+    font-size: 0.85em;
+    background: var(--element-bg-color);
+    color: var(--text-color-primary);
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+.workspace-switcher:focus {
+    outline: 1px solid var(--accent-color);
+}
+
+.workspace-manage {
+    min-width: 280px;
+}
+
+.workspace-manage__list {
+    margin-bottom: 12px;
+    max-height: 320px;
+    overflow-y: auto;
+}
+
+.workspace-manage__empty {
+    padding: 14px;
+    text-align: center;
+    color: var(--text-color-primary);
+    opacity: 0.55;
+    font-size: 0.9em;
+}
+
+.workspace-manage__row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 4px;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.workspace-manage__label {
+    flex: 1;
+    min-width: 0;
+    font-size: 0.9em;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    color: var(--text-color-primary);
+}
+
+.workspace-manage__label.active {
+    font-weight: 600;
+    color: var(--accent-color);
+}
+
+.workspace-manage__btn {
+    flex-shrink: 0;
+    width: 28px;
+    height: 28px;
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    background: var(--element-bg-color);
+    cursor: pointer;
+    font-size: 14px;
+}
+
+.workspace-manage__btn:hover {
+    background: var(--element-bg-hover-color);
+}
+
+.workspace-manage__create {
+    width: 100%;
+    padding: 8px;
+    border: 1px dashed var(--border-color);
+    border-radius: 4px;
+    background: transparent;
+    color: var(--text-color-primary);
+    font-size: 0.9em;
+    cursor: pointer;
+}
+
+.workspace-manage__create:hover {
+    background: var(--element-bg-hover-color);
+    border-style: solid;
+}

--- a/sidepanel.html
+++ b/sidepanel.html
@@ -8,6 +8,13 @@
 </head>
 
 <body>
+    <!-- Workspace switcher: per-window active workspace + manage button.
+         Labels are resolved at runtime by workspaceUI.initWorkspaceUI(). -->
+    <div id="workspace-row" class="workspace-row">
+        <select id="workspace-switcher" class="workspace-switcher"></select>
+        <button id="workspace-manage-btn" class="header-action-btn">⚙️</button>
+    </div>
+
     <div id="search-container">
         <div class="search-top-row">
             <div class="search-input-wrapper">

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -10,6 +10,8 @@ import * as readingListRenderer from './modules/ui/readingListRenderer.js';
 import * as rssManager from './modules/rssManager.js';
 import * as hoverSummarize from './modules/ui/hoverSummarizeManager.js';
 import { initCommandPalette } from './modules/commandPalette/index.js';
+import * as workspaceManager from './modules/workspace/workspaceManager.js';
+import { initWorkspaceUI } from './modules/workspace/workspaceUI.js';
 import { SEARCH_NO_RESULTS_ICON_SVG } from './modules/icons.js';
 import { debounce } from './modules/utils/functionUtils.js';
 
@@ -166,6 +168,8 @@ async function initialize() {
     rssManager.initRssManager().catch(console.error);
     keyboard.initialize();
     hoverSummarize.init(); // Initialize Hover Summarize feature
+    await workspaceManager.initWorkspaces(); // Load workspace cache before UI uses it
+    await initWorkspaceUI(); // Workspace switcher dropdown + manage dialog
     initCommandPalette(); // Cmd+K / Ctrl+K unified search & actions overlay
 
     // Keep multiple open sidepanels in sync: linkedTabs affects bookmark icons,


### PR DESCRIPTION
## 摘要 (Summary)

對應 plan「專案優化與差異化策略計畫」B2.3。把既有 `windowNames`（per-window 字串標籤）升級為含 tab snapshot 的 **Workspace** 概念：可 hibernate（save 當前 tabs 到 workspace）+ restore（切換到另一 workspace 並開出該 workspace 的 tabs）。對抗 Chrome 原生「沒有 workspace 概念」的核心差異化。

### 相關 Issue (Related Issues)

無。基於 plan B2.3。

---

## 📝 變更內容 (Changes)

### 新增 (Added)
- **`modules/workspace/workspaceManager.js`**（~210 行）— Schema、Storage、CRUD、`switchWorkspace` 核心 hibernate→restore 邏輯
- **`modules/workspace/workspaceUI.js`**（~200 行）— 頂部 switcher、manage dialog、與 modalManager / cross-sidepanel sync 整合
- **`sidepanel.html`**：頂部 workspace row（select + manage btn）
- **`sidepanel.css`**：~95 行 `.workspace-*` 樣式
- **`_locales/{en,zh_TW,zh_CN}/messages.json`**：16 個新字串各 3 語
- **`.agent/notes/NOTE_20260527_phase6.md`**：session 摘要

### 修改 (Changed)
- **`sidepanel.js`**：initialize 結尾加 `workspaceManager.initWorkspaces()` + `initWorkspaceUI()`
- **`modules/commandPalette/dataProvider.js`**：加第 5 group `workspaces`，每 workspace 變一 row 觸發 switch（confirm dialog）
- **`modules/commandPalette/actions.js`**：加 2 個 workspace action（Create / Manage）

### 重要決策說明
- **Switch 語意 = close-and-restore，不是 chrome.tabs.discard**：discard 保留 history 但 tab 仍在 strip 上，不符合「切換 workspace」視覺；採 close + 重開。失去 scroll position 與 form state 是 trade-off，配 confirm dialog 讓 user 決定。
- **Storage in `local` 不在 `sync`**：tabSnapshot 可達數十筆遠超 sync 8KB/key 預算。**Phase 9 會加 opt-in sync metadata-only 變體**（只 sync workspace metadata 不 sync snapshot）。
- **「先 open 後 close」順序**：避免關掉最後一個 tab 導致 window 自動關閉。空 snapshot 也至少 open 一個 newtab。
- **不 snapshot tab group 結構（v1）**：重建 group 需穩定的 chrome.tabGroups restore 邏輯，留 v2。Tabs 仍 restore 但無 group 結構。
- **rename/delete 採 inline 更新**：避免 close manage dialog + reopen 的 modal stack 視覺問題。
- **workspace row 在 sidepanel 最頂**：是「全域工作上下文」概念，應在 search box（工作內篩選）之上。
- **switch 用 `<select>`**：高頻動作（每天可能多次），一個 click + 選即切；rename/delete/create 等低頻動作藏 manage dialog 內。
- **v1 不做 theme 綁定 / reading list filter**：增加複雜度但邊際價值低，留 v2。
- **Lazy-import workspaceUI in commandPalette**：避免 commandPalette ↔ workspace 循環依賴。

---

## 🧪 測試 (Testing)

### 自動化測試
- [x] `npm run test:unit` → 3 suites / 57 tests 通過
- [x] Puppeteer happy paths：`happy_path_sidepanel_load` + `happy_path_search` + `happy_path_settings_panel` 14/14 通過
- [x] `esbuild --bundle` 編譯通過（sidepanel.js + background.js 兩 entry）
- [x] 3 個 `messages.json` JSON 合法

### 手動驗證
1. `make` → `chrome://extensions` 載入未封裝
2. **建立 workspace**：點頂部 ⚙️ → 「+ New from current tabs」→ 輸入名稱 → 應建出 workspace（tab count = 當前 window 中非 chrome:// 的 tabs 數）
3. **切換 workspace**：開幾個新 tabs → switcher 選另一個 workspace → 應顯示 confirm「將關閉 N 個分頁」→ 確認後當前 tabs 被關、目標 workspace 的 tabs 開出
4. **離開時 hibernate**：切回原本 workspace → 應看到剛剛開的新 tabs 被自動儲存（snapshot 更新到當前狀態）
5. **rename / delete**：⚙️ → 在 list 內點 ✏️ rename 或 🗑️ delete → 應 inline 更新 / 移除 row
6. **Command Palette 整合**：Cmd+K → 應看到「Workspaces」group 列出所有 workspace + 「Create workspace from current tabs」+「Manage workspaces」2 個 action
7. **多 sidepanel 同步**：開 window A + window B 兩個 sidepanel → A 內建 / rename / delete workspace → B 的 switcher 應即時更新
8. **多語**：切到 zh_TW / zh_CN 確認新字串顯示；切到其他 11 語應 fallback 到 en

---

## ✅ 檢查清單 (Checklist)

- [x] 程式碼遵循專案 coding style（ES modules、vanilla JS、aria-label、design system 變數）
- [x] 自動化測試已通過
- [x] `.agent/notes/NOTE_20260527_phase6.md` 已寫
- [x] PR 描述包含英文版本
- [ ] **待辦**：11 個其他語系翻譯 → Phase 11
- [ ] **待辦**：v2 — tab group 結構 snapshot / restore
- [ ] **待辦**：v2 — theme 綁定（切 workspace 自動套對應 theme）
- [ ] **待辦**：v2 — reading list filter 綁定
- [ ] **待辦**：Phase 9 — workspace metadata sync（sync area，不含 snapshot）
- [ ] **待辦**：Puppeteer test for workspace switch flow

---

## 🌐 English Version

### Summary

Implements plan B2.3: upgrades the existing per-window `windowNames` (single-string labels) into full **Workspaces** — hibernate the current window's tabs into one workspace, restore another workspace's saved tabs as the new active set. This is a core differentiator vs. Chrome's native "no workspace concept".

### Changes

#### Added
- **`modules/workspace/workspaceManager.js`** (~210 lines): schema, storage, CRUD, and `switchWorkspace(targetId, windowId)` doing hibernate→restore atomically.
- **`modules/workspace/workspaceUI.js`** (~200 lines): top-of-sidepanel select + ⚙️ manage dialog; cross-sidepanel sync via `storage.onChanged`.
- **`sidepanel.html` / `sidepanel.css`**: workspace row at the very top + ~95 lines of `.workspace-*` styling.
- 16 new i18n strings each in `en`, `zh_TW`, `zh_CN`.

#### Changed
- **`sidepanel.js`**: initializes workspace cache + UI in `initialize`.
- **`modules/commandPalette/dataProvider.js`**: adds a `workspaces` group so Cmd+K can switch via the palette (still routed through the confirm dialog).
- **`modules/commandPalette/actions.js`**: two new actions — Create workspace from current tabs / Manage workspaces.

#### Key decisions
- **Switch = close-and-restore, not `chrome.tabs.discard`**: discard keeps history but tabs stay in the strip — visually doesn't feel like a "switch". We close + reopen; trade-off (lose scroll/form state) is gated by a confirm dialog.
- **Storage in `local`, not `sync`**: a snapshot can hold dozens of tabs, far over sync's 8KB-per-key budget. **Phase 9 will add an opt-in sync metadata-only variant** (sync workspace info without the tab list).
- **Open new tabs BEFORE closing old**: removing the last tab in a window auto-closes the window; empty snapshot opens one `newtab` for the same reason.
- **No tab group structure snapshot in v1**: stable group restore needs more work; v2.
- **Inline row update for rename/delete**: avoids close-and-reopen modal stacking.
- **Workspace row at the very top**: a workspace is the global "work context", which sits above search (work-internal filter).
- **`<select>` for switching** (high-frequency action), manage dialog for rename/delete/create (low-frequency).
- **Lazy-import** `workspaceUI` from commandPalette to avoid a circular import.

### Testing

- `npm run test:unit` → 57/57 passing
- Puppeteer regression: `sidepanel_load` + `search` + `settings_panel` 14/14 passing
- `esbuild --bundle` succeeds for both `sidepanel.js` and `background.js` entries
- 3 `messages.json` files validate

Manual verification: see the Chinese section for the step-by-step.

### Related Issues
None. Based on plan B2.3.
