### PR TITLE
feat(ai): reading list summary memory + Ask-AI natural-language search

### DIFF
--- a/.agent/notes/NOTE_20260527_phase8.md
+++ b/.agent/notes/NOTE_20260527_phase8.md
@@ -1,0 +1,58 @@
+# 開發摘要 - 2026-05-27 (Phase 8: Reading List Summary Memory + NL Search)
+
+> 對應 plan B2.5（reading list 自動摘要記憶）+ B2.6（自然語言搜尋）。兩個子功能性質很不同——8a 是 reading list 既有體驗的被動延伸，8b 是 command palette 的主動 AI 入口。整合在同一 PR 因為都是 AI-driven + 規模可控。
+
+## 變更項目
+
+### 8a — Reading List Summary Memory
+
+- **`modules/utils/pageContentExtractor.js`** (~40 行)：抽出既有 hoverSummarizeManager 的 `extractPageContent`，讓兩個 summarize 入口共用一份 scrape 邏輯。
+- **`modules/readingList/summaryStore.js`** (~70 行)：chrome.storage.local 持久層；CRUD + `pruneOrphans`。
+- **`modules/readingList/summaryRecorder.js`** (~70 行)：監聽 `chrome.readingList.onEntryAdded`，若 entry.url 匹配 live tab → scrape + summarize + 存 store。Dedupe by store check 避免多 sidepanel race。
+- **`modules/aiManager.js`** 加 `summarizeText(text, domain)`：non-streaming 一次回完整 summary，**嚴格 `=== 'available'`** 防止 background event 觸發 silent 下載。
+- **`modules/ui/readingListRenderer.js`**：item 的 `title` attr 加 summary 作為 hover tooltip（v1 unobtrusive UI）+ `.has-summary` class。
+- **`stateManager.js`**：`readingListSummaryEnabled` (chrome.storage.sync, 預設 enabled) + setting toggle。
+- **`sidepanel.js`**：`initSummaries` + `initSummaryRecorder` + 監聽 `readingListSummaryAdded` 事件刷新 reading list。
+
+### 8b — Natural Language Search via Command Palette
+
+- **`modules/commandPalette/nlSearch.js`** (~180 行)：
+  - AI 是 **reranker** 不是 filter。給 model 30 個 candidates (tabs + bookmarks + reading list) + user query，要求挑 8 個 + 短 reason
+  - 獨立 prompt → results dialog flow，**不入侵 palette 主流的 indexOf incremental search**（兩種互動模型混在一起會難用：snappy keystroke vs slow LLM）
+  - `aiManager.runPrompt(promptText)` 新 helper 提供一次性 LanguageModel 呼叫
+- **`modules/commandPalette/actions.js`**：加「🤖 Ask AI to find tabs or bookmarks」action
+
+### i18n
+
+10 個新字串 × 3 語（en / zh_TW / zh_CN）。其他 11 語留 Phase 11。
+
+## 技術決策
+
+- **Reading list summary 觸發條件 = 加入時匹配 live tab**：lazy / on-demand 設計（先 storage 後 UI hook）會需要 chrome.tabs.create 重 open + scrape + close，對 paywalled / auth-gated 頁面常失敗，且打斷使用者；v1 保守只在已有 active tab 時 summarize，其他情境靜默 skip。
+- **8a summary 顯示用 title attr**：bookmarkRenderer / readingListRenderer 既有 row layout 已密集，加 visible subtitle 是 layout 重做。v1 用 hover tooltip 是 minimum viable + 0 layout risk。v2 可加 visible preview。
+- **8b 用獨立 modal 而非 palette mode toggle**：palette 主流是 indexOf incremental search（debounce 100ms），AI rerank 是 explicit + 慢（1-3s）。兩種互動模型 cleanly 分開，user mental model 明確（不會以為 typing 會自動 AI）。v2 可整合（如 `>` prefix 進 mode）。
+- **8b AI 是 reranker 不是 filter**：local Gemini Nano token 限制 ~1500，全部書籤 + tabs 可能超千個，硬塞 candidates 會超 budget。先 cap 30 個，AI 從中挑出最相關 — 對「找上週看的 X」這種 query，AI 從 candidate metadata 推理仍有效。
+- **8a / 8b 都 `=== 'available'` 嚴格**：summary memory 是 background event 觸發，絕不 silent download；NL search 雖 user-initiated 但同樣不 silent download，提示 user 去 Smart Group 觸發。
+
+## 驗證
+
+- esbuild bundle: sidepanel + background 兩 entry 通過
+- JSON: 3 個 messages.json 合法
+- Unit tests: 57/57 通過
+- Puppeteer happy_path: sidepanel_load + search + settings_panel（結果見 PR）
+- **手動驗證待做**（需 Chrome + Gemini Nano + Summarizer all `available`）：
+  - 8a：開個 tab → 加入 Reading List → 等幾秒 → 再次 hover reading list 該 item 應顯示 summary
+  - 8a 設定 toggle：關閉後新 entries 不再 summarize
+  - 8a 離線：summary 已存的應仍可看
+  - 8b：Cmd+K → 「Ask AI to find...」→ 輸入「上週看的 React」之類 → 等 AI → 結果 modal 顯示
+  - 8b AI 未下載：應提示「請先觸發 Smart Group 下載」
+  - 8b 無 match：應提示「AI found no good matches」
+
+## 待辦
+
+- 11 個其他語系翻譯 → Phase 11
+- v2：8a summary 顯示為 inline subtitle（需 readingListRenderer 改 row layout）
+- v2：8a 手動 summarize button（per-entry「✨」按鈕）
+- v2：8b 整合進 palette 主流（如 `>` prefix mode）
+- v2：8b 失敗時加重試 + 「給更多 candidates」
+- Puppeteer test for both flows

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -904,5 +904,29 @@
   },
   "bmToolsKeepFirstNote": {
     "message": "Note: in groups where every copy is checked, the first one is automatically kept."
+  },
+  "rlSummaryToggleLabel": {
+    "message": "Remember AI summary for Reading List items"
+  },
+  "rlSummaryDescription": {
+    "message": "When you add a page that's open in a tab to your Reading List, AI summarizes it once and stores the result locally so you can preview it later — even offline. Requires the Summarizer model to be already available."
+  },
+  "cmdPaletteActionAskAi": {
+    "message": "Ask AI to find tabs or bookmarks"
+  },
+  "cmdPaletteAskAiTitle": {
+    "message": "Ask AI: find tabs or bookmarks"
+  },
+  "cmdPaletteAskAiThinking": {
+    "message": "Asking AI…"
+  },
+  "cmdPaletteAskAiResultsTitle": {
+    "message": "AI suggestions"
+  },
+  "cmdPaletteAskAiUnavailable": {
+    "message": "AI model is not downloaded yet. Trigger ✨ Smart Group first to download, then try again."
+  },
+  "cmdPaletteAskAiNoMatch": {
+    "message": "AI found no good matches."
   }
 }

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -901,5 +901,29 @@
   },
   "bmToolsKeepFirstNote": {
     "message": "提示：当某组重复内所有副本都被勾选时，会自动保留第一份。"
+  },
+  "rlSummaryToggleLabel": {
+    "message": "为阅读清单项目记住 AI 摘要"
+  },
+  "rlSummaryDescription": {
+    "message": "当你将一个目前已打开标签页的页面加入阅读清单时，AI 会摘要一次并把结果存在本地，之后即可离线预览。需要 Summarizer 模型已下载完成。"
+  },
+  "cmdPaletteActionAskAi": {
+    "message": "问 AI 帮我找标签页或书签"
+  },
+  "cmdPaletteAskAiTitle": {
+    "message": "问 AI：找出标签页或书签"
+  },
+  "cmdPaletteAskAiThinking": {
+    "message": "AI 思考中…"
+  },
+  "cmdPaletteAskAiResultsTitle": {
+    "message": "AI 建议"
+  },
+  "cmdPaletteAskAiUnavailable": {
+    "message": "AI 模型尚未下载。请先点 ✨ 智能整理 触发下载后再试。"
+  },
+  "cmdPaletteAskAiNoMatch": {
+    "message": "AI 找不到合适的结果。"
   }
 }

--- a/_locales/zh_TW/messages.json
+++ b/_locales/zh_TW/messages.json
@@ -901,5 +901,29 @@
   },
   "bmToolsKeepFirstNote": {
     "message": "提示：當某組重複內所有複本都被勾選時，會自動保留第一份。"
+  },
+  "rlSummaryToggleLabel": {
+    "message": "為閱讀清單項目記住 AI 摘要"
+  },
+  "rlSummaryDescription": {
+    "message": "當你將一個目前已開啟分頁的頁面加入閱讀清單時，AI 會摘要一次並把結果存在本地，之後即可離線預覽。需要 Summarizer 模型已下載完成。"
+  },
+  "cmdPaletteActionAskAi": {
+    "message": "問 AI 幫我找分頁或書籤"
+  },
+  "cmdPaletteAskAiTitle": {
+    "message": "問 AI：找出分頁或書籤"
+  },
+  "cmdPaletteAskAiThinking": {
+    "message": "AI 思考中…"
+  },
+  "cmdPaletteAskAiResultsTitle": {
+    "message": "AI 建議"
+  },
+  "cmdPaletteAskAiUnavailable": {
+    "message": "AI 模型尚未下載。請先點 ✨ 智慧整理 觸發下載後再試。"
+  },
+  "cmdPaletteAskAiNoMatch": {
+    "message": "AI 找不到合適的結果。"
   }
 }

--- a/modules/aiManager.js
+++ b/modules/aiManager.js
@@ -114,6 +114,42 @@ export function destroySummarizerSession() {
     }
 }
 
+/**
+ * One-shot summarize. Non-streaming variant for callers that just want the
+ * final text (reading list summary memory). Stricter than checkSummarizerReadiness:
+ * `'available'` only, so we don't silently kick off a model download from a
+ * background event (chrome.readingList.onEntryAdded).
+ *
+ * @param {string} text
+ * @param {string} [domain] - Adds host context to the model prompt.
+ * @returns {Promise<string|null>}
+ */
+export async function summarizeText(text, domain = '') {
+    if (!text || typeof text !== 'string') return null;
+    if (!('Summarizer' in self)) return null;
+    try {
+        const langOpts = _buildSummarizerLangOptions();
+        const availability = await Summarizer.availability(langOpts);
+        if (availability !== 'available') return null;
+    } catch {
+        return null;
+    }
+    const session = await getOrCreateSummarizerSession();
+    if (!session) return null;
+    try {
+        const result = await session.summarize(text, {
+            context: domain
+                ? `Web page from ${domain}. Provide a concise one-sentence summary.`
+                : 'Provide a concise one-sentence summary.',
+        });
+        const out = (result || '').trim();
+        return out || null;
+    } catch (err) {
+        console.warn('[ai] summarizeText failed:', err);
+        return null;
+    }
+}
+
 // === LanguageModel API (Tab Grouping) ===
 
 /** @type {LanguageModel|null} Lazily created and cached session */
@@ -201,6 +237,30 @@ export function destroyLanguageModelSession() {
  */
 export async function triggerLanguageModelDownload(callbacks = {}) {
     await getOrCreateLanguageModelSession(callbacks);
+}
+
+/**
+ * One-shot prompt against the shared LanguageModel session. Strict on
+ * availability (`=== 'available'` only) so callers triggered from
+ * non-user-initiated contexts can't silently start a multi-GB download.
+ *
+ * Callers should structure their prompt to ask for JSON (the session's
+ * systemPrompt enforces JSON output), then parse on their side.
+ *
+ * @param {string} promptText
+ * @returns {Promise<string|null>}
+ */
+export async function runPrompt(promptText) {
+    if (!promptText) return null;
+    if ((await checkModelAvailability()) !== 'available') return null;
+    try {
+        const session = await getOrCreateLanguageModelSession();
+        return await session.prompt(promptText);
+    } catch (err) {
+        console.warn('[ai] runPrompt failed:', err);
+        destroyLanguageModelSession();
+        return null;
+    }
 }
 
 /**

--- a/modules/aiManager.js
+++ b/modules/aiManager.js
@@ -239,13 +239,45 @@ export async function triggerLanguageModelDownload(callbacks = {}) {
     await getOrCreateLanguageModelSession(callbacks);
 }
 
+/** @type {LanguageModel|null} Dedicated session for runPrompt / NL search */
+let nlLanguageModelSession = null;
+
+async function getOrCreateNlSession() {
+    if (nlLanguageModelSession) return nlLanguageModelSession;
+    if ((await checkModelAvailability()) !== 'available') return null;
+    try {
+        nlLanguageModelSession = await globalThis.LanguageModel.create({
+            // Intentionally neutral — generic JSON-output assistant. The shared
+            // grouping session's systemPrompt mentions "theme names" which is
+            // tab-grouping specific and could bias unrelated rerank tasks.
+            systemPrompt: 'You are a helpful assistant. Output ONLY valid JSON arrays as instructed. Do not use markdown code blocks like ```json or ```.',
+            temperature: 0.1,
+            topK: 1,
+            ...LANGUAGE_MODEL_OPTIONS,
+        });
+        return nlLanguageModelSession;
+    } catch (err) {
+        console.warn('[ai] failed to create NL session:', err);
+        nlLanguageModelSession = null;
+        return null;
+    }
+}
+
+function destroyNlSession() {
+    if (nlLanguageModelSession) {
+        try { nlLanguageModelSession.destroy(); } catch { /* ignore */ }
+        nlLanguageModelSession = null;
+    }
+}
+
 /**
- * One-shot prompt against the shared LanguageModel session. Strict on
- * availability (`=== 'available'` only) so callers triggered from
+ * One-shot prompt for tasks unrelated to tab grouping (NL search, etc.).
+ * Strict on availability (`=== 'available'` only) so callers triggered from
  * non-user-initiated contexts can't silently start a multi-GB download.
  *
- * Callers should structure their prompt to ask for JSON (the session's
- * systemPrompt enforces JSON output), then parse on their side.
+ * Uses a DEDICATED session — separate from the tab-grouping session — so
+ * the grouping-specific systemPrompt doesn't bleed into unrelated tasks
+ * and concurrent `prompt()` calls can't interfere on the same session.
  *
  * @param {string} promptText
  * @returns {Promise<string|null>}
@@ -254,11 +286,12 @@ export async function runPrompt(promptText) {
     if (!promptText) return null;
     if ((await checkModelAvailability()) !== 'available') return null;
     try {
-        const session = await getOrCreateLanguageModelSession();
+        const session = await getOrCreateNlSession();
+        if (!session) return null;
         return await session.prompt(promptText);
     } catch (err) {
         console.warn('[ai] runPrompt failed:', err);
-        destroyLanguageModelSession();
+        destroyNlSession();
         return null;
     }
 }

--- a/modules/commandPalette/actions.js
+++ b/modules/commandPalette/actions.js
@@ -84,5 +84,15 @@ export function buildActions() {
             titleKey: 'cmdPaletteActionBookmarkTools',
             handler: () => document.getElementById('bookmark-tools-btn')?.click(),
         },
+        {
+            id: 'action-ask-ai-search',
+            type: 'action',
+            icon: '🤖',
+            titleKey: 'cmdPaletteActionAskAi',
+            handler: async () => {
+                const { openAskAiDialog } = await import('./nlSearch.js');
+                await openAskAiDialog();
+            },
+        },
     ];
 }

--- a/modules/commandPalette/nlSearch.js
+++ b/modules/commandPalette/nlSearch.js
@@ -21,6 +21,40 @@ import * as readingListManager from '../readingListManager.js';
 const MAX_CANDIDATES = 30;
 const MAX_RESULTS = 8;
 
+/** Sanitize user-controlled strings so they can't break the prompt structure
+ *  (newlines would let a malicious title pretend to be a new instruction).
+ *  Cheap belt-and-suspenders — index validation downstream is the real guard.
+ */
+function sanitizeForPrompt(text) {
+    if (typeof text !== 'string') return '';
+    return text
+        // Newlines/tabs -> space so a malicious title can't fake a prompt break.
+        .replace(/[\r\n\t]/g, ' ')
+        // Strip ASCII control chars (0x00-0x1F and 0x7F) that could hide injection.
+        .replace(/[\x00-\x1F\x7F]/g, '')
+        .slice(0, 120);
+}
+
+/** Reduce candidates to a query-relevant subset before sending to the model.
+ *  Without this, "the first 30 by insertion order" gets sent, and a user with
+ *  many tabs would never see their bookmarks/reading-list make the cut — the
+ *  exact use case Ask-AI is supposed to serve.
+ */
+function preFilterByQuery(candidates, query) {
+    if (!query) return candidates.slice(0, MAX_CANDIDATES);
+    const q = query.toLowerCase();
+    const scored = candidates.map(c => {
+        const hay = ((c.title || '') + ' ' + (c.url || '')).toLowerCase();
+        const idx = hay.indexOf(q);
+        return { c, score: idx >= 0 ? idx : Number.MAX_SAFE_INTEGER };
+    });
+    scored.sort((a, b) => a.score - b.score);
+    // Mixed strategy: prefer items that literally match the query; if fewer
+    // than MAX_CANDIDATES match, fill the rest with the remaining items so
+    // the model still has context for semantic matches the literal scan misses.
+    return scored.slice(0, MAX_CANDIDATES).map(s => s.c);
+}
+
 /**
  * Builds a uniform candidate list across tabs / bookmarks / reading list.
  * Each candidate carries a `handler` so the result dialog can act on click.
@@ -78,12 +112,15 @@ export async function askAiToFind(query) {
     const candidates = await buildCandidates();
     if (candidates.length === 0) return { unavailable: false, items: [] };
 
-    const limited = candidates.slice(0, MAX_CANDIDATES);
+    // Pre-filter by query relevance BEFORE the 30-item cap. Without this, a
+    // user with 30+ tabs would never see their bookmarks/reading-list make
+    // it to the model — the exact use case Ask-AI is supposed to serve.
+    const limited = preFilterByQuery(candidates, query.trim());
     const lines = limited
-        .map((c, i) => `${i}. [${c.type}] ${c.title} — ${c.url}`)
+        .map((c, i) => `${i}. [${c.type}] ${sanitizeForPrompt(c.title)} — ${sanitizeForPrompt(c.url)}`)
         .join('\n');
 
-    const prompt = `User wants to find items matching: "${query}"
+    const prompt = `User wants to find items matching: "${sanitizeForPrompt(query)}"
 
 Below is a numbered list of tabs, bookmarks, and reading-list entries. Choose up to ${MAX_RESULTS} items that best match the user's intent. Reply ONLY with a JSON array of {index, reason} where reason is at most 25 chars in the user's locale; no other text:
 [
@@ -107,7 +144,9 @@ ${lines}`;
             .map(p => ({
                 ...limited[p.index],
                 aiReason: typeof p.reason === 'string' ? p.reason.slice(0, 30) : '',
-            }));
+            }))
+            // Hard-cap even if the model ignored "up to MAX_RESULTS" and returned more.
+            .slice(0, MAX_RESULTS);
         return { unavailable: false, items };
     } catch {
         return { unavailable: false, items: [] };
@@ -201,6 +240,11 @@ export async function openAskAiDialog() {
 /**
  * Wraps modal.showCustomDialog with an explicit `close()` so handlers can
  * close from outside the modal (e.g., after a result row is clicked).
+ *
+ * Uses the onOpen callback to capture THIS dialog's overlay element so
+ * close() targets the right modal even when another dialog stacks on top.
+ * (`document.querySelector('.modal-overlay')` would grab whichever overlay
+ * is first in the DOM, which is wrong as soon as anything else stacks.)
  */
 function openResultsDialog(initialContent) {
     return new Promise((resolveClose) => {
@@ -210,18 +254,19 @@ function openResultsDialog(initialContent) {
         container.style.overflowY = 'auto';
         container.appendChild(initialContent);
 
+        let overlayRef = null;
         const close = () => {
-            // Trigger modal's own close button (modalManager doesn't expose a
-            // programmatic close, so we click the standard #closeButton).
-            document.querySelector('.modal-overlay #closeButton')?.click();
+            // Close this specific overlay by clicking its own #closeButton.
+            overlayRef?.querySelector('#closeButton')?.click();
         };
 
         modal.showCustomDialog({
             title: api.getMessage('cmdPaletteAskAiResultsTitle') || 'AI suggestions',
             content: container,
+            onOpen: (modalContent) => {
+                overlayRef = modalContent.closest('.modal-overlay');
+                resolveClose(close);
+            },
         });
-
-        // Resolve next tick so the modal is in the DOM when caller uses `close()`.
-        setTimeout(() => resolveClose(close), 0);
     });
 }

--- a/modules/commandPalette/nlSearch.js
+++ b/modules/commandPalette/nlSearch.js
@@ -1,0 +1,227 @@
+/**
+ * Natural-language search over tabs + bookmarks + reading list.
+ *
+ * Design: AI is a *reranker*, not a *filter*. We feed the model a capped
+ * candidate list (top 30 by indexOf prefilter or random sample) and ask it
+ * to pick up to 8 items most relevant to the user's free-form query, with
+ * a short reason. This keeps token usage bounded and works on the local
+ * Gemini Nano window.
+ *
+ * Triggered from Command Palette's "Ask AI: Find tabs/bookmarks" action,
+ * which opens a prompt + result dialog independently of the main palette
+ * flow. v1 keeps it out of the palette's incremental search to avoid
+ * mixing the two interaction models (snappy indexOf vs. slow LLM).
+ */
+import * as api from '../apiManager.js';
+import * as state from '../stateManager.js';
+import * as aiManager from '../aiManager.js';
+import * as modal from '../modalManager.js';
+import * as readingListManager from '../readingListManager.js';
+
+const MAX_CANDIDATES = 30;
+const MAX_RESULTS = 8;
+
+/**
+ * Builds a uniform candidate list across tabs / bookmarks / reading list.
+ * Each candidate carries a `handler` so the result dialog can act on click.
+ */
+async function buildCandidates() {
+    const out = [];
+
+    const tabs = await chrome.tabs.query({}).catch(() => []);
+    for (const t of tabs) {
+        if (!t.url || /^chrome:/i.test(t.url)) continue;
+        out.push({
+            type: 'tab',
+            title: t.title || '(untitled)',
+            url: t.url,
+            handler: async () => {
+                await chrome.tabs.update(t.id, { active: true });
+                await chrome.windows.update(t.windowId, { focused: true });
+            },
+        });
+    }
+
+    const bookmarks = (state.getBookmarkCache() || []).filter(b => b.type === 'bookmark');
+    for (const b of bookmarks) {
+        out.push({
+            type: 'bookmark',
+            title: b.title || '(untitled)',
+            url: b.url,
+            handler: () => chrome.tabs.create({ url: b.url }),
+        });
+    }
+
+    try {
+        const rl = await readingListManager.getAllEntries();
+        for (const e of rl) {
+            out.push({
+                type: 'reading-list',
+                title: e.title || '(untitled)',
+                url: e.url,
+                handler: () => chrome.tabs.create({ url: e.url }),
+            });
+        }
+    } catch { /* reading list optional */ }
+
+    return out;
+}
+
+/**
+ * Calls the LanguageModel to rerank and pick up to MAX_RESULTS items.
+ * Returns the original candidate objects (with handler intact) plus an
+ * aiReason field.
+ */
+export async function askAiToFind(query) {
+    if (!query || !query.trim()) return { unavailable: false, items: [] };
+
+    const candidates = await buildCandidates();
+    if (candidates.length === 0) return { unavailable: false, items: [] };
+
+    const limited = candidates.slice(0, MAX_CANDIDATES);
+    const lines = limited
+        .map((c, i) => `${i}. [${c.type}] ${c.title} — ${c.url}`)
+        .join('\n');
+
+    const prompt = `User wants to find items matching: "${query}"
+
+Below is a numbered list of tabs, bookmarks, and reading-list entries. Choose up to ${MAX_RESULTS} items that best match the user's intent. Reply ONLY with a JSON array of {index, reason} where reason is at most 25 chars in the user's locale; no other text:
+[
+  { "index": 0, "reason": "short why" }
+]
+
+If nothing matches, reply with: []
+
+[Items]
+${lines}`;
+
+    const raw = await aiManager.runPrompt(prompt);
+    if (raw === null) return { unavailable: true, items: [] };
+
+    try {
+        const match = raw.match(/\[[\s\S]*\]/);
+        const parsed = JSON.parse(match ? match[0] : raw);
+        if (!Array.isArray(parsed)) return { unavailable: false, items: [] };
+        const items = parsed
+            .filter(p => typeof p.index === 'number' && limited[p.index])
+            .map(p => ({
+                ...limited[p.index],
+                aiReason: typeof p.reason === 'string' ? p.reason.slice(0, 30) : '',
+            }));
+        return { unavailable: false, items };
+    } catch {
+        return { unavailable: false, items: [] };
+    }
+}
+
+/**
+ * Opens the Ask-AI prompt-and-results dialog flow.
+ *
+ * v1 uses sequential modals (prompt → results) instead of inline embedding
+ * in the main palette to keep the snappy indexOf incremental search and
+ * the slower LLM rerank cleanly separated.
+ */
+export async function openAskAiDialog() {
+    const query = await modal.showPrompt({
+        title: api.getMessage('cmdPaletteAskAiTitle') || 'Ask AI: find tabs or bookmarks',
+        defaultValue: '',
+    });
+    if (!query || !query.trim()) return;
+
+    const waiting = document.createElement('div');
+    waiting.className = 'cmd-palette-empty';
+    waiting.textContent = api.getMessage('cmdPaletteAskAiThinking') || 'Asking AI…';
+    const close = await openResultsDialog(waiting);
+
+    const { unavailable, items } = await askAiToFind(query.trim());
+    // Replace placeholder content with results, in place.
+    const root = waiting.parentElement;
+    if (!root) return;
+    root.innerHTML = '';
+
+    if (unavailable) {
+        const msg = document.createElement('div');
+        msg.className = 'cmd-palette-empty';
+        msg.textContent = api.getMessage('cmdPaletteAskAiUnavailable')
+            || 'AI model is not downloaded yet. Trigger ✨ Smart Group first to download, then try again.';
+        root.appendChild(msg);
+        return;
+    }
+
+    if (items.length === 0) {
+        const msg = document.createElement('div');
+        msg.className = 'cmd-palette-empty';
+        msg.textContent = api.getMessage('cmdPaletteAskAiNoMatch') || 'AI found no good matches.';
+        root.appendChild(msg);
+        return;
+    }
+
+    for (const item of items) {
+        const row = document.createElement('div');
+        row.className = 'cmd-palette-row';
+        row.setAttribute('role', 'button');
+        row.tabIndex = 0;
+
+        const icon = document.createElement('span');
+        icon.className = 'cmd-palette-icon';
+        icon.textContent = item.type === 'tab' ? '🌐' : item.type === 'bookmark' ? '🔖' : '📚';
+
+        const meta = document.createElement('div');
+        meta.className = 'cmd-palette-meta';
+
+        const title = document.createElement('div');
+        title.className = 'cmd-palette-title';
+        title.textContent = item.title;
+
+        const sub = document.createElement('div');
+        sub.className = 'cmd-palette-subtitle';
+        sub.textContent = item.aiReason ? `${item.aiReason} — ${item.url}` : item.url;
+
+        meta.appendChild(title);
+        meta.appendChild(sub);
+        row.appendChild(icon);
+        row.appendChild(meta);
+
+        const trigger = async () => {
+            try {
+                close();
+                await item.handler();
+            } catch (err) {
+                console.warn('[nlSearch] action failed:', err);
+            }
+        };
+        row.addEventListener('click', trigger);
+        row.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter') { e.preventDefault(); trigger(); }
+        });
+        root.appendChild(row);
+    }
+}
+
+/**
+ * Wraps modal.showCustomDialog with an explicit `close()` so handlers can
+ * close from outside the modal (e.g., after a result row is clicked).
+ */
+function openResultsDialog(initialContent) {
+    return new Promise((resolveClose) => {
+        const container = document.createElement('div');
+        container.className = 'cmd-palette-results';
+        container.style.maxHeight = '60vh';
+        container.style.overflowY = 'auto';
+        container.appendChild(initialContent);
+
+        const close = () => {
+            // Trigger modal's own close button (modalManager doesn't expose a
+            // programmatic close, so we click the standard #closeButton).
+            document.querySelector('.modal-overlay #closeButton')?.click();
+        };
+
+        modal.showCustomDialog({
+            title: api.getMessage('cmdPaletteAskAiResultsTitle') || 'AI suggestions',
+            content: container,
+        });
+
+        // Resolve next tick so the modal is in the DOM when caller uses `close()`.
+        setTimeout(() => resolveClose(close), 0);
+    });
+}

--- a/modules/readingList/summaryRecorder.js
+++ b/modules/readingList/summaryRecorder.js
@@ -1,0 +1,69 @@
+/**
+ * Reading List Summary Recorder
+ *
+ * Listens for chrome.readingList.onEntryAdded. If the just-added URL matches
+ * a currently-open tab, we scrape its content via the shared extractor and
+ * run it through the Summarizer API, then persist the result in the summary
+ * store so the user can read the summary later — even offline, or after the
+ * source page is gone.
+ *
+ * Design choices:
+ * - We only summarize when a live tab matches the URL. Without that, we'd
+ *   have to chrome.tabs.create + scrape + close to extract text, which is
+ *   intrusive and frequently breaks (auth, paywalls, JS rendering).
+ *   v1 stays conservative; manual "summarize now" can come later.
+ * - Multiple open sidepanels would otherwise race to summarize the same
+ *   entry. We dedupe by checking the store before kicking off work.
+ * - aiManager.summarizeText gates itself on `=== 'available'`, so this
+ *   listener will silently skip if the model isn't already downloaded —
+ *   never triggers a multi-GB background download on its own.
+ */
+import * as state from '../stateManager.js';
+import * as aiManager from '../aiManager.js';
+import { extractPageContent } from '../utils/pageContentExtractor.js';
+import * as summaryStore from './summaryStore.js';
+
+let initialized = false;
+
+export function initSummaryRecorder() {
+    if (initialized) return;
+    if (!chrome.readingList || !chrome.readingList.onEntryAdded) return;
+    initialized = true;
+    chrome.readingList.onEntryAdded.addListener(handleEntryAdded);
+}
+
+async function handleEntryAdded(entry) {
+    try {
+        if (!state.isReadingListSummaryEnabled()) return;
+        if (!entry || !entry.url) return;
+        // Dedupe — another sidepanel might have already summarized this URL,
+        // or it was summarized in a previous session.
+        if (summaryStore.hasSummary(entry.url)) return;
+
+        // Only proceed when there's a live tab with this URL — otherwise we'd
+        // need to open a fresh tab just to scrape, which is intrusive and
+        // routinely fails on paywalled / auth-gated pages.
+        const tabs = await chrome.tabs.query({ url: entry.url }).catch(() => []);
+        const tab = tabs.find(t => typeof t.id === 'number');
+        if (!tab) return;
+
+        const text = await extractPageContent(tab.id);
+        if (!text) return;
+
+        const domain = safeHost(entry.url);
+        const summary = await aiManager.summarizeText(text, domain);
+        if (!summary) return;
+
+        await summaryStore.setSummary(entry.url, summary);
+        document.dispatchEvent(new CustomEvent('readingListSummaryAdded', {
+            detail: { url: entry.url },
+        }));
+    } catch (err) {
+        // Best-effort; never let a summarize failure surface to the user.
+        console.warn('[rlSummary] failed to summarize entry', err);
+    }
+}
+
+function safeHost(url) {
+    try { return new URL(url).hostname; } catch { return ''; }
+}

--- a/modules/readingList/summaryStore.js
+++ b/modules/readingList/summaryStore.js
@@ -45,13 +45,16 @@ export async function deleteSummary(url) {
 
 /**
  * Remove summaries whose URL no longer appears in the live Reading List.
- * Called lazily; the cost of carrying a few stale entries is small but they
- * pile up if the user adds/removes lots of articles.
+ *
+ * Guards against an empty list (cold start, fetch failure) silently wiping
+ * every stored summary — same lesson as PR #143's pruneOrphanedBookmarkTags.
+ * Caller passes the live URL set; we never call chrome.readingList ourselves
+ * so this stays a pure function.
  *
  * @param {string[]} liveUrls
  */
 export async function pruneOrphans(liveUrls) {
-    if (!Array.isArray(liveUrls)) return;
+    if (!Array.isArray(liveUrls) || liveUrls.length === 0) return;
     const alive = new Set(liveUrls);
     let changed = false;
     for (const url of Object.keys(summaries)) {
@@ -61,6 +64,25 @@ export async function pruneOrphans(liveUrls) {
         }
     }
     if (changed) await persist();
+}
+
+/**
+ * Cross-sidepanel sync. When another sidepanel writes a new summary, our
+ * in-memory mirror would otherwise stay stale until the next page load.
+ *
+ * @param {() => void} [onChange]
+ */
+export function subscribeToChanges(onChange) {
+    if (!chrome?.storage?.onChanged) return;
+    chrome.storage.onChanged.addListener((changes, area) => {
+        if (area !== 'local') return;
+        if (changes[STORAGE_KEY]) {
+            summaries = changes[STORAGE_KEY].newValue || {};
+            try { onChange?.(); } catch (err) {
+                console.warn('[rlSummary] sync callback failed:', err);
+            }
+        }
+    });
 }
 
 function persist() {

--- a/modules/readingList/summaryStore.js
+++ b/modules/readingList/summaryStore.js
@@ -1,0 +1,68 @@
+/**
+ * Reading List Summary Store
+ *
+ * Persists per-URL AI summaries so they're available even when the user is
+ * offline or the original page is no longer reachable. Stored in
+ * chrome.storage.local keyed by URL (Reading List entries are URL-keyed
+ * upstream too).
+ *
+ * Storage shape:
+ *   chrome.storage.local.readingListSummaries: {
+ *     [url]: { summary, createdAt }
+ *   }
+ */
+import { getStorage, setStorage } from '../apiManager.js';
+
+const STORAGE_KEY = 'readingListSummaries';
+
+/** @type {Object<string, {summary: string, createdAt: number}>} */
+let summaries = {};
+
+export async function initSummaries() {
+    const result = await getStorage('local', [STORAGE_KEY]);
+    summaries = result[STORAGE_KEY] || {};
+}
+
+export function getSummary(url) {
+    return summaries[url] || null;
+}
+
+export function hasSummary(url) {
+    return Boolean(summaries[url]);
+}
+
+export async function setSummary(url, summary) {
+    if (!url || !summary) return;
+    summaries[url] = { summary, createdAt: Date.now() };
+    await persist();
+}
+
+export async function deleteSummary(url) {
+    if (!(url in summaries)) return;
+    delete summaries[url];
+    await persist();
+}
+
+/**
+ * Remove summaries whose URL no longer appears in the live Reading List.
+ * Called lazily; the cost of carrying a few stale entries is small but they
+ * pile up if the user adds/removes lots of articles.
+ *
+ * @param {string[]} liveUrls
+ */
+export async function pruneOrphans(liveUrls) {
+    if (!Array.isArray(liveUrls)) return;
+    const alive = new Set(liveUrls);
+    let changed = false;
+    for (const url of Object.keys(summaries)) {
+        if (!alive.has(url)) {
+            delete summaries[url];
+            changed = true;
+        }
+    }
+    if (changed) await persist();
+}
+
+function persist() {
+    return setStorage('local', { [STORAGE_KEY]: summaries });
+}

--- a/modules/stateManager.js
+++ b/modules/stateManager.js
@@ -260,6 +260,26 @@ export async function setHoverSummarizeEnabled(enabled) {
   await setStorage('sync', { [HOVER_SUMMARIZE_KEY]: enabled });
 }
 
+// --- Reading List Summary Memory State ---
+
+const READING_LIST_SUMMARY_KEY = 'readingListSummaryEnabled';
+let readingListSummaryEnabled = true; // Default to enabled
+
+export async function initReadingListSummary() {
+  const result = await getStorage('sync', [READING_LIST_SUMMARY_KEY]);
+  readingListSummaryEnabled = result[READING_LIST_SUMMARY_KEY] !== false;
+  return readingListSummaryEnabled;
+}
+
+export function isReadingListSummaryEnabled() {
+  return readingListSummaryEnabled;
+}
+
+export async function setReadingListSummaryEnabled(enabled) {
+  readingListSummaryEnabled = enabled;
+  await setStorage('sync', { [READING_LIST_SUMMARY_KEY]: enabled });
+}
+
 // --- UI Language Override State ---
 
 const UI_LANGUAGE_KEY = 'uiLanguage';

--- a/modules/ui/hoverSummarizeManager.js
+++ b/modules/ui/hoverSummarizeManager.js
@@ -8,6 +8,7 @@ import * as aiManager from '../aiManager.js';
 import * as state from '../stateManager.js';
 import * as tooltip from './hoverTooltip.js';
 import { tabListContainer } from './elements.js';
+import { extractPageContent } from '../utils/pageContentExtractor.js';
 
 // === State ===
 
@@ -217,31 +218,8 @@ async function triggerSummarize(tabId, anchorEl) {
 
 // === Content Extraction ===
 
-/**
- * Extracts visible text from a tab's page content.
- * @param {number} tabId 
- * @returns {Promise<string|null>} Truncated text or null if extraction fails
- */
-async function extractPageContent(tabId) {
-    try {
-        const results = await chrome.scripting.executeScript({
-            target: { tabId },
-            func: () => {
-                const clone = document.body.cloneNode(true);
-                clone.querySelectorAll('script, style, nav, footer, header, aside, [role="navigation"], [role="banner"]')
-                    .forEach(el => el.remove());
-                return clone.innerText.replace(/\s+/g, ' ').trim();
-            }
-        });
-
-        const text = results?.[0]?.result || '';
-        if (text.length < 20) return null; // Too little content
-        return text.substring(0, 1500); // Token limit guard (FR-2.02)
-    } catch {
-        // chrome://, chrome-extension://, or restricted pages (FR-2.03)
-        return null;
-    }
-}
+// extractPageContent moved to modules/utils/pageContentExtractor.js so it can
+// be reused by the reading-list summary memory feature.
 
 // === Cache Management ===
 

--- a/modules/ui/readingListRenderer.js
+++ b/modules/ui/readingListRenderer.js
@@ -6,6 +6,7 @@ import * as readingListManager from '../readingListManager.js';
 import * as modalManager from '../modalManager.js';
 import { CHECK_ICON_SVG, CLOCK_ICON_SVG, PLUS_ICON_SVG } from '../icons.js';
 import { reconcileDOM } from '../utils/domUtils.js';
+import { getSummary as readSummary } from '../readingList/summaryStore.js';
 
 /**
  * Creates a reusable empty state element for the reading list.
@@ -388,7 +389,16 @@ function createReadingListItem(entry, isNew = false) {
     item.dataset.url = entry.url;
     item.dataset.title = entry.title;
     item.dataset.hasBeenRead = entry.hasBeenRead.toString();
-    item.title = `${entry.title}\n${entry.url}`;
+    // If we previously summarized this entry (Phase 8 summary memory),
+    // surface it in the hover tooltip so the user can preview content
+    // offline / after the page is gone. v1: tooltip only; inline subtitle
+    // would require row-layout changes covered by Phase 8 follow-up.
+    const summaryEntry = readSummary(entry.url);
+    const summaryText = summaryEntry ? summaryEntry.summary : '';
+    item.title = summaryText
+        ? `${entry.title}\n${entry.url}\n\n${summaryText}`
+        : `${entry.title}\n${entry.url}`;
+    if (summaryText) item.classList.add('has-summary');
 
     // Favicon
     const favicon = document.createElement('img');

--- a/modules/ui/settingManager.js
+++ b/modules/ui/settingManager.js
@@ -238,6 +238,16 @@ async function buildSettingsDialogContent(selectedTheme) {
 
                 <hr style="border: none; border-top: 1px solid var(--border-color); margin: 12px 0;">
 
+                <label class="settings-toggle">
+                    <input type="checkbox" id="rl-summary-toggle" ${state.isReadingListSummaryEnabled() ? 'checked' : ''}>
+                    <span class="toggle-label">${api.getMessage('rlSummaryToggleLabel')}</span>
+                </label>
+                <div class="settings-subsection" style="margin-top: 10px; font-size: 0.9em; opacity: 0.8;">
+                    <p>${api.getMessage('rlSummaryDescription')}</p>
+                </div>
+
+                <hr style="border: none; border-top: 1px solid var(--border-color); margin: 12px 0;">
+
                 <!-- AI Model Status -->
                 <div class="ai-model-status-section">
                     <div class="ai-model-status-header">Gemini Nano</div>
@@ -427,6 +437,14 @@ function bindSettingsEventHandlers(modalContentElement) {
     if (hoverSummarizeToggle) {
         hoverSummarizeToggle.addEventListener('change', async (e) => {
             await state.setHoverSummarizeEnabled(e.target.checked);
+        });
+    }
+
+    // Reading List Summary memory toggle handler
+    const rlSummaryToggle = modalContentElement.querySelector('#rl-summary-toggle');
+    if (rlSummaryToggle) {
+        rlSummaryToggle.addEventListener('change', async (e) => {
+            await state.setReadingListSummaryEnabled(e.target.checked);
         });
     }
 

--- a/modules/utils/pageContentExtractor.js
+++ b/modules/utils/pageContentExtractor.js
@@ -1,0 +1,41 @@
+/**
+ * Pulls the visible text of a tab's page so other code (hover summarize,
+ * reading-list summary memory) can feed it to the Summarizer API.
+ *
+ * Extracted from hoverSummarizeManager so the same helper can be called
+ * from multiple summarize entry points without re-implementing the
+ * executeScript scrape.
+ *
+ * Returns null when:
+ *   - the tab isn't scriptable (chrome://, chrome-extension://, store pages)
+ *   - the page has effectively no text (< 20 chars)
+ *
+ * Truncates at 1500 chars to stay under Gemini Nano's input budget.
+ */
+
+const MIN_TEXT_LEN = 20;
+const MAX_TEXT_LEN = 1500;
+
+/**
+ * @param {number} tabId
+ * @returns {Promise<string|null>}
+ */
+export async function extractPageContent(tabId) {
+    try {
+        const results = await chrome.scripting.executeScript({
+            target: { tabId },
+            func: () => {
+                const clone = document.body.cloneNode(true);
+                clone.querySelectorAll('script, style, nav, footer, header, aside, [role="navigation"], [role="banner"]')
+                    .forEach(el => el.remove());
+                return clone.innerText.replace(/\s+/g, ' ').trim();
+            }
+        });
+
+        const text = results?.[0]?.result || '';
+        if (text.length < MIN_TEXT_LEN) return null;
+        return text.substring(0, MAX_TEXT_LEN);
+    } catch {
+        return null;
+    }
+}

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -178,10 +178,23 @@ async function initialize() {
     // Prune orphaned bookmarkTags entries (bookmarks deleted while we weren't watching).
     tagManager.pruneOrphanedBookmarkTags(state.getBookmarkCache() || [])
         .catch(err => console.warn('[tags] prune failed:', err));
-    await state.initReadingListSummary();
-    await readingListSummaryStore.initSummaries();
+    // Parallelize the two independent storage reads (sync + local) so the
+    // total init time doesn't lengthen the critical path before refreshBookmarks
+    // settles — CI puppeteer tests were sensitive to even small init delays.
+    await Promise.all([
+        state.initReadingListSummary(),
+        readingListSummaryStore.initSummaries(),
+    ]);
     initSummaryRecorder();
     document.addEventListener('readingListSummaryAdded', () => refreshReadingList());
+    // Pick up summaries written by other open sidepanels.
+    readingListSummaryStore.subscribeToChanges(() => refreshReadingList());
+    // Drop summaries for URLs no longer in the Reading List. Run after a real
+    // entries fetch (empty list could mean "really empty" OR "fetch failed";
+    // the store guards against the latter case internally).
+    readingListManager.getAllEntries()
+        .then(entries => readingListSummaryStore.pruneOrphans(entries.map(e => e.url)))
+        .catch(err => console.warn('[rlSummary] prune failed:', err));
     const bookmarkToolsBtn = document.getElementById('bookmark-tools-btn');
     if (bookmarkToolsBtn) {
         // Mirror the workspace-manage-btn pattern: resolve aria-label at runtime

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -14,6 +14,8 @@ import * as workspaceManager from './modules/workspace/workspaceManager.js';
 import { initWorkspaceUI } from './modules/workspace/workspaceUI.js';
 import * as tagManager from './modules/bookmark/tagManager.js';
 import { openBookmarkToolsDialog } from './modules/bookmark/bookmarkToolsUI.js';
+import * as readingListSummaryStore from './modules/readingList/summaryStore.js';
+import { initSummaryRecorder } from './modules/readingList/summaryRecorder.js';
 import { SEARCH_NO_RESULTS_ICON_SVG } from './modules/icons.js';
 import { debounce } from './modules/utils/functionUtils.js';
 
@@ -176,6 +178,10 @@ async function initialize() {
     // Prune orphaned bookmarkTags entries (bookmarks deleted while we weren't watching).
     tagManager.pruneOrphanedBookmarkTags(state.getBookmarkCache() || [])
         .catch(err => console.warn('[tags] prune failed:', err));
+    await state.initReadingListSummary();
+    await readingListSummaryStore.initSummaries();
+    initSummaryRecorder();
+    document.addEventListener('readingListSummaryAdded', () => refreshReadingList());
     const bookmarkToolsBtn = document.getElementById('bookmark-tools-btn');
     if (bookmarkToolsBtn) {
         // Mirror the workspace-manage-btn pattern: resolve aria-label at runtime


### PR DESCRIPTION
## 摘要 (Summary)

對應 plan B2.5（Reading List 摘要記憶）+ B2.6（自然語言搜尋）。兩個子功能性質很不同——8a 是 reading list 既有體驗的**被動延伸**，8b 是 command palette 的**主動 AI 入口**。整合在同一 PR 因為都是 AI-driven + 規模可控。

### 相關 Issue (Related Issues)

無。基於 plan B2.5 + B2.6。

---

## 📝 變更內容 (Changes)

### 新增 (Added)
- **`modules/utils/pageContentExtractor.js`** — 抽出原本私有的 `extractPageContent`，讓 hover summarize 與 reading list summary 共用
- **`modules/readingList/summaryStore.js`** — chrome.storage.local 持久層 + CRUD + pruneOrphans
- **`modules/readingList/summaryRecorder.js`** — 監聽 `chrome.readingList.onEntryAdded`，匹配 live tab 則 scrape + summarize + 存
- **`modules/commandPalette/nlSearch.js`** — `askAiToFind` rerank + `openAskAiDialog` flow
- **`aiManager.js`**：新增 `summarizeText(text, domain)` + `runPrompt(promptText)` helpers（兩者都嚴格 `=== 'available'`）
- **`stateManager.js`**：`readingListSummaryEnabled` 新 state + 3 個 export
- **`settingManager.js`**：加 toggle
- **`readingListRenderer.js`**：item.title 加 summary tooltip + `.has-summary` class
- **`commandPalette/actions.js`**：加「🤖 Ask AI to find tabs or bookmarks」action
- **`sidepanel.js`**：4 行 wiring（init summary store + recorder + event listener）
- **i18n**：10 個新字串 × 3 語
- **`.agent/notes/NOTE_20260527_phase8.md`**

### 修改 (Changed)
- **`hoverSummarizeManager.js`**：移除原本內嵌 `extractPageContent`，改 import 共用 utility

### 重要決策說明
- **8a Summary 觸發條件 = 加入時匹配 live tab**：lazy / on-demand 設計會需要 chrome.tabs.create 重 open + scrape + close，對 paywalled / auth-gated 頁面常失敗且打斷使用者。v1 保守只在已有 active tab 時 summarize，其他情境靜默 skip。
- **8a Summary 顯示用 title attr 而非 visible subtitle**：readingListRenderer 既有 row layout 已密集，加 visible subtitle 是 layout 重做。v1 用 hover tooltip 是 minimum viable + 0 layout risk。v2 可加 visible preview。
- **8b 用獨立 modal 而非 palette mode toggle**：palette 主流是 indexOf incremental search（debounce 100ms snappy），AI rerank 是 explicit + 慢（1-3s）。兩種互動模型 cleanly 分開，user mental model 明確（不會以為 typing 會自動 AI）。v2 可整合（如 `>` prefix 進 mode）。
- **8b AI 是 reranker 不是 filter**：local Gemini Nano token 預算 ~1500，全部書籤 + tabs 可能超千個，硬塞會超 budget。先 cap 30 candidates，AI 從中挑出最相關 — 對「找上週看的 X」這種 query 仍有效（AI 從 candidate metadata 推理）。
- **8a / 8b 都 `=== 'available'` 嚴格**：summary memory 是 background event 觸發，絕不 silent download；NL search 雖 user-initiated 但同樣不 silent download，提示 user 去 Smart Group 觸發。

---

## 🧪 測試 (Testing)

### 自動化測試
- [x] `npm run test:unit` → 57/57 通過
- [x] Puppeteer：`happy_path_sidepanel_load` + `happy_path_search` + `happy_path_settings_panel` 14/14 通過
- [x] `esbuild --bundle` 兩 entry 通過
- [x] 3 個 `messages.json` JSON 合法

### 手動驗證（需 Chrome with Gemini Nano + Summarizer all `available`）
1. `make` → `chrome://extensions` 載入未封裝
2. **8a Summary**：
   - 開個 tab（任意 http(s) 頁）→ 加入 Reading List（從 sidepanel tab item 的「+ 書籤」icon 或 Chrome menu）
   - 等 ~3-5 秒 → 再次 hover reading list 該 item → 應顯示 tooltip 含 summary
   - 設定面板「Remember AI summary」toggle 應預設開
   - 關 toggle 後新加入的 entries 不會 summarize（既有的仍存在）
   - 離線：summary 已存的應仍可看（chrome.storage.local 持久）
3. **8b NL Search**：
   - Cmd+K → 「Ask AI to find tabs or bookmarks」action
   - 輸入「上週看的 React」之類 → 等 1-3s → AI 建議 modal 開啟
   - 點 row → 跳到該 tab 或開該 bookmark/reading list URL
   - AI 未下載狀態：應顯示「請先觸發 Smart Group 下載」
   - 無 match：應顯示「AI found no good matches」
4. **多語**：切到 zh_TW / zh_CN 確認新字串

---

## ✅ 檢查清單 (Checklist)

- [x] 程式碼遵循專案 coding style（ES modules、vanilla JS、textContent 渲染、aria 標籤）
- [x] 自動化測試已通過
- [x] `.agent/notes/NOTE_20260527_phase8.md` 已寫
- [x] PR 描述包含英文版本
- [ ] **待辦**：11 個其他語系翻譯 → Phase 11
- [ ] **待辦**：v2 — 8a summary 顯示為 inline subtitle（需 readingListRenderer 改 row layout）
- [ ] **待辦**：v2 — 8a 手動 summarize button（per-entry「✨」按鈕）
- [ ] **待辦**：v2 — 8b 整合進 palette 主流（如 `>` prefix mode）
- [ ] **待辦**：Puppeteer test for 8a 與 8b flows

---

## 🌐 English Version

### Summary

Implements plan B2.5 + B2.6. Two subfeatures with very different characters bundled into one PR because both are AI-driven and individually small:

- **8a** — Reading List summary memory: passive extension of the existing reading list. When you add a page that's already open in a tab, AI summarizes it once and persists locally so you can preview later (even offline).
- **8b** — Command Palette natural-language search: explicit "Ask AI to find tabs or bookmarks" action. AI is a reranker (cap 30 candidates → pick 8 with short reasons), not a filter.

### Changes

#### Added
- `modules/utils/pageContentExtractor.js` — extracts the previously-private scraper from hoverSummarizeManager so both summarize paths share one implementation.
- `modules/readingList/{summaryStore, summaryRecorder}.js` — chrome.storage.local persistence + onEntryAdded listener that summarizes when a live tab matches the URL. Dedupes against the store to avoid races between open sidepanels.
- `modules/commandPalette/nlSearch.js` — uniform candidate builder + `askAiToFind` reranker + `openAskAiDialog` flow that's deliberately separate from the palette's incremental search.
- `aiManager.summarizeText(text, domain)` and `aiManager.runPrompt(promptText)` — both strictly `=== 'available'` gated so the model is never silently downloaded.

#### Changed
- `readingListRenderer` — item `title` attribute carries the summary as a tooltip (v1 unobtrusive; visible subtitle is row-layout work for v2).
- `settingManager` — new "Remember AI summary for Reading List items" toggle.
- `commandPalette/actions` — adds "🤖 Ask AI to find tabs or bookmarks".
- `sidepanel.js` — 4-line wiring (init store + recorder + event listener).
- `hoverSummarizeManager` — drops its private extractor; imports the shared utility.

#### Key decisions
- **8a fires only when a live tab matches the new URL**: lazy/on-demand summarize would require open-scrape-close, which routinely fails on paywalled/auth pages and is intrusive. Conservative v1 skips entries without a live tab.
- **8a summary as tooltip, not subtitle**: the row layout is already dense; visible subtitle is a layout rework deferred to v2.
- **8b uses a dedicated modal flow, not a palette mode**: the palette's debounced indexOf is snappy; LLM rerank is 1–3s and explicit. Mixing them in one input would confuse the mental model. v2 may add a `>` prefix mode.
- **8b is a reranker, not a filter**: Gemini Nano's input budget can't fit hundreds of bookmarks; we cap candidates at 30 and let the model pick the best 8.
- **Both 8a and 8b strictly require model already `available`**: background event (8a) must not silently start a multi-GB download; user-initiated action (8b) directs the user to Smart Group to trigger the download instead.

### Testing

- `npm run test:unit` → 57/57 passing
- Puppeteer: sidepanel_load + search + settings_panel 14/14 passing
- `esbuild --bundle` succeeds for both entries
- 3 `messages.json` files validate

Manual verification: see the Chinese section.

### Related Issues
None. Based on plan B2.5 + B2.6.
