### PR TITLE
i18n: fill 957 missing keys across 11 langs + sync key_files docs

### DIFF
--- a/.agent/notes/NOTE_20260529_phase11.md
+++ b/.agent/notes/NOTE_20260529_phase11.md
@@ -1,0 +1,115 @@
+# NOTE 2026-05-29 — Phase 11: i18n 全語對齊與 docs sync
+
+## 摘要
+
+Phase 11 收尾全 plan：
+
+1. **i18n 全語對齊**：擴大範圍重審 14 國 `_locales/{lang}/messages.json`，把 Phase 1–10 累積的所有新 keys 補齊。
+2. **Docs sync**：把 Phase 4–9 新增的模組（`commandPalette/`、`workspace/`、`bookmark/`、`readingList/`、`utils/searchUtils.js`、`utils/pageContentExtractor.js`、`keyboardManager.js`、`tab/` 子目錄、jest 設定）寫進 `AGENTS.md` 與 `GEMINI.md` 的 key_files 索引。
+3. **Plan 11 階段總結**：列在文末。
+
+---
+
+## Phase 11a — i18n fill
+
+### Audit 結果
+
+- 14 語 `messages.json` 與 `en` 合併集 **252 個 unique keys**。
+- 3 語完整（**0 missing**）：`en`、`zh_TW`、`zh_CN`。
+- 11 語各缺 **87 keys**，全部來自 Phase 4–9 新功能：
+  - `aiAutoNaming*`、`aiCleanup*`（Phase 4）
+  - `cmdPalette*`、`shortcut*`（Phase 5 + Phase 9）
+  - `workspace*`（Phase 6 + Phase 9）
+  - `bmTools*`（Phase 7）
+  - `rlSummary*`（Phase 8a）
+- 缺失總量：**87 × 11 = 957 個翻譯項目**。
+
+### 補齊策略
+
+沿用 Phase 10 store_description 的階梯式翻譯品質：
+
+| 等級 | 語言 | 翻譯策略 |
+|------|------|---------|
+| 高品質 | `ja`、`ko` | 完整在地化（marketing tone + 技術詞彙） |
+| 結構翻譯 | `de`、`fr`、`es`、`pt_BR`、`ru` | 結構正確；廣為人知的品牌名詞保留英文（`Workspace`、`Command Palette`、`Bookmark Tools`、`Smart Group`、`Reading List` 等） |
+| 保守翻譯 | `hi`、`id`、`th`、`vi` | 保留更多英文關鍵詞維持識別性，建議 v2 由 native speaker 校閱 |
+
+### 實作
+
+- 腳本：`/Users/Tai.Tai/.claude/jobs/86ea5cf2/p11_i18n_fill.py`
+- 流程：載入 `missing_keys_en.json` 為來源 → 各語 dict 填充 → 一次性 `json.load` + dict update + `json.dump`（preserving Unicode）
+- 保護既有 keys：腳本檢查 `if key in data: continue`，**不覆寫**任何已存在的翻譯。
+- 驗證：
+  1. 14 語 252 keys union 完全對齊（zero missing / zero extra）
+  2. Spot-check 5 個含 placeholder 的 keys（`{count}`、`{ws}`、`{n}`、`{total}`、`{pct}`），placeholder 100% 保留
+  3. JSON `json.load` round-trip 全綠
+
+---
+
+## Phase 11b — Docs sync
+
+### AGENTS.md
+
+新增區段：
+- `Key Files Navigator` 加 `modules/aiManager.js`、`modules/keyboardManager.js`、`apiManager.js setStorageStrict` 註記
+- 新增 5 個區段表格：`Command Palette` / `Workspace` / `Bookmark Tools` / `Reading List Summary` / `Utils`
+- `UI 子模組` 表格加 `tab/tabListeners.js`、`tab/splitViewRenderer.js`、`aiCleanupUI.js`
+- `Testing 基礎建設` 新表格：`jest.config.js`、`jest.esbuild-transform.cjs`
+- 底部 timestamp 改 2026-05-29
+
+### GEMINI.md
+
+`key_files` 列表追加 17 個新檔（commandPalette × 4、workspace × 2、bookmark × 5、readingList × 2、utils × 2、keyboardManager、tab × 2、jest × 2、aiCleanupUI），並擴充 `aiManager.js` description 補上 Phase 4/8 新方法。
+
+### CLAUDE.md
+
+**不動**。CLAUDE.md 定位是補 Claude Code 環境專屬慣例（gh 路徑、skill trigger keyword、session 收尾規範），不是 architecture source of truth；架構資訊主檔已在 AGENTS.md。
+
+---
+
+## Phase 1–11 整體總回顧
+
+| Phase | 主題 | 主要成果 |
+|------|------|---------|
+| 1 | 程式碼穩定度 | (1.1) sidepanel 啟動 race fix、(1.2) Jest + esbuild transform 補單元測試骨架（`utils/searchUtils.js` 提取）、(1.3) hoverSummarize 清 cache leak、(1.4) RSS alarm error recovery |
+| 2 | 跨 window 同步 | `background.js` 加 `chrome.storage.onChanged` listener |
+| 3 | tabRenderer 重構 | 561 → 353 行；拆出 `tab/tabListeners.js` + `tab/splitViewRenderer.js` |
+| 4 | AI Phase 2 | aiManager 加 `generateGroupName` (自動命名空群組) + `generateCleanupSuggestions` (cleanup 建議)，UI 走 `aiCleanupUI.js`；所有 AI 入口統一用 `=== 'available'` gating |
+| 5 | Command Palette | ⌘K / Ctrl+K 入口；`modules/commandPalette/` 4 檔（actions / dataProvider / index / nlSearch） |
+| 6 | Workspace | windowNames 升級為 Workspace 概念；切換器 + manage modal + 切換確認（unbound tabs 自動 auto-save 防資料遺失） |
+| 7 | Bookmarks 2.0 | `modules/bookmark/` 5 檔；multi-tag、dedupe、dead-link scan（三重防誤刪：navigator.onLine 預檢 + 預設未勾選 + suspicious-ratio 警告） |
+| 8 | Reading List 摘要 + NL 搜尋 | `modules/readingList/summary*.js` 加 Summarizer API 自動摘要 + 離線預覽；Command Palette 加 NL search（Prompt API 作 reranker，preFilterByQuery 用 indexOf scoring 降候選） |
+| 9 | 跨裝置同步 + 快捷鍵 | Workspace 儲存分離 metadata→sync / tabSnapshot→local，含 legacy migration 與 rollback 安全策略；`apiManager.setStorageStrict` 新增（不破壞 fire-and-forget caller）；`keyboardManager.js` 處理 sidepanel-only 快捷鍵 |
+| 10 | 戰略重定位 | Tagline 「Knowledge Workspace for Chrome」；14 語 README + store_description 改寫；新增 `web/why-not-native/`；`extensionDescription` 短文案重寫；mass-apply 走 Python AST literal_eval |
+| 11 | i18n 對齊 + docs sync | 957 翻譯補齊 + AGENTS / GEMINI key_files 全面同步 |
+
+---
+
+## 修改的檔案
+
+### i18n (Phase 11a)
+- `_locales/{ja,ko,de,fr,es,pt_BR,ru,hi,id,th,vi}/messages.json` — 各加 87 keys
+
+### Docs (Phase 11b)
+- `AGENTS.md` — Key Files Navigator 全面擴充 + timestamp 更新
+- `GEMINI.md` — `key_files` 列表加 17 個新檔
+
+### Note (Phase 11c)
+- `.agent/notes/NOTE_20260529_phase11.md` — 本檔
+
+---
+
+## 驗證
+
+- ✅ 14 語 `messages.json` 各 252 keys 完整對齊（Python `json.load` audit zero missing / zero extra）
+- ✅ 5 個含 placeholder 的 keys spot-check 100% 保留 `{count}` / `{ws}` / `{n}` / `{total}` / `{pct}`
+- ⚠️ 本 phase 無 code 改動 — Puppeteer / unit test 跳過
+
+---
+
+## 翻譯品質聲明（給 reviewer）
+
+- **EN + zh_TW + zh_CN**: pre-existing source，無變更
+- **ja + ko**: 完整在地化，含 marketing tone 與技術詞彙
+- **de + fr + es + pt_BR + ru**: 結構正確；`Workspace` / `Command Palette` / `Bookmark Tools` / `Smart Group` / `Reading List` 等廣為人知品牌詞保留英文；native marketing-tone review 留 v2
+- **hi + id + th + vi**: 保守翻譯，混合英文關鍵詞以維持識別性；建議 v2 找 native speaker 校閱

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,12 +137,14 @@ graph LR
 |------|------|------|
 | `sidepanel.js` | **[總指揮]** | 應用程式進入點，事件監聽與模組初始化 |
 | `modules/uiManager.js` | **[UI Facade]** | UI 模組入口，Facade 模式 |
-| `modules/apiManager.js` | **[通訊]** | Chrome API 封裝層 |
+| `modules/apiManager.js` | **[通訊]** | Chrome API 封裝層；含 `setStorageStrict`（Phase 9）回報 chrome.runtime.lastError，給關鍵 migration 用 |
 | `modules/stateManager.js` | **[狀態]** | UI 狀態與持久化關聯管理 |
 | `modules/modalManager.js` | **[互動]** | 客製化對話框 |
 | `modules/dragDropManager.js` | **[功能]** | SortableJS 拖曳邏輯 |
 | `modules/searchManager.js` | **[功能]** | 搜尋過濾邏輯 |
 | `modules/icons.js` | **[資源]** | 集中管理所有 SVG 圖示 |
+| `modules/aiManager.js` | **[AI]** | LanguageModel + Summarizer API；Phase 4/8 加 `generateGroupName` / `generateCleanupSuggestions` / `summarizeText` / `runPrompt` |
+| `modules/keyboardManager.js` | **[功能]** | sidepanel-only 鍵盤快捷鍵（Phase 9；繞過 chrome.commands 4-command 上限） |
 
 ### UI 子模組 (`modules/ui/`)
 | 檔案 | 職責 |
@@ -151,8 +153,58 @@ graph LR
 | `settingManager.js` | 設定與主題切換邏輯 |
 | `customThemeManager.js` | 自訂主題配色 |
 | `searchUI.js` | 搜尋介面更新 |
-| `tabRenderer.js` | 分頁渲染 |
+| `tabRenderer.js` | 分頁渲染（Phase 3 拆解後從 561 → 353 行） |
+| `tab/tabListeners.js` | 分頁事件監聽（Phase 3 拆出） |
+| `tab/splitViewRenderer.js` | Split View 分頁渲染（Phase 3 拆出） |
 | `bookmarkRenderer.js` | 書籤渲染 |
+| `aiGrouperUI.js` | ✨ Smart Group 介面 + Toast 復原 |
+| `aiCleanupUI.js` | 🧹 AI Tab Cleanup 介面（Phase 4b） |
+
+### Command Palette (`modules/commandPalette/`, Phase 5)
+| 檔案 | 職責 |
+|------|------|
+| `index.js` | ⌘K / Ctrl+K 入口 + overlay UI |
+| `dataProvider.js` | 多源（tabs / bookmarks / reading list / actions / workspaces）資料聚合與分組 |
+| `actions.js` | 可執行動作集合（new tab / smart group / AI cleanup / workspace 管理…） |
+| `nlSearch.js` | AI 自然語言搜尋（reranker；Phase 8b） |
+
+### Workspace (`modules/workspace/`, Phase 6, Phase 9 重構儲存)
+| 檔案 | 職責 |
+|------|------|
+| `workspaceManager.js` | CRUD + 儲存分離 (metadata→sync / tabSnapshot→local) + legacy 一次性遷移 + onChanged 跨裝置同步 |
+| `workspaceUI.js` | 切換器 / 管理 modal / 切換確認（unbound tabs 自動 auto-save） |
+
+### Bookmark Tools (`modules/bookmark/`, Phase 7)
+| 檔案 | 職責 |
+|------|------|
+| `bookmarkToolsUI.js` | Bookmark Tools modal（Tags / Duplicates / Dead Links 三 tab） |
+| `tagManager.js` | 多標籤管理（chrome.storage.local 自建 tag index） |
+| `dedupe.js` | 重複書籤偵測與批次清理 |
+| `deadLinkChecker.js` | 死連結 HEAD scan（navigator.onLine 預檢 + 預設未勾選 + suspicious-ratio 警告） |
+| `bookmarkUtils.js` | URL normalize / host 抽取等純函式 |
+
+### Reading List Summary (`modules/readingList/`, Phase 8a)
+| 檔案 | 職責 |
+|------|------|
+| `summaryStore.js` | 摘要本機儲存（含 pruneOrphans 空陣列守衛） |
+| `summaryRecorder.js` | 加入時自動摘要並存檔（離線可預覽） |
+
+### Utils (`modules/utils/`)
+| 檔案 | 職責 |
+|------|------|
+| `colorUtils.js` | HSL/HEX 轉換、WCAG 對比度 |
+| `imageUtils.js` | 圖片壓縮、WebP 轉換 |
+| `textUtils.js` | escapeHtml 等 XSS 防護 |
+| `domUtils.js` | DOM helper |
+| `functionUtils.js` | function helper |
+| `searchUtils.js` | 搜尋純函式（Phase 1.2 從 searchManager 提取，避免測試連帶 import elements.js） |
+| `pageContentExtractor.js` | 頁面內容擷取（Phase 8；給 reading list 摘要與 NL search 用） |
+
+### Testing 基礎建設
+| 檔案 | 職責 |
+|------|------|
+| `jest.config.js` | Jest 設定（jsdom 環境）— Phase 1.2 補骨架 |
+| `jest.esbuild-transform.cjs` | esbuild ESM → CJS transform，避免引入 babel-jest |
 
 ---
 
@@ -390,4 +442,4 @@ Jules 可自動掃描 `#TODO` 註解並提出改善建議。
 
 ---
 
-*Last updated: 2026-01-23*
+*Last updated: 2026-05-29 (Phase 11 — 同步 Phase 4-9 新模組與 i18n 全語對齊)*

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -70,13 +70,55 @@ key_files:
   - file_path: modules/icons.js
     description: "[UI] SVG 圖示集中管理。匯出所有 UI 使用的 SVG 圖示常數，避免重複定義。"
   - file_path: modules/aiManager.js
-    description: "[AI] 本機 AI 模型管理。負責封裝 LanguageModel (Prompt API) 與 Summarizer API 的對接，提供 tab grouping 與頁面摘要功能。"
+    description: "[AI] 本機 AI 模型管理。封裝 LanguageModel (Prompt API) 與 Summarizer API；提供 tab grouping、頁面摘要、AI 群組自動命名 (generateGroupName)、AI tab cleanup 建議 (generateCleanupSuggestions)、reading-list 摘要 (summarizeText)、自然語言搜尋的 reranker (runPrompt，使用獨立 nlLanguageModelSession)。"
   - file_path: modules/ui/aiGrouperUI.js
     description: "[UI] 智慧整理介面。負責處理未分類分頁的讀取、呼叫 AI、執行群組化，以及 Toast 復原機制。"
+  - file_path: modules/ui/aiCleanupUI.js
+    description: "[UI] AI Tab Cleanup 介面。Phase 4b 新增；在 Smart Group 旁顯示 🧹 按鈕，inline section 展示 AI 建議的可關閉分頁清單，預設未勾選防止誤刪。"
   - file_path: modules/ui/hoverSummarizeManager.js
     description: "[功能] Hover Summarize 核心邏輯。管理 2 秒 debounce、AbortController 取消、chrome.scripting 文字擷取、Summarizer API 串流摘要、記憶體快取。"
   - file_path: modules/ui/hoverTooltip.js
     description: "[UI] Hover Summarize 的 Tooltip UI 元件。提供 show/hide/updateStreamChunk API，含 shimmer 載入動畫與 glassmorphism 樣式。"
+  - file_path: modules/commandPalette/index.js
+    description: "[功能] Command Palette (⌘K / Ctrl+K) 入口。Phase 5 新增；統一搜尋 tabs / bookmarks / reading list / actions / workspaces。"
+  - file_path: modules/commandPalette/dataProvider.js
+    description: "[功能] Command Palette 資料源。Phase 5 新增；聚合多個 source 的搜尋結果與分組顯示邏輯。"
+  - file_path: modules/commandPalette/actions.js
+    description: "[功能] Command Palette 動作集合。Phase 5 新增；包含 new tab / smart group / AI cleanup / workspace 管理等可執行動作。"
+  - file_path: modules/commandPalette/nlSearch.js
+    description: "[AI] 自然語言搜尋。Phase 8b 新增；使用 Chrome Prompt API 作 reranker（非 filter），透過 preFilterByQuery 用 indexOf scoring 降低候選後再送 LLM。"
+  - file_path: modules/workspace/workspaceManager.js
+    description: "[功能] Workspace 業務邏輯。Phase 6 新增、Phase 9 重構儲存架構；分離 metadata (chrome.storage.sync, 8KB/key 限制) 與 tabSnapshot (chrome.storage.local)，含 legacy windowNames 一次性遷移與 onChanged 跨裝置同步。"
+  - file_path: modules/workspace/workspaceUI.js
+    description: "[UI] Workspace 切換器與管理介面。Phase 6 新增；下拉切換 + 管理 modal + 切換確認 (含 unbound tabs 自動 auto-save 防資料遺失)。"
+  - file_path: modules/bookmark/tagManager.js
+    description: "[功能] 書籤多標籤管理。Phase 7 新增；用 chrome.storage.local 自建 tag index 突破 Chrome 內建單層資料夾限制。"
+  - file_path: modules/bookmark/dedupe.js
+    description: "[功能] 重複書籤偵測與批次清理。Phase 7 新增；以 normalized URL 分組，UI 允許每組保留任一份。"
+  - file_path: modules/bookmark/deadLinkChecker.js
+    description: "[功能] 死連結掃描。Phase 7 新增；用 HEAD 請求批次掃描 http(s) 書籤，含 navigator.onLine 預檢、預設未勾選、suspicious-ratio 警告三重防誤刪。"
+  - file_path: modules/bookmark/bookmarkUtils.js
+    description: "[工具] 書籤共用工具。Phase 7 新增；URL normalize、host 抽取等純函式，方便單元測試。"
+  - file_path: modules/bookmark/bookmarkToolsUI.js
+    description: "[UI] Bookmark Tools modal。Phase 7 新增；整合 Tags / Duplicates / Dead Links 三個 tab。"
+  - file_path: modules/readingList/summaryStore.js
+    description: "[功能] Reading List 摘要本機儲存。Phase 8a 新增；存於 chrome.storage.local，含 pruneOrphans 守衛防止空陣列誤刪全部。"
+  - file_path: modules/readingList/summaryRecorder.js
+    description: "[功能] Reading List 摘要錄製器。Phase 8a 新增；當使用者把開啟中分頁加入 Reading List 時，自動透過 Summarizer API 摘要並存檔，離線時可預覽。"
+  - file_path: modules/utils/searchUtils.js
+    description: "[工具] 搜尋純函式工具。Phase 1.2 提取自 searchManager；避免測試時連帶 import elements.js 觸發 DOM 存取，含 matchesAnyKeyword、extractDomain。"
+  - file_path: modules/utils/pageContentExtractor.js
+    description: "[工具] 頁面內容擷取。Phase 8 新增；給 reading list 摘要與 NL search 使用，透過 chrome.scripting 抓取頁面文字。"
+  - file_path: modules/keyboardManager.js
+    description: "[功能] 鍵盤快捷鍵管理。Phase 9 新增；管理 sidepanel 內 keyboard shortcuts（受限於 chrome.commands API 4-command 上限，sidepanel-only 快捷鍵走自管路線）。"
+  - file_path: modules/ui/tab/tabListeners.js
+    description: "[UI] 分頁事件監聽。Phase 3 重構自 tabRenderer.js；負責 click / drag / contextmenu 等事件綁定。"
+  - file_path: modules/ui/tab/splitViewRenderer.js
+    description: "[UI] Split View 分頁渲染。Phase 3 重構自 tabRenderer.js；專門處理 split-view 分頁顯示。"
+  - file_path: jest.config.js
+    description: "[Test] Jest 設定（Phase 1.2 補單元測試骨架）。設定 jsdom 環境、transform 使用 esbuild-jest。"
+  - file_path: jest.esbuild-transform.cjs
+    description: "[Test] Jest 自訂 transform。Phase 1.2 新增；用 esbuild 將 ESM .js 編譯為 CJS，避免引入 babel-jest 依賴。"
   - file_path: manifest.json
     description: "擴充功能的設定檔。定義名稱、版本、權限、圖示和快捷鍵等。"
 

--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -682,5 +682,266 @@
   },
   "aiSetupStep2b": {
     "message": "Prompt API Multimodal-Eingabe aktivieren: Öffnen Sie den Link und setzen Sie auf \"Enabled\"."
+  },
+  "aiAutoNamingDescription": {
+    "message": "Wenn Sie eine neue Tab-Gruppe ohne Titel erstellen, schlägt KI eine kurze Bezeichnung vor (Emoji + Name). Läuft nur, wenn das lokale Modell bereits heruntergeladen ist."
+  },
+  "aiAutoNamingToggleLabel": {
+    "message": "Leere Tab-Gruppen automatisch benennen"
+  },
+  "aiCleanupAnalyzing": {
+    "message": "Tabs werden analysiert..."
+  },
+  "aiCleanupBtnText": {
+    "message": "🧹 Aufräumen"
+  },
+  "aiCleanupBtnTitle": {
+    "message": "KI-vorgeschlagene Tab-Bereinigung"
+  },
+  "aiCleanupConfirm": {
+    "message": "Auswahl schließen"
+  },
+  "aiCleanupDescription": {
+    "message": "Fügt eine Schaltfläche neben Smart Group hinzu, die KI fragt, welche Tabs Sie schließen können."
+  },
+  "aiCleanupEmpty": {
+    "message": "Ihre Tabs sehen aufgeräumt aus — nichts zum Aufräumen."
+  },
+  "aiCleanupError": {
+    "message": "KI-Aufräumen fehlgeschlagen. Versuchen Sie es später erneut."
+  },
+  "aiCleanupFound": {
+    "message": "KI schlägt {count} Tab(s) zum Schließen vor. Deaktivieren Sie die, die Sie behalten möchten."
+  },
+  "aiCleanupNeedsDownload": {
+    "message": "KI-Modell ist noch nicht heruntergeladen. Klicken Sie zuerst ✨ Smart Group, um den Download zu starten."
+  },
+  "aiCleanupSectionHeader": {
+    "message": "Tabs, die Sie schließen könnten"
+  },
+  "aiCleanupSelectAll": {
+    "message": "Alle auswählen"
+  },
+  "aiCleanupToggleLabel": {
+    "message": "🧹 Tab-Bereinigung-Schaltfläche anzeigen"
+  },
+  "bmToolsConfirmRemove": {
+    "message": "Ausgewählte entfernen"
+  },
+  "bmToolsConfirmRemoveMessage": {
+    "message": "{n} Lesezeichen entfernen? Dies kann nicht rückgängig gemacht werden."
+  },
+  "bmToolsConfirmRemoveTitle": {
+    "message": "Lesezeichen entfernen"
+  },
+  "bmToolsCreateTag": {
+    "message": "+ Neues Tag"
+  },
+  "bmToolsCreateTagPrompt": {
+    "message": "Neuer Tag-Name"
+  },
+  "bmToolsDeadLinksIntro": {
+    "message": "Scan versucht jedes http(s)-Lesezeichen via HEAD zu erreichen. Nur netzwerk-unerreichbare Links werden markiert (HTTP 404 kann ohne pro-Origin CORS nicht erkannt werden, siehe Notes)."
+  },
+  "bmToolsDeadLinksTab": {
+    "message": "Tote Links"
+  },
+  "bmToolsDeleteTagMessage": {
+    "message": "Tag \"{t}\" löschen? Lesezeichen werden nicht gelöscht, nur die Tag-Verknüpfung."
+  },
+  "bmToolsDeleteTagTitle": {
+    "message": "Tag löschen"
+  },
+  "bmToolsDuplicatesEmpty": {
+    "message": "Keine doppelten Lesezeichen. 🎉"
+  },
+  "bmToolsDuplicatesIntro": {
+    "message": "{n} Duplikat-Gruppen gefunden. Deaktivieren Sie das Exemplar, das Sie in jeder Gruppe behalten möchten."
+  },
+  "bmToolsDuplicatesTab": {
+    "message": "Duplikate"
+  },
+  "bmToolsKeepFirstNote": {
+    "message": "Hinweis: In Gruppen, in denen jedes Exemplar markiert ist, wird das erste automatisch behalten."
+  },
+  "bmToolsNetworkRatioWarning": {
+    "message": "{n} von {total} fehlgeschlagen ({pct}%) — ungewöhnlich hoch und sieht eher nach Netzwerkproblem als toten Links aus. Vor dem Entfernen sorgfältig prüfen."
+  },
+  "bmToolsNoBookmarks": {
+    "message": "Keine Lesezeichen zum Scannen."
+  },
+  "bmToolsOfflineWarning": {
+    "message": "Sie scheinen offline zu sein. Verbinden Sie sich mit dem Internet und versuchen Sie es erneut — ohne Netzwerk würde der Scan jedes Lesezeichen fälschlicherweise als unerreichbar markieren."
+  },
+  "bmToolsPrivacyNote": {
+    "message": "Hinweis: Scan sendet eine HEAD-Anfrage an den Host jedes Lesezeichens."
+  },
+  "bmToolsRemoveUnreachable": {
+    "message": "Markierte unerreichbare Lesezeichen entfernen"
+  },
+  "bmToolsScanDone": {
+    "message": "Scan abgeschlossen: {n} unerreichbare Link(s)."
+  },
+  "bmToolsScanProgress": {
+    "message": "Prüfung… {done}/{total}"
+  },
+  "bmToolsStartScan": {
+    "message": "Scan starten"
+  },
+  "bmToolsTagsEmpty": {
+    "message": "Noch keine Tags."
+  },
+  "bmToolsTagsTab": {
+    "message": "Tags"
+  },
+  "bmToolsTitle": {
+    "message": "Lesezeichen-Tools"
+  },
+  "cmdPaletteActionAiCleanup": {
+    "message": "AI Tab Cleanup"
+  },
+  "cmdPaletteActionAskAi": {
+    "message": "KI fragen: Tabs oder Lesezeichen finden"
+  },
+  "cmdPaletteActionBookmarkTools": {
+    "message": "Bookmark Tools öffnen"
+  },
+  "cmdPaletteActionCreateWorkspace": {
+    "message": "Workspace aus aktuellen Tabs erstellen"
+  },
+  "cmdPaletteActionManageWorkspaces": {
+    "message": "Workspaces verwalten"
+  },
+  "cmdPaletteActionNewTabRight": {
+    "message": "Neuer Tab rechts"
+  },
+  "cmdPaletteActionRefreshBookmarks": {
+    "message": "Lesezeichen aktualisieren"
+  },
+  "cmdPaletteActionSettings": {
+    "message": "Einstellungen öffnen"
+  },
+  "cmdPaletteActionSmartGroup": {
+    "message": "Alle Tabs Smart Group"
+  },
+  "cmdPaletteAriaLabel": {
+    "message": "Command Palette"
+  },
+  "cmdPaletteAskAiNoMatch": {
+    "message": "KI hat keine guten Übereinstimmungen gefunden."
+  },
+  "cmdPaletteAskAiResultsTitle": {
+    "message": "KI-Vorschläge"
+  },
+  "cmdPaletteAskAiThinking": {
+    "message": "KI wird gefragt…"
+  },
+  "cmdPaletteAskAiTitle": {
+    "message": "KI fragen: Tabs oder Lesezeichen finden"
+  },
+  "cmdPaletteAskAiUnavailable": {
+    "message": "KI-Modell ist noch nicht heruntergeladen. Lösen Sie zuerst ✨ Smart Group zum Herunterladen aus und versuchen Sie es erneut."
+  },
+  "cmdPaletteEmpty": {
+    "message": "Keine Ergebnisse"
+  },
+  "cmdPaletteGroupActions": {
+    "message": "Aktionen"
+  },
+  "cmdPaletteGroupBookmarks": {
+    "message": "Lesezeichen"
+  },
+  "cmdPaletteGroupReadingList": {
+    "message": "Leseliste"
+  },
+  "cmdPaletteGroupTabs": {
+    "message": "Tabs"
+  },
+  "cmdPaletteGroupWorkspaces": {
+    "message": "Workspaces"
+  },
+  "cmdPaletteHintClose": {
+    "message": "schließen"
+  },
+  "cmdPaletteHintNavigate": {
+    "message": "navigieren"
+  },
+  "cmdPaletteHintSelect": {
+    "message": "auswählen"
+  },
+  "cmdPalettePlaceholder": {
+    "message": "Tabs, Lesezeichen oder Aktionen suchen..."
+  },
+  "rlSummaryDescription": {
+    "message": "Wenn Sie eine Seite, die in einem Tab geöffnet ist, zu Ihrer Leseliste hinzufügen, fasst KI sie einmal zusammen und speichert das Ergebnis lokal, sodass Sie es später vorab anzeigen können — sogar offline. Erfordert, dass das Summarizer-Modell bereits verfügbar ist."
+  },
+  "rlSummaryToggleLabel": {
+    "message": "KI-Zusammenfassung für Leselisten-Elemente merken"
+  },
+  "shortcutDescCommandPalette": {
+    "message": "Command Palette öffnen"
+  },
+  "shortcutDescPaletteClose": {
+    "message": "Command Palette schließen"
+  },
+  "shortcutDescPaletteNav": {
+    "message": "Command Palette-Ergebnisse navigieren"
+  },
+  "shortcutDescPaletteSelect": {
+    "message": "Ausgewähltes Ergebnis aktivieren"
+  },
+  "shortcutInSidepanelHeader": {
+    "message": "Sidepanel-Shortcuts"
+  },
+  "shortcutInSidepanelNote": {
+    "message": "Diese laufen nur innerhalb des Sidepanels und können nicht über die Chrome-Shortcut-Seite neu zugewiesen werden."
+  },
+  "workspaceCreateFromCurrent": {
+    "message": "+ Aus aktuellen Tabs erstellen"
+  },
+  "workspaceCreatePromptTitle": {
+    "message": "Diesen Workspace benennen"
+  },
+  "workspaceDelete": {
+    "message": "Löschen"
+  },
+  "workspaceDeleteConfirmMessage": {
+    "message": "\"{ws}\" löschen? Dies kann nicht rückgängig gemacht werden."
+  },
+  "workspaceDeleteConfirmTitle": {
+    "message": "Workspace löschen"
+  },
+  "workspaceManageEmpty": {
+    "message": "Noch keine Workspaces."
+  },
+  "workspaceManageTitle": {
+    "message": "Workspaces verwalten"
+  },
+  "workspaceNoActive": {
+    "message": "— kein Workspace —"
+  },
+  "workspaceRename": {
+    "message": "Umbenennen"
+  },
+  "workspaceSwitchConfirmBtn": {
+    "message": "Wechseln"
+  },
+  "workspaceSwitchConfirmMessage": {
+    "message": "Zum Wechseln zu \"{ws}\" werden {n} Tab(s) in diesem Fenster geschlossen und die gespeicherten Tabs geöffnet."
+  },
+  "workspaceSwitchConfirmMessageUnbound": {
+    "message": "Zum Wechseln zu \"{ws}\" — Ihre aktuellen {n} Tab(s) sind noch in keinem Workspace. Sie werden vor dem Wechsel in einem neuen \"Untitled\" Workspace automatisch gespeichert."
+  },
+  "workspaceSwitchConfirmTitle": {
+    "message": "Workspace wechseln"
+  },
+  "workspaceSwitchFailedMessage": {
+    "message": "Workspace konnte nicht gewechselt werden. Ihre aktuellen Tabs wurden nicht geändert."
+  },
+  "workspaceSwitchFailedTitle": {
+    "message": "Wechsel fehlgeschlagen"
+  },
+  "workspaceSwitcherAriaLabel": {
+    "message": "Aktiver Workspace"
   }
 }

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -682,5 +682,266 @@
   },
   "aiSetupStep2b": {
     "message": "Activar entrada multimodal del Prompt API: abre el enlace y configúralo como \"Enabled\"."
+  },
+  "aiAutoNamingDescription": {
+    "message": "Cuando creas un nuevo grupo de pestañas sin título, la IA sugiere una etiqueta corta (Emoji + nombre). Solo funciona si el modelo local ya está descargado."
+  },
+  "aiAutoNamingToggleLabel": {
+    "message": "Nombrar automáticamente los grupos vacíos"
+  },
+  "aiCleanupAnalyzing": {
+    "message": "Analizando pestañas..."
+  },
+  "aiCleanupBtnText": {
+    "message": "🧹 Limpiar"
+  },
+  "aiCleanupBtnTitle": {
+    "message": "Limpieza de pestañas sugerida por IA"
+  },
+  "aiCleanupConfirm": {
+    "message": "Cerrar selección"
+  },
+  "aiCleanupDescription": {
+    "message": "Añade un botón junto a Smart Group que pregunta a la IA qué pestañas puedes cerrar."
+  },
+  "aiCleanupEmpty": {
+    "message": "Tus pestañas están ordenadas — nada que limpiar."
+  },
+  "aiCleanupError": {
+    "message": "La limpieza IA falló. Inténtalo más tarde."
+  },
+  "aiCleanupFound": {
+    "message": "La IA sugiere {count} pestaña(s) que puedes cerrar. Desmarca las que quieras conservar."
+  },
+  "aiCleanupNeedsDownload": {
+    "message": "El modelo IA aún no está descargado. Haz clic primero en ✨ Smart Group para iniciar la descarga."
+  },
+  "aiCleanupSectionHeader": {
+    "message": "Pestañas que podrías cerrar"
+  },
+  "aiCleanupSelectAll": {
+    "message": "Seleccionar todo"
+  },
+  "aiCleanupToggleLabel": {
+    "message": "Mostrar botón 🧹 Limpieza de pestañas"
+  },
+  "bmToolsConfirmRemove": {
+    "message": "Eliminar selección"
+  },
+  "bmToolsConfirmRemoveMessage": {
+    "message": "¿Eliminar {n} marcador(es)? Esta acción no se puede deshacer."
+  },
+  "bmToolsConfirmRemoveTitle": {
+    "message": "Eliminar marcadores"
+  },
+  "bmToolsCreateTag": {
+    "message": "+ Nueva etiqueta"
+  },
+  "bmToolsCreateTagPrompt": {
+    "message": "Nombre de la nueva etiqueta"
+  },
+  "bmToolsDeadLinksIntro": {
+    "message": "El escaneo intenta alcanzar cada marcador http(s) vía HEAD. Solo se marcan los enlaces inalcanzables por red (HTTP 404 no se puede detectar sin CORS por origen, ver notas)."
+  },
+  "bmToolsDeadLinksTab": {
+    "message": "Enlaces muertos"
+  },
+  "bmToolsDeleteTagMessage": {
+    "message": "¿Eliminar la etiqueta \"{t}\"? Los marcadores no se eliminarán, solo la vinculación."
+  },
+  "bmToolsDeleteTagTitle": {
+    "message": "Eliminar etiqueta"
+  },
+  "bmToolsDuplicatesEmpty": {
+    "message": "No hay marcadores duplicados. 🎉"
+  },
+  "bmToolsDuplicatesIntro": {
+    "message": "Encontrados {n} grupo(s) duplicados. Desmarca la copia que quieras conservar en cada grupo."
+  },
+  "bmToolsDuplicatesTab": {
+    "message": "Duplicados"
+  },
+  "bmToolsKeepFirstNote": {
+    "message": "Nota: en grupos donde todas las copias están marcadas, la primera se conserva automáticamente."
+  },
+  "bmToolsNetworkRatioWarning": {
+    "message": "{n} de {total} fallaron ({pct}%) — inusualmente alto y parece más un problema de red que enlaces muertos. Revisa cuidadosamente antes de eliminar."
+  },
+  "bmToolsNoBookmarks": {
+    "message": "No hay marcadores que escanear."
+  },
+  "bmToolsOfflineWarning": {
+    "message": "Pareces estar sin conexión. Conéctate a internet e inténtalo de nuevo — sin red, el escaneo marcaría erróneamente cada marcador como inalcanzable."
+  },
+  "bmToolsPrivacyNote": {
+    "message": "Nota: el escaneo envía una solicitud HEAD al host de cada marcador."
+  },
+  "bmToolsRemoveUnreachable": {
+    "message": "Eliminar marcadores inalcanzables marcados"
+  },
+  "bmToolsScanDone": {
+    "message": "Escaneo completado: {n} enlace(s) inalcanzable(s)."
+  },
+  "bmToolsScanProgress": {
+    "message": "Comprobando… {done}/{total}"
+  },
+  "bmToolsStartScan": {
+    "message": "Iniciar escaneo"
+  },
+  "bmToolsTagsEmpty": {
+    "message": "Aún no hay etiquetas."
+  },
+  "bmToolsTagsTab": {
+    "message": "Etiquetas"
+  },
+  "bmToolsTitle": {
+    "message": "Herramientas para marcadores"
+  },
+  "cmdPaletteActionAiCleanup": {
+    "message": "AI Tab Cleanup"
+  },
+  "cmdPaletteActionAskAi": {
+    "message": "Pedir a la IA que encuentre pestañas o marcadores"
+  },
+  "cmdPaletteActionBookmarkTools": {
+    "message": "Abrir Bookmark Tools"
+  },
+  "cmdPaletteActionCreateWorkspace": {
+    "message": "Crear Workspace desde las pestañas actuales"
+  },
+  "cmdPaletteActionManageWorkspaces": {
+    "message": "Gestionar Workspaces"
+  },
+  "cmdPaletteActionNewTabRight": {
+    "message": "Nueva pestaña a la derecha"
+  },
+  "cmdPaletteActionRefreshBookmarks": {
+    "message": "Actualizar marcadores"
+  },
+  "cmdPaletteActionSettings": {
+    "message": "Abrir configuración"
+  },
+  "cmdPaletteActionSmartGroup": {
+    "message": "Smart Group todas las pestañas"
+  },
+  "cmdPaletteAriaLabel": {
+    "message": "Paleta de comandos"
+  },
+  "cmdPaletteAskAiNoMatch": {
+    "message": "La IA no encontró buenas coincidencias."
+  },
+  "cmdPaletteAskAiResultsTitle": {
+    "message": "Sugerencias de IA"
+  },
+  "cmdPaletteAskAiThinking": {
+    "message": "Preguntando a la IA…"
+  },
+  "cmdPaletteAskAiTitle": {
+    "message": "Pedir a la IA: encontrar pestañas o marcadores"
+  },
+  "cmdPaletteAskAiUnavailable": {
+    "message": "El modelo IA aún no está descargado. Activa primero ✨ Smart Group para descargar y luego vuelve a intentarlo."
+  },
+  "cmdPaletteEmpty": {
+    "message": "Sin resultados"
+  },
+  "cmdPaletteGroupActions": {
+    "message": "Acciones"
+  },
+  "cmdPaletteGroupBookmarks": {
+    "message": "Marcadores"
+  },
+  "cmdPaletteGroupReadingList": {
+    "message": "Lista de lectura"
+  },
+  "cmdPaletteGroupTabs": {
+    "message": "Pestañas"
+  },
+  "cmdPaletteGroupWorkspaces": {
+    "message": "Workspaces"
+  },
+  "cmdPaletteHintClose": {
+    "message": "cerrar"
+  },
+  "cmdPaletteHintNavigate": {
+    "message": "navegar"
+  },
+  "cmdPaletteHintSelect": {
+    "message": "seleccionar"
+  },
+  "cmdPalettePlaceholder": {
+    "message": "Buscar pestañas, marcadores o acciones..."
+  },
+  "rlSummaryDescription": {
+    "message": "Cuando añades a tu lista de lectura una página abierta en una pestaña, la IA la resume una vez y guarda el resultado localmente para que puedas previsualizarlo más tarde — incluso sin conexión. Requiere que el modelo Summarizer ya esté disponible."
+  },
+  "rlSummaryToggleLabel": {
+    "message": "Recordar el resumen IA para los elementos de la lista de lectura"
+  },
+  "shortcutDescCommandPalette": {
+    "message": "Abrir la paleta de comandos"
+  },
+  "shortcutDescPaletteClose": {
+    "message": "Cerrar la paleta de comandos"
+  },
+  "shortcutDescPaletteNav": {
+    "message": "Navegar por los resultados de la paleta"
+  },
+  "shortcutDescPaletteSelect": {
+    "message": "Activar el resultado seleccionado"
+  },
+  "shortcutInSidepanelHeader": {
+    "message": "Atajos del panel lateral"
+  },
+  "shortcutInSidepanelNote": {
+    "message": "Estos solo funcionan dentro del panel lateral y no se pueden reasignar a través de la página de atajos de Chrome."
+  },
+  "workspaceCreateFromCurrent": {
+    "message": "+ Crear desde pestañas actuales"
+  },
+  "workspaceCreatePromptTitle": {
+    "message": "Nombrar este Workspace"
+  },
+  "workspaceDelete": {
+    "message": "Eliminar"
+  },
+  "workspaceDeleteConfirmMessage": {
+    "message": "¿Eliminar \"{ws}\"? Esta acción no se puede deshacer."
+  },
+  "workspaceDeleteConfirmTitle": {
+    "message": "Eliminar Workspace"
+  },
+  "workspaceManageEmpty": {
+    "message": "Aún no hay Workspaces."
+  },
+  "workspaceManageTitle": {
+    "message": "Gestionar Workspaces"
+  },
+  "workspaceNoActive": {
+    "message": "— sin Workspace —"
+  },
+  "workspaceRename": {
+    "message": "Renombrar"
+  },
+  "workspaceSwitchConfirmBtn": {
+    "message": "Cambiar"
+  },
+  "workspaceSwitchConfirmMessage": {
+    "message": "Cambiar a \"{ws}\" cerrará {n} pestaña(s) en esta ventana y abrirá las pestañas guardadas."
+  },
+  "workspaceSwitchConfirmMessageUnbound": {
+    "message": "Cambiar a \"{ws}\" — tus {n} pestaña(s) actuales no están en ningún Workspace. Se guardarán automáticamente en un nuevo Workspace \"Untitled\" antes del cambio."
+  },
+  "workspaceSwitchConfirmTitle": {
+    "message": "Cambiar de Workspace"
+  },
+  "workspaceSwitchFailedMessage": {
+    "message": "No se pudo cambiar de Workspace. Tus pestañas actuales no fueron modificadas."
+  },
+  "workspaceSwitchFailedTitle": {
+    "message": "Cambio fallido"
+  },
+  "workspaceSwitcherAriaLabel": {
+    "message": "Workspace activo"
   }
 }

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -682,5 +682,266 @@
   },
   "aiSetupStep2b": {
     "message": "Activer l'entrée multimodale du Prompt API : ouvrez le lien et définissez sur \"Enabled\"."
+  },
+  "aiAutoNamingDescription": {
+    "message": "Lorsque vous créez un nouveau groupe d'onglets sans titre, l'IA suggère une étiquette courte (Emoji + nom). Fonctionne uniquement si le modèle local est déjà téléchargé."
+  },
+  "aiAutoNamingToggleLabel": {
+    "message": "Nommer automatiquement les groupes d'onglets vides"
+  },
+  "aiCleanupAnalyzing": {
+    "message": "Analyse des onglets..."
+  },
+  "aiCleanupBtnText": {
+    "message": "🧹 Nettoyer"
+  },
+  "aiCleanupBtnTitle": {
+    "message": "Nettoyage d'onglets suggéré par IA"
+  },
+  "aiCleanupConfirm": {
+    "message": "Fermer la sélection"
+  },
+  "aiCleanupDescription": {
+    "message": "Ajoute un bouton à côté de Smart Group qui demande à l'IA quels onglets vous pouvez fermer."
+  },
+  "aiCleanupEmpty": {
+    "message": "Vos onglets sont bien rangés — rien à nettoyer."
+  },
+  "aiCleanupError": {
+    "message": "Le nettoyage IA a échoué. Réessayez plus tard."
+  },
+  "aiCleanupFound": {
+    "message": "L'IA suggère {count} onglet(s) que vous pouvez fermer. Décochez ceux que vous voulez garder."
+  },
+  "aiCleanupNeedsDownload": {
+    "message": "Le modèle IA n'est pas encore téléchargé. Cliquez d'abord sur ✨ Smart Group pour démarrer le téléchargement."
+  },
+  "aiCleanupSectionHeader": {
+    "message": "Onglets que vous pourriez fermer"
+  },
+  "aiCleanupSelectAll": {
+    "message": "Tout sélectionner"
+  },
+  "aiCleanupToggleLabel": {
+    "message": "Afficher le bouton 🧹 Nettoyage d'onglets"
+  },
+  "bmToolsConfirmRemove": {
+    "message": "Supprimer la sélection"
+  },
+  "bmToolsConfirmRemoveMessage": {
+    "message": "Supprimer {n} signet(s) ? Cette action ne peut pas être annulée."
+  },
+  "bmToolsConfirmRemoveTitle": {
+    "message": "Supprimer les signets"
+  },
+  "bmToolsCreateTag": {
+    "message": "+ Nouvelle étiquette"
+  },
+  "bmToolsCreateTagPrompt": {
+    "message": "Nom de la nouvelle étiquette"
+  },
+  "bmToolsDeadLinksIntro": {
+    "message": "Le scan tente d'atteindre chaque signet http(s) via HEAD. Seuls les liens inaccessibles via le réseau sont signalés (HTTP 404 ne peut pas être détecté sans CORS par origine, voir notes)."
+  },
+  "bmToolsDeadLinksTab": {
+    "message": "Liens morts"
+  },
+  "bmToolsDeleteTagMessage": {
+    "message": "Supprimer l'étiquette \"{t}\" ? Les signets ne seront pas supprimés, seule la liaison d'étiquette."
+  },
+  "bmToolsDeleteTagTitle": {
+    "message": "Supprimer l'étiquette"
+  },
+  "bmToolsDuplicatesEmpty": {
+    "message": "Aucun signet en double. 🎉"
+  },
+  "bmToolsDuplicatesIntro": {
+    "message": "Trouvé {n} groupe(s) de doublons. Décochez la copie que vous voulez garder dans chaque groupe."
+  },
+  "bmToolsDuplicatesTab": {
+    "message": "Doublons"
+  },
+  "bmToolsKeepFirstNote": {
+    "message": "Note : dans les groupes où chaque copie est cochée, la première est automatiquement gardée."
+  },
+  "bmToolsNetworkRatioWarning": {
+    "message": "{n} sur {total} échoués ({pct}%) — anormalement élevé et ressemble plus à un problème de réseau que des liens morts. Vérifiez attentivement avant de supprimer."
+  },
+  "bmToolsNoBookmarks": {
+    "message": "Aucun signet à scanner."
+  },
+  "bmToolsOfflineWarning": {
+    "message": "Vous semblez être hors ligne. Connectez-vous à internet et réessayez — sans réseau, le scan marquerait à tort chaque signet comme inaccessible."
+  },
+  "bmToolsPrivacyNote": {
+    "message": "Note : le scan envoie une requête HEAD à l'hôte de chaque signet."
+  },
+  "bmToolsRemoveUnreachable": {
+    "message": "Supprimer les signets inaccessibles cochés"
+  },
+  "bmToolsScanDone": {
+    "message": "Scan terminé : {n} lien(s) inaccessible(s)."
+  },
+  "bmToolsScanProgress": {
+    "message": "Vérification… {done}/{total}"
+  },
+  "bmToolsStartScan": {
+    "message": "Démarrer le scan"
+  },
+  "bmToolsTagsEmpty": {
+    "message": "Pas encore d'étiquettes."
+  },
+  "bmToolsTagsTab": {
+    "message": "Étiquettes"
+  },
+  "bmToolsTitle": {
+    "message": "Outils pour signets"
+  },
+  "cmdPaletteActionAiCleanup": {
+    "message": "AI Tab Cleanup"
+  },
+  "cmdPaletteActionAskAi": {
+    "message": "Demander à l'IA de trouver des onglets ou signets"
+  },
+  "cmdPaletteActionBookmarkTools": {
+    "message": "Ouvrir Bookmark Tools"
+  },
+  "cmdPaletteActionCreateWorkspace": {
+    "message": "Créer un Workspace à partir des onglets actuels"
+  },
+  "cmdPaletteActionManageWorkspaces": {
+    "message": "Gérer les Workspaces"
+  },
+  "cmdPaletteActionNewTabRight": {
+    "message": "Nouvel onglet à droite"
+  },
+  "cmdPaletteActionRefreshBookmarks": {
+    "message": "Rafraîchir les signets"
+  },
+  "cmdPaletteActionSettings": {
+    "message": "Ouvrir les paramètres"
+  },
+  "cmdPaletteActionSmartGroup": {
+    "message": "Smart Group tous les onglets"
+  },
+  "cmdPaletteAriaLabel": {
+    "message": "Palette de commandes"
+  },
+  "cmdPaletteAskAiNoMatch": {
+    "message": "L'IA n'a pas trouvé de bonnes correspondances."
+  },
+  "cmdPaletteAskAiResultsTitle": {
+    "message": "Suggestions de l'IA"
+  },
+  "cmdPaletteAskAiThinking": {
+    "message": "Interrogation de l'IA…"
+  },
+  "cmdPaletteAskAiTitle": {
+    "message": "Demander à l'IA : trouver des onglets ou signets"
+  },
+  "cmdPaletteAskAiUnavailable": {
+    "message": "Le modèle IA n'est pas encore téléchargé. Déclenchez d'abord ✨ Smart Group pour télécharger, puis réessayez."
+  },
+  "cmdPaletteEmpty": {
+    "message": "Aucun résultat"
+  },
+  "cmdPaletteGroupActions": {
+    "message": "Actions"
+  },
+  "cmdPaletteGroupBookmarks": {
+    "message": "Signets"
+  },
+  "cmdPaletteGroupReadingList": {
+    "message": "Liste de lecture"
+  },
+  "cmdPaletteGroupTabs": {
+    "message": "Onglets"
+  },
+  "cmdPaletteGroupWorkspaces": {
+    "message": "Workspaces"
+  },
+  "cmdPaletteHintClose": {
+    "message": "fermer"
+  },
+  "cmdPaletteHintNavigate": {
+    "message": "naviguer"
+  },
+  "cmdPaletteHintSelect": {
+    "message": "sélectionner"
+  },
+  "cmdPalettePlaceholder": {
+    "message": "Rechercher onglets, signets ou actions..."
+  },
+  "rlSummaryDescription": {
+    "message": "Lorsque vous ajoutez à votre liste de lecture une page ouverte dans un onglet, l'IA la résume une fois et stocke le résultat localement afin que vous puissiez la prévisualiser plus tard — même hors ligne. Requiert que le modèle Summarizer soit déjà disponible."
+  },
+  "rlSummaryToggleLabel": {
+    "message": "Mémoriser le résumé IA pour les éléments de la liste de lecture"
+  },
+  "shortcutDescCommandPalette": {
+    "message": "Ouvrir la palette de commandes"
+  },
+  "shortcutDescPaletteClose": {
+    "message": "Fermer la palette de commandes"
+  },
+  "shortcutDescPaletteNav": {
+    "message": "Naviguer dans les résultats de la palette"
+  },
+  "shortcutDescPaletteSelect": {
+    "message": "Activer le résultat sélectionné"
+  },
+  "shortcutInSidepanelHeader": {
+    "message": "Raccourcis du panneau latéral"
+  },
+  "shortcutInSidepanelNote": {
+    "message": "Ces raccourcis ne fonctionnent que dans le panneau latéral et ne peuvent pas être remappés via la page des raccourcis Chrome."
+  },
+  "workspaceCreateFromCurrent": {
+    "message": "+ Créer à partir des onglets actuels"
+  },
+  "workspaceCreatePromptTitle": {
+    "message": "Nommer ce Workspace"
+  },
+  "workspaceDelete": {
+    "message": "Supprimer"
+  },
+  "workspaceDeleteConfirmMessage": {
+    "message": "Supprimer \"{ws}\" ? Cette action ne peut pas être annulée."
+  },
+  "workspaceDeleteConfirmTitle": {
+    "message": "Supprimer le Workspace"
+  },
+  "workspaceManageEmpty": {
+    "message": "Pas encore de Workspaces."
+  },
+  "workspaceManageTitle": {
+    "message": "Gérer les Workspaces"
+  },
+  "workspaceNoActive": {
+    "message": "— aucun Workspace —"
+  },
+  "workspaceRename": {
+    "message": "Renommer"
+  },
+  "workspaceSwitchConfirmBtn": {
+    "message": "Changer"
+  },
+  "workspaceSwitchConfirmMessage": {
+    "message": "Changer pour \"{ws}\" fermera {n} onglet(s) dans cette fenêtre et ouvrira les onglets enregistrés."
+  },
+  "workspaceSwitchConfirmMessageUnbound": {
+    "message": "Changer pour \"{ws}\" — vos {n} onglet(s) actuels ne sont dans aucun Workspace. Ils seront auto-enregistrés dans un nouveau Workspace \"Untitled\" avant le changement."
+  },
+  "workspaceSwitchConfirmTitle": {
+    "message": "Changer de Workspace"
+  },
+  "workspaceSwitchFailedMessage": {
+    "message": "Impossible de changer de Workspace. Vos onglets actuels n'ont pas été modifiés."
+  },
+  "workspaceSwitchFailedTitle": {
+    "message": "Changement échoué"
+  },
+  "workspaceSwitcherAriaLabel": {
+    "message": "Workspace actif"
   }
 }

--- a/_locales/hi/messages.json
+++ b/_locales/hi/messages.json
@@ -682,5 +682,266 @@
   },
   "aiSetupStep2b": {
     "message": "Prompt API मल्टीमोडल इनपुट सक्षम करें: लिंक खोलें और \"Enabled\" पर सेट करें।"
+  },
+  "aiAutoNamingDescription": {
+    "message": "जब आप बिना title के नया tab group बनाते हैं, AI एक छोटा label (Emoji + name) सुझाता है। केवल तब काम करता है जब local model पहले से download हो।"
+  },
+  "aiAutoNamingToggleLabel": {
+    "message": "खाली tab groups को अपने आप name दें"
+  },
+  "aiCleanupAnalyzing": {
+    "message": "Tabs analyze हो रहे हैं..."
+  },
+  "aiCleanupBtnText": {
+    "message": "🧹 Cleanup"
+  },
+  "aiCleanupBtnTitle": {
+    "message": "AI द्वारा सुझाया Tab Cleanup"
+  },
+  "aiCleanupConfirm": {
+    "message": "चुने हुए बंद करें"
+  },
+  "aiCleanupDescription": {
+    "message": "Smart Group के बगल में एक button जोड़ता है जो AI से पूछता है कि कौन से tabs आप बंद कर सकते हैं।"
+  },
+  "aiCleanupEmpty": {
+    "message": "आपके tabs व्यवस्थित हैं — कुछ cleanup करने को नहीं।"
+  },
+  "aiCleanupError": {
+    "message": "AI cleanup विफल। बाद में फिर कोशिश करें।"
+  },
+  "aiCleanupFound": {
+    "message": "AI {count} tab(s) बंद करने का सुझाव देता है। जिन्हें रखना है उनसे tick हटा दें।"
+  },
+  "aiCleanupNeedsDownload": {
+    "message": "AI model अभी download नहीं हुआ है। पहले ✨ Smart Group click करें download शुरू करने के लिए।"
+  },
+  "aiCleanupSectionHeader": {
+    "message": "जिन Tabs को आप बंद कर सकते हैं"
+  },
+  "aiCleanupSelectAll": {
+    "message": "सभी चुनें"
+  },
+  "aiCleanupToggleLabel": {
+    "message": "🧹 Tab Cleanup button दिखाएं"
+  },
+  "bmToolsConfirmRemove": {
+    "message": "चुने हुए हटाएं"
+  },
+  "bmToolsConfirmRemoveMessage": {
+    "message": "{n} bookmark(s) हटाएं? इसे वापस नहीं किया जा सकता।"
+  },
+  "bmToolsConfirmRemoveTitle": {
+    "message": "Bookmarks हटाएं"
+  },
+  "bmToolsCreateTag": {
+    "message": "+ नया tag"
+  },
+  "bmToolsCreateTagPrompt": {
+    "message": "नए tag का नाम"
+  },
+  "bmToolsDeadLinksIntro": {
+    "message": "Scan HEAD से हर http(s) bookmark तक पहुंचने की कोशिश करता है। केवल network-unreachable links flag होते हैं (HTTP 404 per-origin CORS के बिना detect नहीं हो सकता, notes देखें)।"
+  },
+  "bmToolsDeadLinksTab": {
+    "message": "Dead Links"
+  },
+  "bmToolsDeleteTagMessage": {
+    "message": "Tag \"{t}\" delete करें? Bookmarks नहीं delete होंगे, केवल tag binding।"
+  },
+  "bmToolsDeleteTagTitle": {
+    "message": "Tag delete करें"
+  },
+  "bmToolsDuplicatesEmpty": {
+    "message": "कोई duplicate bookmarks नहीं। 🎉"
+  },
+  "bmToolsDuplicatesIntro": {
+    "message": "{n} duplicate group(s) मिले। हर group में जिस copy को रखना है उससे tick हटा दें।"
+  },
+  "bmToolsDuplicatesTab": {
+    "message": "Duplicates"
+  },
+  "bmToolsKeepFirstNote": {
+    "message": "Note: groups में जहां सभी copies checked हैं, पहली copy अपने आप रखी जाती है।"
+  },
+  "bmToolsNetworkRatioWarning": {
+    "message": "{n} में से {total} fail हुए ({pct}%) — असामान्य रूप से ज्यादा और network problem जैसा लगता है dead links से अधिक। हटाने से पहले ध्यान से check करें।"
+  },
+  "bmToolsNoBookmarks": {
+    "message": "Scan करने को bookmarks नहीं।"
+  },
+  "bmToolsOfflineWarning": {
+    "message": "आप offline लगते हैं। Internet से connect करें और फिर try करें — network के बिना scan हर bookmark को unreachable के रूप में गलत flag करेगा।"
+  },
+  "bmToolsPrivacyNote": {
+    "message": "Note: scan हर bookmark के host को HEAD request भेजता है।"
+  },
+  "bmToolsRemoveUnreachable": {
+    "message": "Checked unreachable bookmarks हटाएं"
+  },
+  "bmToolsScanDone": {
+    "message": "Scan पूरा: {n} unreachable link(s)।"
+  },
+  "bmToolsScanProgress": {
+    "message": "Check हो रहा है… {done}/{total}"
+  },
+  "bmToolsStartScan": {
+    "message": "Scan शुरू करें"
+  },
+  "bmToolsTagsEmpty": {
+    "message": "अभी कोई tags नहीं।"
+  },
+  "bmToolsTagsTab": {
+    "message": "Tags"
+  },
+  "bmToolsTitle": {
+    "message": "Bookmark Tools"
+  },
+  "cmdPaletteActionAiCleanup": {
+    "message": "AI Tab Cleanup"
+  },
+  "cmdPaletteActionAskAi": {
+    "message": "AI से tabs या bookmarks ढूंढने को कहें"
+  },
+  "cmdPaletteActionBookmarkTools": {
+    "message": "Bookmark Tools खोलें"
+  },
+  "cmdPaletteActionCreateWorkspace": {
+    "message": "मौजूदा tabs से Workspace बनाएं"
+  },
+  "cmdPaletteActionManageWorkspaces": {
+    "message": "Workspaces manage करें"
+  },
+  "cmdPaletteActionNewTabRight": {
+    "message": "दाहिनी तरफ नया tab"
+  },
+  "cmdPaletteActionRefreshBookmarks": {
+    "message": "Bookmarks refresh करें"
+  },
+  "cmdPaletteActionSettings": {
+    "message": "Settings खोलें"
+  },
+  "cmdPaletteActionSmartGroup": {
+    "message": "सभी tabs Smart Group"
+  },
+  "cmdPaletteAriaLabel": {
+    "message": "Command Palette"
+  },
+  "cmdPaletteAskAiNoMatch": {
+    "message": "AI को अच्छा match नहीं मिला।"
+  },
+  "cmdPaletteAskAiResultsTitle": {
+    "message": "AI सुझाव"
+  },
+  "cmdPaletteAskAiThinking": {
+    "message": "AI से पूछ रहे हैं…"
+  },
+  "cmdPaletteAskAiTitle": {
+    "message": "AI से पूछें: tabs या bookmarks ढूंढें"
+  },
+  "cmdPaletteAskAiUnavailable": {
+    "message": "AI model अभी download नहीं हुआ है। पहले ✨ Smart Group से download trigger करें, फिर try करें।"
+  },
+  "cmdPaletteEmpty": {
+    "message": "कोई results नहीं"
+  },
+  "cmdPaletteGroupActions": {
+    "message": "Actions"
+  },
+  "cmdPaletteGroupBookmarks": {
+    "message": "Bookmarks"
+  },
+  "cmdPaletteGroupReadingList": {
+    "message": "Reading List"
+  },
+  "cmdPaletteGroupTabs": {
+    "message": "Tabs"
+  },
+  "cmdPaletteGroupWorkspaces": {
+    "message": "Workspaces"
+  },
+  "cmdPaletteHintClose": {
+    "message": "बंद करें"
+  },
+  "cmdPaletteHintNavigate": {
+    "message": "navigate"
+  },
+  "cmdPaletteHintSelect": {
+    "message": "चुनें"
+  },
+  "cmdPalettePlaceholder": {
+    "message": "Tabs, bookmarks या actions search करें..."
+  },
+  "rlSummaryDescription": {
+    "message": "जब आप एक page जो tab में खुला है उसे Reading List में add करते हैं, AI एक बार summarize करता है और result locally store करता है ताकि आप बाद में preview कर सकें — offline भी। Summarizer model का पहले से available होना जरूरी है।"
+  },
+  "rlSummaryToggleLabel": {
+    "message": "Reading List items के लिए AI summary याद रखें"
+  },
+  "shortcutDescCommandPalette": {
+    "message": "Command Palette खोलें"
+  },
+  "shortcutDescPaletteClose": {
+    "message": "Command Palette बंद करें"
+  },
+  "shortcutDescPaletteNav": {
+    "message": "Command Palette results navigate करें"
+  },
+  "shortcutDescPaletteSelect": {
+    "message": "चुने हुए result को activate करें"
+  },
+  "shortcutInSidepanelHeader": {
+    "message": "Sidepanel के अंदर के shortcuts"
+  },
+  "shortcutInSidepanelNote": {
+    "message": "ये केवल sidepanel के अंदर काम करते हैं और Chrome shortcuts page से remap नहीं किए जा सकते।"
+  },
+  "workspaceCreateFromCurrent": {
+    "message": "+ मौजूदा tabs से बनाएं"
+  },
+  "workspaceCreatePromptTitle": {
+    "message": "इस Workspace का नाम रखें"
+  },
+  "workspaceDelete": {
+    "message": "Delete"
+  },
+  "workspaceDeleteConfirmMessage": {
+    "message": "\"{ws}\" delete करें? इसे वापस नहीं किया जा सकता।"
+  },
+  "workspaceDeleteConfirmTitle": {
+    "message": "Workspace delete करें"
+  },
+  "workspaceManageEmpty": {
+    "message": "अभी कोई Workspaces नहीं।"
+  },
+  "workspaceManageTitle": {
+    "message": "Workspaces manage करें"
+  },
+  "workspaceNoActive": {
+    "message": "— कोई Workspace नहीं —"
+  },
+  "workspaceRename": {
+    "message": "Rename"
+  },
+  "workspaceSwitchConfirmBtn": {
+    "message": "Switch"
+  },
+  "workspaceSwitchConfirmMessage": {
+    "message": "\"{ws}\" पर switch करने से इस window के मौजूदा {n} tab(s) बंद होंगे और save किए हुए tabs खुलेंगे।"
+  },
+  "workspaceSwitchConfirmMessageUnbound": {
+    "message": "\"{ws}\" पर switch — आपके मौजूदा {n} tab(s) किसी Workspace में नहीं हैं। Switch से पहले एक नए \"Untitled\" Workspace में auto-save हो जाएंगे।"
+  },
+  "workspaceSwitchConfirmTitle": {
+    "message": "Workspace switch करें"
+  },
+  "workspaceSwitchFailedMessage": {
+    "message": "Workspace switch नहीं हो सका। आपके मौजूदा tabs में बदलाव नहीं हुआ।"
+  },
+  "workspaceSwitchFailedTitle": {
+    "message": "Switch fail"
+  },
+  "workspaceSwitcherAriaLabel": {
+    "message": "सक्रिय Workspace"
   }
 }

--- a/_locales/id/messages.json
+++ b/_locales/id/messages.json
@@ -682,5 +682,266 @@
   },
   "aiSetupStep2b": {
     "message": "Aktifkan input multimodal Prompt API: buka tautan dan atur ke \"Enabled\"."
+  },
+  "aiAutoNamingDescription": {
+    "message": "Saat Anda membuat tab group baru tanpa judul, AI menyarankan label pendek (Emoji + nama). Hanya berjalan jika model lokal sudah diunduh."
+  },
+  "aiAutoNamingToggleLabel": {
+    "message": "Beri nama otomatis tab group kosong"
+  },
+  "aiCleanupAnalyzing": {
+    "message": "Menganalisis tab..."
+  },
+  "aiCleanupBtnText": {
+    "message": "🧹 Cleanup"
+  },
+  "aiCleanupBtnTitle": {
+    "message": "Tab cleanup yang disarankan AI"
+  },
+  "aiCleanupConfirm": {
+    "message": "Tutup yang dipilih"
+  },
+  "aiCleanupDescription": {
+    "message": "Menambahkan tombol di sebelah Smart Group yang bertanya pada AI tab mana yang bisa Anda tutup."
+  },
+  "aiCleanupEmpty": {
+    "message": "Tab Anda rapi — tidak ada yang perlu dibersihkan."
+  },
+  "aiCleanupError": {
+    "message": "Cleanup AI gagal. Coba lagi nanti."
+  },
+  "aiCleanupFound": {
+    "message": "AI menyarankan {count} tab yang mungkin bisa Anda tutup. Hapus centang yang ingin Anda simpan."
+  },
+  "aiCleanupNeedsDownload": {
+    "message": "Model AI belum diunduh. Klik ✨ Smart Group terlebih dahulu untuk memulai unduhan."
+  },
+  "aiCleanupSectionHeader": {
+    "message": "Tab yang mungkin bisa ditutup"
+  },
+  "aiCleanupSelectAll": {
+    "message": "Pilih semua"
+  },
+  "aiCleanupToggleLabel": {
+    "message": "Tampilkan tombol 🧹 Tab Cleanup"
+  },
+  "bmToolsConfirmRemove": {
+    "message": "Hapus pilihan"
+  },
+  "bmToolsConfirmRemoveMessage": {
+    "message": "Hapus {n} bookmark? Aksi ini tidak bisa dibatalkan."
+  },
+  "bmToolsConfirmRemoveTitle": {
+    "message": "Hapus bookmark"
+  },
+  "bmToolsCreateTag": {
+    "message": "+ Tag baru"
+  },
+  "bmToolsCreateTagPrompt": {
+    "message": "Nama tag baru"
+  },
+  "bmToolsDeadLinksIntro": {
+    "message": "Scan mencoba menjangkau setiap bookmark http(s) via HEAD. Hanya link yang tidak terjangkau jaringan yang ditandai (HTTP 404 tidak dapat dideteksi tanpa per-origin CORS, lihat notes)."
+  },
+  "bmToolsDeadLinksTab": {
+    "message": "Dead Links"
+  },
+  "bmToolsDeleteTagMessage": {
+    "message": "Hapus tag \"{t}\"? Bookmark tidak akan dihapus, hanya binding tag."
+  },
+  "bmToolsDeleteTagTitle": {
+    "message": "Hapus tag"
+  },
+  "bmToolsDuplicatesEmpty": {
+    "message": "Tidak ada bookmark duplikat. 🎉"
+  },
+  "bmToolsDuplicatesIntro": {
+    "message": "Ditemukan {n} grup duplikat. Hapus centang salinan yang ingin Anda simpan di setiap grup."
+  },
+  "bmToolsDuplicatesTab": {
+    "message": "Duplikat"
+  },
+  "bmToolsKeepFirstNote": {
+    "message": "Catatan: di grup di mana setiap salinan dicentang, yang pertama disimpan otomatis."
+  },
+  "bmToolsNetworkRatioWarning": {
+    "message": "{n} dari {total} gagal ({pct}%) — sangat tinggi dan lebih terlihat seperti masalah jaringan daripada dead link. Tinjau dengan hati-hati sebelum menghapus."
+  },
+  "bmToolsNoBookmarks": {
+    "message": "Tidak ada bookmark untuk discan."
+  },
+  "bmToolsOfflineWarning": {
+    "message": "Anda tampaknya offline. Hubungkan ke internet dan coba lagi — tanpa jaringan, scan akan salah menandai setiap bookmark sebagai unreachable."
+  },
+  "bmToolsPrivacyNote": {
+    "message": "Catatan: scan mengirim HEAD request ke host setiap bookmark."
+  },
+  "bmToolsRemoveUnreachable": {
+    "message": "Hapus bookmark unreachable yang dicentang"
+  },
+  "bmToolsScanDone": {
+    "message": "Scan selesai: {n} link unreachable."
+  },
+  "bmToolsScanProgress": {
+    "message": "Memeriksa… {done}/{total}"
+  },
+  "bmToolsStartScan": {
+    "message": "Mulai scan"
+  },
+  "bmToolsTagsEmpty": {
+    "message": "Belum ada tag."
+  },
+  "bmToolsTagsTab": {
+    "message": "Tags"
+  },
+  "bmToolsTitle": {
+    "message": "Bookmark Tools"
+  },
+  "cmdPaletteActionAiCleanup": {
+    "message": "AI Tab Cleanup"
+  },
+  "cmdPaletteActionAskAi": {
+    "message": "Minta AI mencari tab atau bookmark"
+  },
+  "cmdPaletteActionBookmarkTools": {
+    "message": "Buka Bookmark Tools"
+  },
+  "cmdPaletteActionCreateWorkspace": {
+    "message": "Buat Workspace dari tab saat ini"
+  },
+  "cmdPaletteActionManageWorkspaces": {
+    "message": "Kelola Workspaces"
+  },
+  "cmdPaletteActionNewTabRight": {
+    "message": "Tab baru di kanan"
+  },
+  "cmdPaletteActionRefreshBookmarks": {
+    "message": "Refresh bookmark"
+  },
+  "cmdPaletteActionSettings": {
+    "message": "Buka pengaturan"
+  },
+  "cmdPaletteActionSmartGroup": {
+    "message": "Smart Group semua tab"
+  },
+  "cmdPaletteAriaLabel": {
+    "message": "Command Palette"
+  },
+  "cmdPaletteAskAiNoMatch": {
+    "message": "AI tidak menemukan kecocokan yang baik."
+  },
+  "cmdPaletteAskAiResultsTitle": {
+    "message": "Saran AI"
+  },
+  "cmdPaletteAskAiThinking": {
+    "message": "Bertanya pada AI…"
+  },
+  "cmdPaletteAskAiTitle": {
+    "message": "Minta AI: temukan tab atau bookmark"
+  },
+  "cmdPaletteAskAiUnavailable": {
+    "message": "Model AI belum diunduh. Picu ✨ Smart Group terlebih dahulu untuk mengunduh, lalu coba lagi."
+  },
+  "cmdPaletteEmpty": {
+    "message": "Tidak ada hasil"
+  },
+  "cmdPaletteGroupActions": {
+    "message": "Aksi"
+  },
+  "cmdPaletteGroupBookmarks": {
+    "message": "Bookmarks"
+  },
+  "cmdPaletteGroupReadingList": {
+    "message": "Reading List"
+  },
+  "cmdPaletteGroupTabs": {
+    "message": "Tabs"
+  },
+  "cmdPaletteGroupWorkspaces": {
+    "message": "Workspaces"
+  },
+  "cmdPaletteHintClose": {
+    "message": "tutup"
+  },
+  "cmdPaletteHintNavigate": {
+    "message": "navigasi"
+  },
+  "cmdPaletteHintSelect": {
+    "message": "pilih"
+  },
+  "cmdPalettePlaceholder": {
+    "message": "Cari tabs, bookmarks atau aksi..."
+  },
+  "rlSummaryDescription": {
+    "message": "Saat Anda menambahkan halaman yang terbuka di tab ke Reading List, AI meringkasnya sekali dan menyimpan hasil secara lokal sehingga Anda bisa pratinjau nanti — bahkan offline. Membutuhkan model Summarizer sudah tersedia."
+  },
+  "rlSummaryToggleLabel": {
+    "message": "Ingat ringkasan AI untuk item Reading List"
+  },
+  "shortcutDescCommandPalette": {
+    "message": "Buka Command Palette"
+  },
+  "shortcutDescPaletteClose": {
+    "message": "Tutup Command Palette"
+  },
+  "shortcutDescPaletteNav": {
+    "message": "Navigasi hasil Command Palette"
+  },
+  "shortcutDescPaletteSelect": {
+    "message": "Aktifkan hasil yang dipilih"
+  },
+  "shortcutInSidepanelHeader": {
+    "message": "Shortcut di dalam sidepanel"
+  },
+  "shortcutInSidepanelNote": {
+    "message": "Ini hanya berjalan di dalam sidepanel dan tidak dapat dipetakan ulang melalui halaman shortcut Chrome."
+  },
+  "workspaceCreateFromCurrent": {
+    "message": "+ Buat dari tab saat ini"
+  },
+  "workspaceCreatePromptTitle": {
+    "message": "Beri nama Workspace ini"
+  },
+  "workspaceDelete": {
+    "message": "Hapus"
+  },
+  "workspaceDeleteConfirmMessage": {
+    "message": "Hapus \"{ws}\"? Aksi ini tidak bisa dibatalkan."
+  },
+  "workspaceDeleteConfirmTitle": {
+    "message": "Hapus Workspace"
+  },
+  "workspaceManageEmpty": {
+    "message": "Belum ada Workspaces."
+  },
+  "workspaceManageTitle": {
+    "message": "Kelola Workspaces"
+  },
+  "workspaceNoActive": {
+    "message": "— tidak ada Workspace —"
+  },
+  "workspaceRename": {
+    "message": "Ubah nama"
+  },
+  "workspaceSwitchConfirmBtn": {
+    "message": "Ganti"
+  },
+  "workspaceSwitchConfirmMessage": {
+    "message": "Beralih ke \"{ws}\" akan menutup {n} tab di window ini dan membuka tab yang disimpan."
+  },
+  "workspaceSwitchConfirmMessageUnbound": {
+    "message": "Beralih ke \"{ws}\" — {n} tab Anda saat ini tidak ada di Workspace mana pun. Akan auto-saved ke Workspace \"Untitled\" baru sebelum beralih."
+  },
+  "workspaceSwitchConfirmTitle": {
+    "message": "Ganti Workspace"
+  },
+  "workspaceSwitchFailedMessage": {
+    "message": "Tidak dapat ganti Workspace. Tab Anda saat ini tidak diubah."
+  },
+  "workspaceSwitchFailedTitle": {
+    "message": "Ganti gagal"
+  },
+  "workspaceSwitcherAriaLabel": {
+    "message": "Workspace aktif"
   }
 }

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -682,5 +682,266 @@
   },
   "aiSetupStep2b": {
     "message": "Prompt API マルチモーダル入力を有効化：リンクを開き「Enabled」に設定してください。"
+  },
+  "aiAutoNamingDescription": {
+    "message": "タイトルなしの新しいタブグループを作成すると、AI が短いラベル（絵文字 + 名前）を提案します。ローカルモデルが既にダウンロードされている場合のみ動作します。"
+  },
+  "aiAutoNamingToggleLabel": {
+    "message": "空のタブグループを自動命名"
+  },
+  "aiCleanupAnalyzing": {
+    "message": "タブを分析中..."
+  },
+  "aiCleanupBtnText": {
+    "message": "🧹 整理"
+  },
+  "aiCleanupBtnTitle": {
+    "message": "AI タブ整理提案"
+  },
+  "aiCleanupConfirm": {
+    "message": "選択したタブを閉じる"
+  },
+  "aiCleanupDescription": {
+    "message": "Smart Group の隣にボタンを追加し、AI が閉じてよいタブを提案します。"
+  },
+  "aiCleanupEmpty": {
+    "message": "タブはきれいです — 整理する必要はありません。"
+  },
+  "aiCleanupError": {
+    "message": "AI 整理に失敗しました。後で再試行してください。"
+  },
+  "aiCleanupFound": {
+    "message": "AI は {count} 個のタブを閉じてよいと提案しています。残したいタブのチェックを外してください。"
+  },
+  "aiCleanupNeedsDownload": {
+    "message": "AI モデルがまだダウンロードされていません。まず ✨ Smart Group をクリックしてダウンロードを開始してください。"
+  },
+  "aiCleanupSectionHeader": {
+    "message": "閉じてよいタブ"
+  },
+  "aiCleanupSelectAll": {
+    "message": "すべて選択"
+  },
+  "aiCleanupToggleLabel": {
+    "message": "🧹 タブ整理ボタンを表示"
+  },
+  "bmToolsConfirmRemove": {
+    "message": "選択を削除"
+  },
+  "bmToolsConfirmRemoveMessage": {
+    "message": "{n} 個のブックマークを削除しますか？この操作は元に戻せません。"
+  },
+  "bmToolsConfirmRemoveTitle": {
+    "message": "ブックマークを削除"
+  },
+  "bmToolsCreateTag": {
+    "message": "+ 新しいタグ"
+  },
+  "bmToolsCreateTagPrompt": {
+    "message": "新しいタグ名"
+  },
+  "bmToolsDeadLinksIntro": {
+    "message": "スキャンは HEAD ですべての http(s) ブックマークに接続を試みます。ネットワーク到達不可のリンクのみフラグされます（HTTP 404 は CORS なしでは検出不可、ノート参照）。"
+  },
+  "bmToolsDeadLinksTab": {
+    "message": "リンク切れ"
+  },
+  "bmToolsDeleteTagMessage": {
+    "message": "タグ「{t}」を削除しますか？ブックマーク自体は削除されず、タグ紐付けのみ解除されます。"
+  },
+  "bmToolsDeleteTagTitle": {
+    "message": "タグを削除"
+  },
+  "bmToolsDuplicatesEmpty": {
+    "message": "重複したブックマークはありません。🎉"
+  },
+  "bmToolsDuplicatesIntro": {
+    "message": "{n} 個の重複グループが見つかりました。各グループで残したい複本のチェックを外してください。"
+  },
+  "bmToolsDuplicatesTab": {
+    "message": "重複"
+  },
+  "bmToolsKeepFirstNote": {
+    "message": "備考：グループ内のすべての複本がチェックされた場合、最初の複本は自動的に残されます。"
+  },
+  "bmToolsNetworkRatioWarning": {
+    "message": "{n} / {total} が失敗 ({pct}%) — 異常に高く、ネットワーク問題の可能性が高いです。削除前に注意深く確認してください。"
+  },
+  "bmToolsNoBookmarks": {
+    "message": "スキャンするブックマークがありません。"
+  },
+  "bmToolsOfflineWarning": {
+    "message": "オフラインのようです。インターネットに接続してから再試行してください — ネットワークなしではスキャンがすべてのブックマークを誤って到達不可とフラグします。"
+  },
+  "bmToolsPrivacyNote": {
+    "message": "注意：スキャンは各ブックマークのホストに HEAD リクエストを送信します。"
+  },
+  "bmToolsRemoveUnreachable": {
+    "message": "チェックされた到達不可なブックマークを削除"
+  },
+  "bmToolsScanDone": {
+    "message": "スキャン完了：{n} 個の到達不可なリンク。"
+  },
+  "bmToolsScanProgress": {
+    "message": "確認中… {done}/{total}"
+  },
+  "bmToolsStartScan": {
+    "message": "スキャン開始"
+  },
+  "bmToolsTagsEmpty": {
+    "message": "タグはまだありません。"
+  },
+  "bmToolsTagsTab": {
+    "message": "タグ"
+  },
+  "bmToolsTitle": {
+    "message": "ブックマークツール"
+  },
+  "cmdPaletteActionAiCleanup": {
+    "message": "AI タブ整理"
+  },
+  "cmdPaletteActionAskAi": {
+    "message": "AI にタブやブックマークを探してもらう"
+  },
+  "cmdPaletteActionBookmarkTools": {
+    "message": "ブックマークツールを開く"
+  },
+  "cmdPaletteActionCreateWorkspace": {
+    "message": "現在のタブから Workspace を作成"
+  },
+  "cmdPaletteActionManageWorkspaces": {
+    "message": "Workspaces を管理"
+  },
+  "cmdPaletteActionNewTabRight": {
+    "message": "右に新しいタブ"
+  },
+  "cmdPaletteActionRefreshBookmarks": {
+    "message": "ブックマークを更新"
+  },
+  "cmdPaletteActionSettings": {
+    "message": "設定を開く"
+  },
+  "cmdPaletteActionSmartGroup": {
+    "message": "すべてのタブを Smart Group"
+  },
+  "cmdPaletteAriaLabel": {
+    "message": "コマンドパレット"
+  },
+  "cmdPaletteAskAiNoMatch": {
+    "message": "AI は一致するものを見つけられませんでした。"
+  },
+  "cmdPaletteAskAiResultsTitle": {
+    "message": "AI 提案"
+  },
+  "cmdPaletteAskAiThinking": {
+    "message": "AI に問い合わせ中…"
+  },
+  "cmdPaletteAskAiTitle": {
+    "message": "AI に依頼：タブやブックマークを探す"
+  },
+  "cmdPaletteAskAiUnavailable": {
+    "message": "AI モデルがまだダウンロードされていません。まず ✨ Smart Group でダウンロードしてから再試行してください。"
+  },
+  "cmdPaletteEmpty": {
+    "message": "結果なし"
+  },
+  "cmdPaletteGroupActions": {
+    "message": "アクション"
+  },
+  "cmdPaletteGroupBookmarks": {
+    "message": "ブックマーク"
+  },
+  "cmdPaletteGroupReadingList": {
+    "message": "リーディングリスト"
+  },
+  "cmdPaletteGroupTabs": {
+    "message": "タブ"
+  },
+  "cmdPaletteGroupWorkspaces": {
+    "message": "Workspaces"
+  },
+  "cmdPaletteHintClose": {
+    "message": "閉じる"
+  },
+  "cmdPaletteHintNavigate": {
+    "message": "移動"
+  },
+  "cmdPaletteHintSelect": {
+    "message": "選択"
+  },
+  "cmdPalettePlaceholder": {
+    "message": "タブ、ブックマーク、アクションを検索..."
+  },
+  "rlSummaryDescription": {
+    "message": "タブで開かれているページをリーディングリストに追加すると、AI が一度要約してローカルに保存するので、後で（オフラインでも）プレビューできます。Summarizer モデルが既に利用可能である必要があります。"
+  },
+  "rlSummaryToggleLabel": {
+    "message": "リーディングリスト項目の AI 要約を記憶"
+  },
+  "shortcutDescCommandPalette": {
+    "message": "コマンドパレットを開く"
+  },
+  "shortcutDescPaletteClose": {
+    "message": "コマンドパレットを閉じる"
+  },
+  "shortcutDescPaletteNav": {
+    "message": "コマンドパレットの結果を移動"
+  },
+  "shortcutDescPaletteSelect": {
+    "message": "選択された結果を有効化"
+  },
+  "shortcutInSidepanelHeader": {
+    "message": "サイドパネル内ショートカット"
+  },
+  "shortcutInSidepanelNote": {
+    "message": "これらはサイドパネル内のみで動作し、Chrome のショートカットページから再マッピングはできません。"
+  },
+  "workspaceCreateFromCurrent": {
+    "message": "+ 現在のタブから作成"
+  },
+  "workspaceCreatePromptTitle": {
+    "message": "この Workspace に名前を付ける"
+  },
+  "workspaceDelete": {
+    "message": "削除"
+  },
+  "workspaceDeleteConfirmMessage": {
+    "message": "「{ws}」を削除しますか？この操作は元に戻せません。"
+  },
+  "workspaceDeleteConfirmTitle": {
+    "message": "Workspace を削除"
+  },
+  "workspaceManageEmpty": {
+    "message": "Workspaces はまだありません。"
+  },
+  "workspaceManageTitle": {
+    "message": "Workspaces を管理"
+  },
+  "workspaceNoActive": {
+    "message": "— Workspace なし —"
+  },
+  "workspaceRename": {
+    "message": "名前を変更"
+  },
+  "workspaceSwitchConfirmBtn": {
+    "message": "切り替え"
+  },
+  "workspaceSwitchConfirmMessage": {
+    "message": "「{ws}」に切り替えると、このウィンドウの現在の {n} 個のタブが閉じられ、保存されたタブが開きます。"
+  },
+  "workspaceSwitchConfirmMessageUnbound": {
+    "message": "「{ws}」に切り替え — 現在の {n} 個のタブはまだどの Workspace にも保存されていません。切り替え前に新しい「Untitled」Workspace に自動保存されます。"
+  },
+  "workspaceSwitchConfirmTitle": {
+    "message": "Workspace を切り替え"
+  },
+  "workspaceSwitchFailedMessage": {
+    "message": "Workspace の切り替えに失敗しました。現在のタブは変更されていません。"
+  },
+  "workspaceSwitchFailedTitle": {
+    "message": "切り替え失敗"
+  },
+  "workspaceSwitcherAriaLabel": {
+    "message": "アクティブな Workspace"
   }
 }

--- a/_locales/ko/messages.json
+++ b/_locales/ko/messages.json
@@ -682,5 +682,266 @@
   },
   "aiSetupStep2b": {
     "message": "Prompt API 멀티모달 입력 활성화: 링크를 열고 \"Enabled\"로 설정하세요."
+  },
+  "aiAutoNamingDescription": {
+    "message": "제목 없는 새 탭 그룹을 만들면 AI 가 짧은 레이블(이모지 + 이름)을 제안합니다. 로컬 모델이 이미 다운로드된 경우에만 실행됩니다."
+  },
+  "aiAutoNamingToggleLabel": {
+    "message": "빈 탭 그룹 자동 명명"
+  },
+  "aiCleanupAnalyzing": {
+    "message": "탭 분석 중..."
+  },
+  "aiCleanupBtnText": {
+    "message": "🧹 정리"
+  },
+  "aiCleanupBtnTitle": {
+    "message": "AI 탭 정리 제안"
+  },
+  "aiCleanupConfirm": {
+    "message": "선택 항목 닫기"
+  },
+  "aiCleanupDescription": {
+    "message": "Smart Group 옆에 AI 가 닫을 수 있는 탭을 제안하는 버튼을 추가합니다."
+  },
+  "aiCleanupEmpty": {
+    "message": "탭이 정돈되어 있습니다 — 정리할 것이 없습니다."
+  },
+  "aiCleanupError": {
+    "message": "AI 정리 실패. 나중에 다시 시도하세요."
+  },
+  "aiCleanupFound": {
+    "message": "AI 가 닫을 수 있는 탭 {count} 개를 제안합니다. 유지하고 싶은 항목의 체크를 해제하세요."
+  },
+  "aiCleanupNeedsDownload": {
+    "message": "AI 모델이 아직 다운로드되지 않았습니다. 먼저 ✨ Smart Group 을 클릭해서 다운로드를 시작하세요."
+  },
+  "aiCleanupSectionHeader": {
+    "message": "닫을 수 있는 탭"
+  },
+  "aiCleanupSelectAll": {
+    "message": "모두 선택"
+  },
+  "aiCleanupToggleLabel": {
+    "message": "🧹 탭 정리 버튼 표시"
+  },
+  "bmToolsConfirmRemove": {
+    "message": "선택 삭제"
+  },
+  "bmToolsConfirmRemoveMessage": {
+    "message": "{n} 개의 북마크를 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+  },
+  "bmToolsConfirmRemoveTitle": {
+    "message": "북마크 삭제"
+  },
+  "bmToolsCreateTag": {
+    "message": "+ 새 태그"
+  },
+  "bmToolsCreateTagPrompt": {
+    "message": "새 태그 이름"
+  },
+  "bmToolsDeadLinksIntro": {
+    "message": "스캔은 HEAD 로 모든 http(s) 북마크에 도달을 시도합니다. 네트워크 도달 불가 링크만 표시됩니다(HTTP 404 는 CORS 없이는 감지 불가, 노트 참조)."
+  },
+  "bmToolsDeadLinksTab": {
+    "message": "죽은 링크"
+  },
+  "bmToolsDeleteTagMessage": {
+    "message": "태그 \"{t}\" 를 삭제하시겠습니까? 북마크는 삭제되지 않고 태그 연결만 해제됩니다."
+  },
+  "bmToolsDeleteTagTitle": {
+    "message": "태그 삭제"
+  },
+  "bmToolsDuplicatesEmpty": {
+    "message": "중복 북마크가 없습니다. 🎉"
+  },
+  "bmToolsDuplicatesIntro": {
+    "message": "{n} 개의 중복 그룹을 발견했습니다. 각 그룹에서 유지하고 싶은 사본의 체크를 해제하세요."
+  },
+  "bmToolsDuplicatesTab": {
+    "message": "중복"
+  },
+  "bmToolsKeepFirstNote": {
+    "message": "참고: 그룹에서 모든 사본이 선택된 경우, 첫 번째 사본은 자동으로 유지됩니다."
+  },
+  "bmToolsNetworkRatioWarning": {
+    "message": "{n} / {total} 실패 ({pct}%) — 비정상적으로 높으며 죽은 링크보다는 네트워크 문제로 보입니다. 삭제 전 신중히 확인하세요."
+  },
+  "bmToolsNoBookmarks": {
+    "message": "스캔할 북마크가 없습니다."
+  },
+  "bmToolsOfflineWarning": {
+    "message": "오프라인 상태인 것 같습니다. 인터넷에 연결한 후 다시 시도하세요 — 네트워크 없이는 스캔이 모든 북마크를 도달 불가로 잘못 표시합니다."
+  },
+  "bmToolsPrivacyNote": {
+    "message": "참고: 스캔은 각 북마크 호스트에 HEAD 요청을 보냅니다."
+  },
+  "bmToolsRemoveUnreachable": {
+    "message": "체크된 도달 불가 북마크 삭제"
+  },
+  "bmToolsScanDone": {
+    "message": "스캔 완료: {n} 개의 도달 불가 링크."
+  },
+  "bmToolsScanProgress": {
+    "message": "확인 중… {done}/{total}"
+  },
+  "bmToolsStartScan": {
+    "message": "스캔 시작"
+  },
+  "bmToolsTagsEmpty": {
+    "message": "태그가 아직 없습니다."
+  },
+  "bmToolsTagsTab": {
+    "message": "태그"
+  },
+  "bmToolsTitle": {
+    "message": "북마크 도구"
+  },
+  "cmdPaletteActionAiCleanup": {
+    "message": "AI 탭 정리"
+  },
+  "cmdPaletteActionAskAi": {
+    "message": "AI 에게 탭이나 북마크 찾기 요청"
+  },
+  "cmdPaletteActionBookmarkTools": {
+    "message": "북마크 도구 열기"
+  },
+  "cmdPaletteActionCreateWorkspace": {
+    "message": "현재 탭으로 Workspace 만들기"
+  },
+  "cmdPaletteActionManageWorkspaces": {
+    "message": "Workspaces 관리"
+  },
+  "cmdPaletteActionNewTabRight": {
+    "message": "오른쪽에 새 탭"
+  },
+  "cmdPaletteActionRefreshBookmarks": {
+    "message": "북마크 새로고침"
+  },
+  "cmdPaletteActionSettings": {
+    "message": "설정 열기"
+  },
+  "cmdPaletteActionSmartGroup": {
+    "message": "모든 탭 Smart Group"
+  },
+  "cmdPaletteAriaLabel": {
+    "message": "명령 팔레트"
+  },
+  "cmdPaletteAskAiNoMatch": {
+    "message": "AI 가 적절한 결과를 찾지 못했습니다."
+  },
+  "cmdPaletteAskAiResultsTitle": {
+    "message": "AI 제안"
+  },
+  "cmdPaletteAskAiThinking": {
+    "message": "AI 생각 중…"
+  },
+  "cmdPaletteAskAiTitle": {
+    "message": "AI 에게 요청: 탭이나 북마크 찾기"
+  },
+  "cmdPaletteAskAiUnavailable": {
+    "message": "AI 모델이 아직 다운로드되지 않았습니다. 먼저 ✨ Smart Group 으로 다운로드를 트리거하고 다시 시도하세요."
+  },
+  "cmdPaletteEmpty": {
+    "message": "결과 없음"
+  },
+  "cmdPaletteGroupActions": {
+    "message": "액션"
+  },
+  "cmdPaletteGroupBookmarks": {
+    "message": "북마크"
+  },
+  "cmdPaletteGroupReadingList": {
+    "message": "리딩 리스트"
+  },
+  "cmdPaletteGroupTabs": {
+    "message": "탭"
+  },
+  "cmdPaletteGroupWorkspaces": {
+    "message": "Workspaces"
+  },
+  "cmdPaletteHintClose": {
+    "message": "닫기"
+  },
+  "cmdPaletteHintNavigate": {
+    "message": "이동"
+  },
+  "cmdPaletteHintSelect": {
+    "message": "선택"
+  },
+  "cmdPalettePlaceholder": {
+    "message": "탭, 북마크, 액션 검색..."
+  },
+  "rlSummaryDescription": {
+    "message": "탭에 열려 있는 페이지를 리딩 리스트에 추가하면 AI 가 한 번 요약하고 로컬에 저장하여 나중에(오프라인에서도) 미리볼 수 있습니다. Summarizer 모델이 이미 사용 가능해야 합니다."
+  },
+  "rlSummaryToggleLabel": {
+    "message": "리딩 리스트 항목의 AI 요약 기억"
+  },
+  "shortcutDescCommandPalette": {
+    "message": "명령 팔레트 열기"
+  },
+  "shortcutDescPaletteClose": {
+    "message": "명령 팔레트 닫기"
+  },
+  "shortcutDescPaletteNav": {
+    "message": "명령 팔레트 결과 이동"
+  },
+  "shortcutDescPaletteSelect": {
+    "message": "선택된 결과 활성화"
+  },
+  "shortcutInSidepanelHeader": {
+    "message": "사이드패널 내 단축키"
+  },
+  "shortcutInSidepanelNote": {
+    "message": "이 단축키는 사이드패널 내에서만 작동하며 Chrome 단축키 페이지에서 재매핑할 수 없습니다."
+  },
+  "workspaceCreateFromCurrent": {
+    "message": "+ 현재 탭에서 만들기"
+  },
+  "workspaceCreatePromptTitle": {
+    "message": "이 Workspace 의 이름"
+  },
+  "workspaceDelete": {
+    "message": "삭제"
+  },
+  "workspaceDeleteConfirmMessage": {
+    "message": "\"{ws}\" 을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+  },
+  "workspaceDeleteConfirmTitle": {
+    "message": "Workspace 삭제"
+  },
+  "workspaceManageEmpty": {
+    "message": "Workspaces 가 아직 없습니다."
+  },
+  "workspaceManageTitle": {
+    "message": "Workspaces 관리"
+  },
+  "workspaceNoActive": {
+    "message": "— Workspace 없음 —"
+  },
+  "workspaceRename": {
+    "message": "이름 변경"
+  },
+  "workspaceSwitchConfirmBtn": {
+    "message": "전환"
+  },
+  "workspaceSwitchConfirmMessage": {
+    "message": "\"{ws}\" 로 전환하면 이 창의 현재 {n} 개 탭이 닫히고 저장된 탭이 열립니다."
+  },
+  "workspaceSwitchConfirmMessageUnbound": {
+    "message": "\"{ws}\" 로 전환 — 현재 {n} 개 탭은 아직 어떤 Workspace 에도 저장되지 않았습니다. 전환 전 새 \"Untitled\" Workspace 에 자동 저장됩니다."
+  },
+  "workspaceSwitchConfirmTitle": {
+    "message": "Workspace 전환"
+  },
+  "workspaceSwitchFailedMessage": {
+    "message": "Workspace 전환 실패. 현재 탭은 변경되지 않았습니다."
+  },
+  "workspaceSwitchFailedTitle": {
+    "message": "전환 실패"
+  },
+  "workspaceSwitcherAriaLabel": {
+    "message": "활성 Workspace"
   }
 }

--- a/_locales/pt_BR/messages.json
+++ b/_locales/pt_BR/messages.json
@@ -682,5 +682,266 @@
   },
   "aiSetupStep2b": {
     "message": "Ativar entrada multimodal do Prompt API: abra o link e defina como \"Enabled\"."
+  },
+  "aiAutoNamingDescription": {
+    "message": "Quando você cria um novo grupo de abas sem título, a IA sugere um rótulo curto (Emoji + nome). Funciona somente se o modelo local já estiver baixado."
+  },
+  "aiAutoNamingToggleLabel": {
+    "message": "Nomear automaticamente grupos de abas vazios"
+  },
+  "aiCleanupAnalyzing": {
+    "message": "Analisando abas..."
+  },
+  "aiCleanupBtnText": {
+    "message": "🧹 Limpar"
+  },
+  "aiCleanupBtnTitle": {
+    "message": "Limpeza de abas sugerida por IA"
+  },
+  "aiCleanupConfirm": {
+    "message": "Fechar seleção"
+  },
+  "aiCleanupDescription": {
+    "message": "Adiciona um botão ao lado do Smart Group que pergunta à IA quais abas você pode fechar."
+  },
+  "aiCleanupEmpty": {
+    "message": "Suas abas estão organizadas — nada para limpar."
+  },
+  "aiCleanupError": {
+    "message": "A limpeza IA falhou. Tente novamente mais tarde."
+  },
+  "aiCleanupFound": {
+    "message": "A IA sugere {count} aba(s) que você provavelmente pode fechar. Desmarque as que quiser manter."
+  },
+  "aiCleanupNeedsDownload": {
+    "message": "O modelo IA ainda não foi baixado. Clique primeiro em ✨ Smart Group para iniciar o download."
+  },
+  "aiCleanupSectionHeader": {
+    "message": "Abas que você poderia fechar"
+  },
+  "aiCleanupSelectAll": {
+    "message": "Selecionar tudo"
+  },
+  "aiCleanupToggleLabel": {
+    "message": "Mostrar botão 🧹 Limpeza de abas"
+  },
+  "bmToolsConfirmRemove": {
+    "message": "Remover selecionados"
+  },
+  "bmToolsConfirmRemoveMessage": {
+    "message": "Remover {n} favorito(s)? Esta ação não pode ser desfeita."
+  },
+  "bmToolsConfirmRemoveTitle": {
+    "message": "Remover favoritos"
+  },
+  "bmToolsCreateTag": {
+    "message": "+ Nova tag"
+  },
+  "bmToolsCreateTagPrompt": {
+    "message": "Nome da nova tag"
+  },
+  "bmToolsDeadLinksIntro": {
+    "message": "A varredura tenta alcançar cada favorito http(s) via HEAD. Apenas links inacessíveis pela rede são sinalizados (HTTP 404 não pode ser detectado sem CORS por origem, ver notas)."
+  },
+  "bmToolsDeadLinksTab": {
+    "message": "Links mortos"
+  },
+  "bmToolsDeleteTagMessage": {
+    "message": "Excluir tag \"{t}\"? Os favoritos não serão excluídos, apenas a vinculação da tag."
+  },
+  "bmToolsDeleteTagTitle": {
+    "message": "Excluir tag"
+  },
+  "bmToolsDuplicatesEmpty": {
+    "message": "Sem favoritos duplicados. 🎉"
+  },
+  "bmToolsDuplicatesIntro": {
+    "message": "Encontrado(s) {n} grupo(s) de duplicados. Desmarque a cópia que quer manter em cada grupo."
+  },
+  "bmToolsDuplicatesTab": {
+    "message": "Duplicados"
+  },
+  "bmToolsKeepFirstNote": {
+    "message": "Nota: em grupos onde todas as cópias estão marcadas, a primeira é mantida automaticamente."
+  },
+  "bmToolsNetworkRatioWarning": {
+    "message": "{n} de {total} falharam ({pct}%) — incomumente alto e parece mais um problema de rede que links mortos. Revise com cuidado antes de remover."
+  },
+  "bmToolsNoBookmarks": {
+    "message": "Sem favoritos para varrer."
+  },
+  "bmToolsOfflineWarning": {
+    "message": "Você parece estar offline. Conecte-se à internet e tente novamente — sem rede, a varredura marcaria incorretamente cada favorito como inacessível."
+  },
+  "bmToolsPrivacyNote": {
+    "message": "Nota: a varredura envia uma requisição HEAD para o host de cada favorito."
+  },
+  "bmToolsRemoveUnreachable": {
+    "message": "Remover favoritos inacessíveis marcados"
+  },
+  "bmToolsScanDone": {
+    "message": "Varredura concluída: {n} link(s) inacessível(eis)."
+  },
+  "bmToolsScanProgress": {
+    "message": "Verificando… {done}/{total}"
+  },
+  "bmToolsStartScan": {
+    "message": "Iniciar varredura"
+  },
+  "bmToolsTagsEmpty": {
+    "message": "Ainda sem tags."
+  },
+  "bmToolsTagsTab": {
+    "message": "Tags"
+  },
+  "bmToolsTitle": {
+    "message": "Ferramentas para favoritos"
+  },
+  "cmdPaletteActionAiCleanup": {
+    "message": "AI Tab Cleanup"
+  },
+  "cmdPaletteActionAskAi": {
+    "message": "Pedir à IA para encontrar abas ou favoritos"
+  },
+  "cmdPaletteActionBookmarkTools": {
+    "message": "Abrir Bookmark Tools"
+  },
+  "cmdPaletteActionCreateWorkspace": {
+    "message": "Criar Workspace a partir das abas atuais"
+  },
+  "cmdPaletteActionManageWorkspaces": {
+    "message": "Gerenciar Workspaces"
+  },
+  "cmdPaletteActionNewTabRight": {
+    "message": "Nova aba à direita"
+  },
+  "cmdPaletteActionRefreshBookmarks": {
+    "message": "Atualizar favoritos"
+  },
+  "cmdPaletteActionSettings": {
+    "message": "Abrir configurações"
+  },
+  "cmdPaletteActionSmartGroup": {
+    "message": "Smart Group todas as abas"
+  },
+  "cmdPaletteAriaLabel": {
+    "message": "Paleta de comandos"
+  },
+  "cmdPaletteAskAiNoMatch": {
+    "message": "A IA não encontrou boas correspondências."
+  },
+  "cmdPaletteAskAiResultsTitle": {
+    "message": "Sugestões da IA"
+  },
+  "cmdPaletteAskAiThinking": {
+    "message": "Perguntando à IA…"
+  },
+  "cmdPaletteAskAiTitle": {
+    "message": "Pedir à IA: encontrar abas ou favoritos"
+  },
+  "cmdPaletteAskAiUnavailable": {
+    "message": "O modelo IA ainda não foi baixado. Acione primeiro ✨ Smart Group para baixar, depois tente novamente."
+  },
+  "cmdPaletteEmpty": {
+    "message": "Sem resultados"
+  },
+  "cmdPaletteGroupActions": {
+    "message": "Ações"
+  },
+  "cmdPaletteGroupBookmarks": {
+    "message": "Favoritos"
+  },
+  "cmdPaletteGroupReadingList": {
+    "message": "Lista de leitura"
+  },
+  "cmdPaletteGroupTabs": {
+    "message": "Abas"
+  },
+  "cmdPaletteGroupWorkspaces": {
+    "message": "Workspaces"
+  },
+  "cmdPaletteHintClose": {
+    "message": "fechar"
+  },
+  "cmdPaletteHintNavigate": {
+    "message": "navegar"
+  },
+  "cmdPaletteHintSelect": {
+    "message": "selecionar"
+  },
+  "cmdPalettePlaceholder": {
+    "message": "Buscar abas, favoritos ou ações..."
+  },
+  "rlSummaryDescription": {
+    "message": "Quando você adiciona à sua lista de leitura uma página aberta em uma aba, a IA a resume uma vez e salva o resultado localmente para que você possa pré-visualizar mais tarde — mesmo offline. Requer que o modelo Summarizer já esteja disponível."
+  },
+  "rlSummaryToggleLabel": {
+    "message": "Lembrar o resumo IA para itens da lista de leitura"
+  },
+  "shortcutDescCommandPalette": {
+    "message": "Abrir paleta de comandos"
+  },
+  "shortcutDescPaletteClose": {
+    "message": "Fechar paleta de comandos"
+  },
+  "shortcutDescPaletteNav": {
+    "message": "Navegar pelos resultados da paleta"
+  },
+  "shortcutDescPaletteSelect": {
+    "message": "Ativar resultado selecionado"
+  },
+  "shortcutInSidepanelHeader": {
+    "message": "Atalhos do painel lateral"
+  },
+  "shortcutInSidepanelNote": {
+    "message": "Estes funcionam apenas dentro do painel lateral e não podem ser remapeados pela página de atalhos do Chrome."
+  },
+  "workspaceCreateFromCurrent": {
+    "message": "+ Criar a partir das abas atuais"
+  },
+  "workspaceCreatePromptTitle": {
+    "message": "Nomear este Workspace"
+  },
+  "workspaceDelete": {
+    "message": "Excluir"
+  },
+  "workspaceDeleteConfirmMessage": {
+    "message": "Excluir \"{ws}\"? Esta ação não pode ser desfeita."
+  },
+  "workspaceDeleteConfirmTitle": {
+    "message": "Excluir Workspace"
+  },
+  "workspaceManageEmpty": {
+    "message": "Ainda sem Workspaces."
+  },
+  "workspaceManageTitle": {
+    "message": "Gerenciar Workspaces"
+  },
+  "workspaceNoActive": {
+    "message": "— sem Workspace —"
+  },
+  "workspaceRename": {
+    "message": "Renomear"
+  },
+  "workspaceSwitchConfirmBtn": {
+    "message": "Trocar"
+  },
+  "workspaceSwitchConfirmMessage": {
+    "message": "Trocar para \"{ws}\" fechará {n} aba(s) nesta janela e abrirá as abas salvas."
+  },
+  "workspaceSwitchConfirmMessageUnbound": {
+    "message": "Trocar para \"{ws}\" — suas {n} aba(s) atuais não estão em nenhum Workspace. Serão salvas automaticamente em um novo Workspace \"Untitled\" antes da troca."
+  },
+  "workspaceSwitchConfirmTitle": {
+    "message": "Trocar de Workspace"
+  },
+  "workspaceSwitchFailedMessage": {
+    "message": "Não foi possível trocar de Workspace. Suas abas atuais não foram alteradas."
+  },
+  "workspaceSwitchFailedTitle": {
+    "message": "Troca falhou"
+  },
+  "workspaceSwitcherAriaLabel": {
+    "message": "Workspace ativo"
   }
 }

--- a/_locales/ru/messages.json
+++ b/_locales/ru/messages.json
@@ -682,5 +682,266 @@
   },
   "aiSetupStep2b": {
     "message": "Включить мультимодальный ввод Prompt API: откройте ссылку и установите значение \"Enabled\"."
+  },
+  "aiAutoNamingDescription": {
+    "message": "Когда вы создаёте новую пустую группу вкладок, AI предлагает короткую метку (Эмодзи + название). Работает только если локальная модель уже загружена."
+  },
+  "aiAutoNamingToggleLabel": {
+    "message": "Автоматически именовать пустые группы вкладок"
+  },
+  "aiCleanupAnalyzing": {
+    "message": "Анализ вкладок..."
+  },
+  "aiCleanupBtnText": {
+    "message": "🧹 Очистка"
+  },
+  "aiCleanupBtnTitle": {
+    "message": "Очистка вкладок, предложенная AI"
+  },
+  "aiCleanupConfirm": {
+    "message": "Закрыть выбранные"
+  },
+  "aiCleanupDescription": {
+    "message": "Добавляет кнопку рядом с Smart Group, которая спрашивает AI, какие вкладки можно закрыть."
+  },
+  "aiCleanupEmpty": {
+    "message": "Ваши вкладки в порядке — ничего убирать."
+  },
+  "aiCleanupError": {
+    "message": "Очистка AI не удалась. Попробуйте позже."
+  },
+  "aiCleanupFound": {
+    "message": "AI предлагает {count} вкладку(вкладок) к закрытию. Снимите галочку с тех, что хотите оставить."
+  },
+  "aiCleanupNeedsDownload": {
+    "message": "Модель AI ещё не загружена. Сначала нажмите ✨ Smart Group для запуска загрузки."
+  },
+  "aiCleanupSectionHeader": {
+    "message": "Вкладки, которые можно закрыть"
+  },
+  "aiCleanupSelectAll": {
+    "message": "Выбрать всё"
+  },
+  "aiCleanupToggleLabel": {
+    "message": "Показать кнопку 🧹 Очистка вкладок"
+  },
+  "bmToolsConfirmRemove": {
+    "message": "Удалить выбранное"
+  },
+  "bmToolsConfirmRemoveMessage": {
+    "message": "Удалить {n} закладку(закладок)? Это действие нельзя отменить."
+  },
+  "bmToolsConfirmRemoveTitle": {
+    "message": "Удалить закладки"
+  },
+  "bmToolsCreateTag": {
+    "message": "+ Новый тег"
+  },
+  "bmToolsCreateTagPrompt": {
+    "message": "Имя нового тега"
+  },
+  "bmToolsDeadLinksIntro": {
+    "message": "Сканирование пытается достичь каждую http(s)-закладку через HEAD. Только сетево-недостижимые ссылки помечаются (HTTP 404 нельзя обнаружить без per-origin CORS, см. notes)."
+  },
+  "bmToolsDeadLinksTab": {
+    "message": "Мёртвые ссылки"
+  },
+  "bmToolsDeleteTagMessage": {
+    "message": "Удалить тег \"{t}\"? Закладки не будут удалены, только привязка тега."
+  },
+  "bmToolsDeleteTagTitle": {
+    "message": "Удалить тег"
+  },
+  "bmToolsDuplicatesEmpty": {
+    "message": "Нет дубликатов закладок. 🎉"
+  },
+  "bmToolsDuplicatesIntro": {
+    "message": "Найдено {n} групп(ы) дубликатов. Снимите галочку с копии, которую хотите оставить в каждой группе."
+  },
+  "bmToolsDuplicatesTab": {
+    "message": "Дубликаты"
+  },
+  "bmToolsKeepFirstNote": {
+    "message": "Заметка: в группах, где все копии отмечены, первая копия оставляется автоматически."
+  },
+  "bmToolsNetworkRatioWarning": {
+    "message": "{n} из {total} не удалось ({pct}%) — необычно высоко и больше похоже на проблему сети, чем мёртвые ссылки. Внимательно проверьте перед удалением."
+  },
+  "bmToolsNoBookmarks": {
+    "message": "Нет закладок для сканирования."
+  },
+  "bmToolsOfflineWarning": {
+    "message": "Похоже, вы офлайн. Подключитесь к интернету и попробуйте снова — без сети сканирование ошибочно пометит каждую закладку как недостижимую."
+  },
+  "bmToolsPrivacyNote": {
+    "message": "Заметка: сканирование отправляет HEAD-запрос на хост каждой закладки."
+  },
+  "bmToolsRemoveUnreachable": {
+    "message": "Удалить отмеченные недостижимые закладки"
+  },
+  "bmToolsScanDone": {
+    "message": "Сканирование завершено: {n} недостижимых ссылок."
+  },
+  "bmToolsScanProgress": {
+    "message": "Проверка… {done}/{total}"
+  },
+  "bmToolsStartScan": {
+    "message": "Начать сканирование"
+  },
+  "bmToolsTagsEmpty": {
+    "message": "Пока нет тегов."
+  },
+  "bmToolsTagsTab": {
+    "message": "Теги"
+  },
+  "bmToolsTitle": {
+    "message": "Инструменты для закладок"
+  },
+  "cmdPaletteActionAiCleanup": {
+    "message": "AI Tab Cleanup"
+  },
+  "cmdPaletteActionAskAi": {
+    "message": "Попросить AI найти вкладки или закладки"
+  },
+  "cmdPaletteActionBookmarkTools": {
+    "message": "Открыть Bookmark Tools"
+  },
+  "cmdPaletteActionCreateWorkspace": {
+    "message": "Создать Workspace из текущих вкладок"
+  },
+  "cmdPaletteActionManageWorkspaces": {
+    "message": "Управление Workspaces"
+  },
+  "cmdPaletteActionNewTabRight": {
+    "message": "Новая вкладка справа"
+  },
+  "cmdPaletteActionRefreshBookmarks": {
+    "message": "Обновить закладки"
+  },
+  "cmdPaletteActionSettings": {
+    "message": "Открыть настройки"
+  },
+  "cmdPaletteActionSmartGroup": {
+    "message": "Smart Group все вкладки"
+  },
+  "cmdPaletteAriaLabel": {
+    "message": "Палитра команд"
+  },
+  "cmdPaletteAskAiNoMatch": {
+    "message": "AI не нашёл хороших совпадений."
+  },
+  "cmdPaletteAskAiResultsTitle": {
+    "message": "Предложения AI"
+  },
+  "cmdPaletteAskAiThinking": {
+    "message": "Спрашиваем AI…"
+  },
+  "cmdPaletteAskAiTitle": {
+    "message": "Попросить AI: найти вкладки или закладки"
+  },
+  "cmdPaletteAskAiUnavailable": {
+    "message": "Модель AI ещё не загружена. Сначала запустите ✨ Smart Group для загрузки и попробуйте снова."
+  },
+  "cmdPaletteEmpty": {
+    "message": "Нет результатов"
+  },
+  "cmdPaletteGroupActions": {
+    "message": "Действия"
+  },
+  "cmdPaletteGroupBookmarks": {
+    "message": "Закладки"
+  },
+  "cmdPaletteGroupReadingList": {
+    "message": "Список чтения"
+  },
+  "cmdPaletteGroupTabs": {
+    "message": "Вкладки"
+  },
+  "cmdPaletteGroupWorkspaces": {
+    "message": "Workspaces"
+  },
+  "cmdPaletteHintClose": {
+    "message": "закрыть"
+  },
+  "cmdPaletteHintNavigate": {
+    "message": "навигация"
+  },
+  "cmdPaletteHintSelect": {
+    "message": "выбрать"
+  },
+  "cmdPalettePlaceholder": {
+    "message": "Поиск вкладок, закладок или действий..."
+  },
+  "rlSummaryDescription": {
+    "message": "Когда вы добавляете в Список чтения страницу, открытую во вкладке, AI делает её краткое содержание один раз и сохраняет результат локально, чтобы вы могли просматривать его позже — даже офлайн. Требуется, чтобы модель Summarizer была уже доступна."
+  },
+  "rlSummaryToggleLabel": {
+    "message": "Запоминать AI-резюме для элементов Списка чтения"
+  },
+  "shortcutDescCommandPalette": {
+    "message": "Открыть палитру команд"
+  },
+  "shortcutDescPaletteClose": {
+    "message": "Закрыть палитру команд"
+  },
+  "shortcutDescPaletteNav": {
+    "message": "Навигация по результатам палитры"
+  },
+  "shortcutDescPaletteSelect": {
+    "message": "Активировать выбранный результат"
+  },
+  "shortcutInSidepanelHeader": {
+    "message": "Сочетания клавиш боковой панели"
+  },
+  "shortcutInSidepanelNote": {
+    "message": "Эти работают только внутри боковой панели и не могут быть переназначены через страницу сочетаний Chrome."
+  },
+  "workspaceCreateFromCurrent": {
+    "message": "+ Создать из текущих вкладок"
+  },
+  "workspaceCreatePromptTitle": {
+    "message": "Назвать этот Workspace"
+  },
+  "workspaceDelete": {
+    "message": "Удалить"
+  },
+  "workspaceDeleteConfirmMessage": {
+    "message": "Удалить \"{ws}\"? Это действие нельзя отменить."
+  },
+  "workspaceDeleteConfirmTitle": {
+    "message": "Удалить Workspace"
+  },
+  "workspaceManageEmpty": {
+    "message": "Пока нет Workspaces."
+  },
+  "workspaceManageTitle": {
+    "message": "Управление Workspaces"
+  },
+  "workspaceNoActive": {
+    "message": "— нет Workspace —"
+  },
+  "workspaceRename": {
+    "message": "Переименовать"
+  },
+  "workspaceSwitchConfirmBtn": {
+    "message": "Переключить"
+  },
+  "workspaceSwitchConfirmMessage": {
+    "message": "Переключение на \"{ws}\" закроет {n} вкладку(вкладок) в этом окне и откроет сохранённые вкладки."
+  },
+  "workspaceSwitchConfirmMessageUnbound": {
+    "message": "Переключение на \"{ws}\" — ваши текущие {n} вкладок не находятся ни в каком Workspace. Они будут автоматически сохранены в новом Workspace \"Untitled\" перед переключением."
+  },
+  "workspaceSwitchConfirmTitle": {
+    "message": "Переключить Workspace"
+  },
+  "workspaceSwitchFailedMessage": {
+    "message": "Не удалось переключить Workspace. Ваши текущие вкладки не были изменены."
+  },
+  "workspaceSwitchFailedTitle": {
+    "message": "Переключение не удалось"
+  },
+  "workspaceSwitcherAriaLabel": {
+    "message": "Активный Workspace"
   }
 }

--- a/_locales/th/messages.json
+++ b/_locales/th/messages.json
@@ -682,5 +682,266 @@
   },
   "aiSetupStep2b": {
     "message": "เปิดใช้งานอินพุตหลายรูปแบบของ Prompt API: เปิดลิงก์แล้วตั้งค่าเป็น \"Enabled\""
+  },
+  "aiAutoNamingDescription": {
+    "message": "เมื่อคุณสร้าง tab group ใหม่ที่ไม่มีชื่อ AI จะแนะนำ label สั้น (Emoji + ชื่อ) ทำงานเฉพาะเมื่อ local model ดาวน์โหลดแล้ว"
+  },
+  "aiAutoNamingToggleLabel": {
+    "message": "ตั้งชื่อ tab group ว่างอัตโนมัติ"
+  },
+  "aiCleanupAnalyzing": {
+    "message": "กำลังวิเคราะห์ tabs..."
+  },
+  "aiCleanupBtnText": {
+    "message": "🧹 Cleanup"
+  },
+  "aiCleanupBtnTitle": {
+    "message": "AI แนะนำ Tab Cleanup"
+  },
+  "aiCleanupConfirm": {
+    "message": "ปิดที่เลือก"
+  },
+  "aiCleanupDescription": {
+    "message": "เพิ่มปุ่มข้าง Smart Group ที่ถาม AI ว่า tab ไหนปิดได้"
+  },
+  "aiCleanupEmpty": {
+    "message": "Tabs ของคุณเรียบร้อย — ไม่มีอะไรต้อง cleanup"
+  },
+  "aiCleanupError": {
+    "message": "AI cleanup ล้มเหลว ลองอีกครั้งภายหลัง"
+  },
+  "aiCleanupFound": {
+    "message": "AI แนะนำ {count} tab ที่ปิดได้ ยกเลิกการเลือก tab ที่ต้องการเก็บ"
+  },
+  "aiCleanupNeedsDownload": {
+    "message": "AI model ยังไม่ดาวน์โหลด คลิก ✨ Smart Group ก่อนเพื่อเริ่มดาวน์โหลด"
+  },
+  "aiCleanupSectionHeader": {
+    "message": "Tabs ที่อาจปิดได้"
+  },
+  "aiCleanupSelectAll": {
+    "message": "เลือกทั้งหมด"
+  },
+  "aiCleanupToggleLabel": {
+    "message": "แสดงปุ่ม 🧹 Tab Cleanup"
+  },
+  "bmToolsConfirmRemove": {
+    "message": "ลบที่เลือก"
+  },
+  "bmToolsConfirmRemoveMessage": {
+    "message": "ลบ {n} bookmark? การกระทำนี้ไม่สามารถยกเลิกได้"
+  },
+  "bmToolsConfirmRemoveTitle": {
+    "message": "ลบ bookmarks"
+  },
+  "bmToolsCreateTag": {
+    "message": "+ tag ใหม่"
+  },
+  "bmToolsCreateTagPrompt": {
+    "message": "ชื่อ tag ใหม่"
+  },
+  "bmToolsDeadLinksIntro": {
+    "message": "Scan พยายามเข้าถึงทุก http(s) bookmark ผ่าน HEAD เฉพาะ link ที่ network unreachable ถูกระบุ (HTTP 404 ตรวจไม่ได้หากไม่มี per-origin CORS, ดู notes)"
+  },
+  "bmToolsDeadLinksTab": {
+    "message": "Dead Links"
+  },
+  "bmToolsDeleteTagMessage": {
+    "message": "ลบ tag \"{t}\"? bookmarks จะไม่ถูกลบ เฉพาะ binding ของ tag"
+  },
+  "bmToolsDeleteTagTitle": {
+    "message": "ลบ tag"
+  },
+  "bmToolsDuplicatesEmpty": {
+    "message": "ไม่มี bookmarks ซ้ำ 🎉"
+  },
+  "bmToolsDuplicatesIntro": {
+    "message": "พบ {n} กลุ่มซ้ำ ยกเลิกการเลือกสำเนาที่ต้องการเก็บในแต่ละกลุ่ม"
+  },
+  "bmToolsDuplicatesTab": {
+    "message": "ซ้ำ"
+  },
+  "bmToolsKeepFirstNote": {
+    "message": "หมายเหตุ: ในกลุ่มที่ทุกสำเนาถูกเลือก สำเนาแรกจะถูกเก็บโดยอัตโนมัติ"
+  },
+  "bmToolsNetworkRatioWarning": {
+    "message": "{n} จาก {total} ล้มเหลว ({pct}%) — สูงผิดปกติและดูเหมือนเป็นปัญหา network มากกว่า dead links ตรวจสอบให้ดีก่อนลบ"
+  },
+  "bmToolsNoBookmarks": {
+    "message": "ไม่มี bookmarks ให้ scan"
+  },
+  "bmToolsOfflineWarning": {
+    "message": "คุณดูเหมือน offline เชื่อมต่อ internet แล้วลองใหม่ — ไม่มีเครือข่าย scan จะระบุ bookmark ทั้งหมดเป็น unreachable อย่างผิดพลาด"
+  },
+  "bmToolsPrivacyNote": {
+    "message": "หมายเหตุ: scan ส่ง HEAD request ไปยัง host ของแต่ละ bookmark"
+  },
+  "bmToolsRemoveUnreachable": {
+    "message": "ลบ bookmarks unreachable ที่เลือก"
+  },
+  "bmToolsScanDone": {
+    "message": "Scan เสร็จ: {n} link unreachable"
+  },
+  "bmToolsScanProgress": {
+    "message": "กำลังตรวจสอบ… {done}/{total}"
+  },
+  "bmToolsStartScan": {
+    "message": "เริ่ม scan"
+  },
+  "bmToolsTagsEmpty": {
+    "message": "ยังไม่มี tags"
+  },
+  "bmToolsTagsTab": {
+    "message": "Tags"
+  },
+  "bmToolsTitle": {
+    "message": "Bookmark Tools"
+  },
+  "cmdPaletteActionAiCleanup": {
+    "message": "AI Tab Cleanup"
+  },
+  "cmdPaletteActionAskAi": {
+    "message": "ถาม AI ให้หา tabs หรือ bookmarks"
+  },
+  "cmdPaletteActionBookmarkTools": {
+    "message": "เปิด Bookmark Tools"
+  },
+  "cmdPaletteActionCreateWorkspace": {
+    "message": "สร้าง Workspace จาก tabs ปัจจุบัน"
+  },
+  "cmdPaletteActionManageWorkspaces": {
+    "message": "จัดการ Workspaces"
+  },
+  "cmdPaletteActionNewTabRight": {
+    "message": "tab ใหม่ทางขวา"
+  },
+  "cmdPaletteActionRefreshBookmarks": {
+    "message": "รีเฟรช bookmarks"
+  },
+  "cmdPaletteActionSettings": {
+    "message": "เปิด settings"
+  },
+  "cmdPaletteActionSmartGroup": {
+    "message": "Smart Group ทุก tabs"
+  },
+  "cmdPaletteAriaLabel": {
+    "message": "Command Palette"
+  },
+  "cmdPaletteAskAiNoMatch": {
+    "message": "AI ไม่พบผลลัพธ์ที่เหมาะสม"
+  },
+  "cmdPaletteAskAiResultsTitle": {
+    "message": "คำแนะนำของ AI"
+  },
+  "cmdPaletteAskAiThinking": {
+    "message": "กำลังถาม AI…"
+  },
+  "cmdPaletteAskAiTitle": {
+    "message": "ถาม AI: หา tabs หรือ bookmarks"
+  },
+  "cmdPaletteAskAiUnavailable": {
+    "message": "AI model ยังไม่ดาวน์โหลด เรียก ✨ Smart Group ก่อนเพื่อดาวน์โหลด แล้วลองอีกครั้ง"
+  },
+  "cmdPaletteEmpty": {
+    "message": "ไม่มีผลลัพธ์"
+  },
+  "cmdPaletteGroupActions": {
+    "message": "Actions"
+  },
+  "cmdPaletteGroupBookmarks": {
+    "message": "Bookmarks"
+  },
+  "cmdPaletteGroupReadingList": {
+    "message": "Reading List"
+  },
+  "cmdPaletteGroupTabs": {
+    "message": "Tabs"
+  },
+  "cmdPaletteGroupWorkspaces": {
+    "message": "Workspaces"
+  },
+  "cmdPaletteHintClose": {
+    "message": "ปิด"
+  },
+  "cmdPaletteHintNavigate": {
+    "message": "เลื่อน"
+  },
+  "cmdPaletteHintSelect": {
+    "message": "เลือก"
+  },
+  "cmdPalettePlaceholder": {
+    "message": "ค้นหา tabs, bookmarks หรือ actions..."
+  },
+  "rlSummaryDescription": {
+    "message": "เมื่อคุณเพิ่ม page ที่เปิดอยู่ใน tab ไปยัง Reading List, AI จะสรุปครั้งเดียวและเก็บผลลัพธ์ในเครื่องเพื่อให้คุณ preview ภายหลังได้ — แม้ offline ต้องการให้ Summarizer model พร้อมใช้งานแล้ว"
+  },
+  "rlSummaryToggleLabel": {
+    "message": "จดจำ AI summary สำหรับรายการ Reading List"
+  },
+  "shortcutDescCommandPalette": {
+    "message": "เปิด Command Palette"
+  },
+  "shortcutDescPaletteClose": {
+    "message": "ปิด Command Palette"
+  },
+  "shortcutDescPaletteNav": {
+    "message": "เลื่อนผลลัพธ์ Command Palette"
+  },
+  "shortcutDescPaletteSelect": {
+    "message": "เปิดผลลัพธ์ที่เลือก"
+  },
+  "shortcutInSidepanelHeader": {
+    "message": "Shortcuts ภายใน sidepanel"
+  },
+  "shortcutInSidepanelNote": {
+    "message": "เหล่านี้ทำงานเฉพาะภายใน sidepanel และไม่สามารถ remap ผ่านหน้า shortcuts ของ Chrome"
+  },
+  "workspaceCreateFromCurrent": {
+    "message": "+ สร้างจาก tabs ปัจจุบัน"
+  },
+  "workspaceCreatePromptTitle": {
+    "message": "ตั้งชื่อ Workspace นี้"
+  },
+  "workspaceDelete": {
+    "message": "ลบ"
+  },
+  "workspaceDeleteConfirmMessage": {
+    "message": "ลบ \"{ws}\"? การกระทำนี้ไม่สามารถยกเลิกได้"
+  },
+  "workspaceDeleteConfirmTitle": {
+    "message": "ลบ Workspace"
+  },
+  "workspaceManageEmpty": {
+    "message": "ยังไม่มี Workspaces"
+  },
+  "workspaceManageTitle": {
+    "message": "จัดการ Workspaces"
+  },
+  "workspaceNoActive": {
+    "message": "— ไม่มี Workspace —"
+  },
+  "workspaceRename": {
+    "message": "เปลี่ยนชื่อ"
+  },
+  "workspaceSwitchConfirmBtn": {
+    "message": "สลับ"
+  },
+  "workspaceSwitchConfirmMessage": {
+    "message": "สลับไป \"{ws}\" จะปิด {n} tab ใน window นี้และเปิด tabs ที่บันทึกไว้"
+  },
+  "workspaceSwitchConfirmMessageUnbound": {
+    "message": "สลับไป \"{ws}\" — {n} tab ปัจจุบันของคุณยังไม่อยู่ใน Workspace ใด จะถูก auto-save ไปยัง Workspace \"Untitled\" ใหม่ก่อนสลับ"
+  },
+  "workspaceSwitchConfirmTitle": {
+    "message": "สลับ Workspace"
+  },
+  "workspaceSwitchFailedMessage": {
+    "message": "ไม่สามารถสลับ Workspace ได้ tabs ปัจจุบันของคุณไม่ถูกเปลี่ยน"
+  },
+  "workspaceSwitchFailedTitle": {
+    "message": "สลับล้มเหลว"
+  },
+  "workspaceSwitcherAriaLabel": {
+    "message": "Workspace ที่ใช้งาน"
   }
 }

--- a/_locales/vi/messages.json
+++ b/_locales/vi/messages.json
@@ -682,5 +682,266 @@
   },
   "aiSetupStep2b": {
     "message": "Bật đầu vào đa phương thức của Prompt API: mở liên kết và đặt thành \"Enabled\"."
+  },
+  "aiAutoNamingDescription": {
+    "message": "Khi bạn tạo một tab group mới không có tiêu đề, AI gợi ý một nhãn ngắn (Emoji + tên). Chỉ chạy nếu model cục bộ đã được tải xuống."
+  },
+  "aiAutoNamingToggleLabel": {
+    "message": "Tự động đặt tên tab group trống"
+  },
+  "aiCleanupAnalyzing": {
+    "message": "Đang phân tích tabs..."
+  },
+  "aiCleanupBtnText": {
+    "message": "🧹 Cleanup"
+  },
+  "aiCleanupBtnTitle": {
+    "message": "Tab cleanup do AI gợi ý"
+  },
+  "aiCleanupConfirm": {
+    "message": "Đóng đã chọn"
+  },
+  "aiCleanupDescription": {
+    "message": "Thêm một nút bên cạnh Smart Group hỏi AI tab nào có thể đóng."
+  },
+  "aiCleanupEmpty": {
+    "message": "Tabs của bạn gọn gàng — không có gì để cleanup."
+  },
+  "aiCleanupError": {
+    "message": "Cleanup AI thất bại. Thử lại sau."
+  },
+  "aiCleanupFound": {
+    "message": "AI gợi ý {count} tab có thể đóng. Bỏ chọn những cái bạn muốn giữ."
+  },
+  "aiCleanupNeedsDownload": {
+    "message": "Model AI chưa được tải. Nhấn ✨ Smart Group trước để bắt đầu tải."
+  },
+  "aiCleanupSectionHeader": {
+    "message": "Tabs có thể đóng"
+  },
+  "aiCleanupSelectAll": {
+    "message": "Chọn tất cả"
+  },
+  "aiCleanupToggleLabel": {
+    "message": "Hiển thị nút 🧹 Tab Cleanup"
+  },
+  "bmToolsConfirmRemove": {
+    "message": "Xóa đã chọn"
+  },
+  "bmToolsConfirmRemoveMessage": {
+    "message": "Xóa {n} bookmark? Hành động này không thể hoàn tác."
+  },
+  "bmToolsConfirmRemoveTitle": {
+    "message": "Xóa bookmarks"
+  },
+  "bmToolsCreateTag": {
+    "message": "+ Tag mới"
+  },
+  "bmToolsCreateTagPrompt": {
+    "message": "Tên tag mới"
+  },
+  "bmToolsDeadLinksIntro": {
+    "message": "Scan cố gắng tiếp cận mọi bookmark http(s) qua HEAD. Chỉ các link không thể tiếp cận qua mạng được đánh dấu (HTTP 404 không thể phát hiện mà không có per-origin CORS, xem notes)."
+  },
+  "bmToolsDeadLinksTab": {
+    "message": "Dead Links"
+  },
+  "bmToolsDeleteTagMessage": {
+    "message": "Xóa tag \"{t}\"? Bookmarks sẽ không bị xóa, chỉ binding của tag."
+  },
+  "bmToolsDeleteTagTitle": {
+    "message": "Xóa tag"
+  },
+  "bmToolsDuplicatesEmpty": {
+    "message": "Không có bookmark trùng lặp. 🎉"
+  },
+  "bmToolsDuplicatesIntro": {
+    "message": "Tìm thấy {n} nhóm trùng lặp. Bỏ chọn bản sao bạn muốn giữ trong mỗi nhóm."
+  },
+  "bmToolsDuplicatesTab": {
+    "message": "Trùng lặp"
+  },
+  "bmToolsKeepFirstNote": {
+    "message": "Lưu ý: trong các nhóm mà mọi bản sao được chọn, bản đầu tiên được giữ tự động."
+  },
+  "bmToolsNetworkRatioWarning": {
+    "message": "{n} trên {total} thất bại ({pct}%) — cao bất thường và trông giống vấn đề mạng hơn là dead link. Xem kỹ trước khi xóa."
+  },
+  "bmToolsNoBookmarks": {
+    "message": "Không có bookmarks để scan."
+  },
+  "bmToolsOfflineWarning": {
+    "message": "Bạn có vẻ offline. Kết nối internet và thử lại — không có mạng, scan sẽ đánh dấu sai mọi bookmark là unreachable."
+  },
+  "bmToolsPrivacyNote": {
+    "message": "Lưu ý: scan gửi HEAD request đến host của mỗi bookmark."
+  },
+  "bmToolsRemoveUnreachable": {
+    "message": "Xóa bookmarks unreachable đã chọn"
+  },
+  "bmToolsScanDone": {
+    "message": "Scan hoàn tất: {n} link unreachable."
+  },
+  "bmToolsScanProgress": {
+    "message": "Đang kiểm tra… {done}/{total}"
+  },
+  "bmToolsStartScan": {
+    "message": "Bắt đầu scan"
+  },
+  "bmToolsTagsEmpty": {
+    "message": "Chưa có tags."
+  },
+  "bmToolsTagsTab": {
+    "message": "Tags"
+  },
+  "bmToolsTitle": {
+    "message": "Bookmark Tools"
+  },
+  "cmdPaletteActionAiCleanup": {
+    "message": "AI Tab Cleanup"
+  },
+  "cmdPaletteActionAskAi": {
+    "message": "Yêu cầu AI tìm tabs hoặc bookmarks"
+  },
+  "cmdPaletteActionBookmarkTools": {
+    "message": "Mở Bookmark Tools"
+  },
+  "cmdPaletteActionCreateWorkspace": {
+    "message": "Tạo Workspace từ tabs hiện tại"
+  },
+  "cmdPaletteActionManageWorkspaces": {
+    "message": "Quản lý Workspaces"
+  },
+  "cmdPaletteActionNewTabRight": {
+    "message": "Tab mới bên phải"
+  },
+  "cmdPaletteActionRefreshBookmarks": {
+    "message": "Làm mới bookmarks"
+  },
+  "cmdPaletteActionSettings": {
+    "message": "Mở cài đặt"
+  },
+  "cmdPaletteActionSmartGroup": {
+    "message": "Smart Group tất cả tabs"
+  },
+  "cmdPaletteAriaLabel": {
+    "message": "Command Palette"
+  },
+  "cmdPaletteAskAiNoMatch": {
+    "message": "AI không tìm thấy kết quả phù hợp."
+  },
+  "cmdPaletteAskAiResultsTitle": {
+    "message": "Gợi ý của AI"
+  },
+  "cmdPaletteAskAiThinking": {
+    "message": "Đang hỏi AI…"
+  },
+  "cmdPaletteAskAiTitle": {
+    "message": "Yêu cầu AI: tìm tabs hoặc bookmarks"
+  },
+  "cmdPaletteAskAiUnavailable": {
+    "message": "Model AI chưa được tải. Kích hoạt ✨ Smart Group trước để tải, rồi thử lại."
+  },
+  "cmdPaletteEmpty": {
+    "message": "Không có kết quả"
+  },
+  "cmdPaletteGroupActions": {
+    "message": "Hành động"
+  },
+  "cmdPaletteGroupBookmarks": {
+    "message": "Bookmarks"
+  },
+  "cmdPaletteGroupReadingList": {
+    "message": "Reading List"
+  },
+  "cmdPaletteGroupTabs": {
+    "message": "Tabs"
+  },
+  "cmdPaletteGroupWorkspaces": {
+    "message": "Workspaces"
+  },
+  "cmdPaletteHintClose": {
+    "message": "đóng"
+  },
+  "cmdPaletteHintNavigate": {
+    "message": "điều hướng"
+  },
+  "cmdPaletteHintSelect": {
+    "message": "chọn"
+  },
+  "cmdPalettePlaceholder": {
+    "message": "Tìm tabs, bookmarks hoặc hành động..."
+  },
+  "rlSummaryDescription": {
+    "message": "Khi bạn thêm một page đang mở trong tab vào Reading List, AI tóm tắt một lần và lưu kết quả cục bộ để bạn có thể preview sau — kể cả offline. Yêu cầu Summarizer model đã có sẵn."
+  },
+  "rlSummaryToggleLabel": {
+    "message": "Ghi nhớ AI summary cho các mục Reading List"
+  },
+  "shortcutDescCommandPalette": {
+    "message": "Mở Command Palette"
+  },
+  "shortcutDescPaletteClose": {
+    "message": "Đóng Command Palette"
+  },
+  "shortcutDescPaletteNav": {
+    "message": "Điều hướng kết quả Command Palette"
+  },
+  "shortcutDescPaletteSelect": {
+    "message": "Kích hoạt kết quả đã chọn"
+  },
+  "shortcutInSidepanelHeader": {
+    "message": "Shortcuts trong sidepanel"
+  },
+  "shortcutInSidepanelNote": {
+    "message": "Các shortcut này chỉ chạy trong sidepanel và không thể remap qua trang shortcuts của Chrome."
+  },
+  "workspaceCreateFromCurrent": {
+    "message": "+ Tạo từ tabs hiện tại"
+  },
+  "workspaceCreatePromptTitle": {
+    "message": "Đặt tên Workspace này"
+  },
+  "workspaceDelete": {
+    "message": "Xóa"
+  },
+  "workspaceDeleteConfirmMessage": {
+    "message": "Xóa \"{ws}\"? Hành động này không thể hoàn tác."
+  },
+  "workspaceDeleteConfirmTitle": {
+    "message": "Xóa Workspace"
+  },
+  "workspaceManageEmpty": {
+    "message": "Chưa có Workspaces."
+  },
+  "workspaceManageTitle": {
+    "message": "Quản lý Workspaces"
+  },
+  "workspaceNoActive": {
+    "message": "— không có Workspace —"
+  },
+  "workspaceRename": {
+    "message": "Đổi tên"
+  },
+  "workspaceSwitchConfirmBtn": {
+    "message": "Chuyển"
+  },
+  "workspaceSwitchConfirmMessage": {
+    "message": "Chuyển sang \"{ws}\" sẽ đóng {n} tab trong window này và mở các tabs đã lưu."
+  },
+  "workspaceSwitchConfirmMessageUnbound": {
+    "message": "Chuyển sang \"{ws}\" — {n} tab hiện tại của bạn chưa thuộc Workspace nào. Sẽ được auto-save vào Workspace \"Untitled\" mới trước khi chuyển."
+  },
+  "workspaceSwitchConfirmTitle": {
+    "message": "Chuyển Workspace"
+  },
+  "workspaceSwitchFailedMessage": {
+    "message": "Không thể chuyển Workspace. Tabs hiện tại của bạn không bị thay đổi."
+  },
+  "workspaceSwitchFailedTitle": {
+    "message": "Chuyển thất bại"
+  },
+  "workspaceSwitcherAriaLabel": {
+    "message": "Workspace đang hoạt động"
   }
 }


### PR DESCRIPTION
## 摘要 (Summary)

Phase 11 收尾全 plan 執行：補齊 Phase 4–9 累積的 i18n 缺漏並把新模組寫進 architecture index。

擴大原 Phase 11 scope（user 指示）：本次**重審 14 國 `_locales/{lang}/messages.json`**，補上所有 Phase 1–10 新增 keys 的對應翻譯，不能有任何遺漏。

### 相關 Issue (Related Issues)

無。Phase 11 of plan B（compressed-puzzling-pine.md）。

---

## 📝 變更內容 (Changes)

### Phase 11a — i18n 對齊（957 個翻譯）

**Audit 結果**：
- 14 語 `messages.json` 合併集 **252 unique keys**
- 3 語完整（zero missing）：`en` / `zh_TW` / `zh_CN`
- 11 語各缺 **87 keys**，全來自 Phase 4–9 新功能：
  - `aiAutoNaming*` / `aiCleanup*`（Phase 4）
  - `cmdPalette*` / `shortcut*`（Phase 5 + 9）
  - `workspace*`（Phase 6 + 9）
  - `bmTools*`（Phase 7）
  - `rlSummary*`（Phase 8a）

**修改**：
- `_locales/{ja,ko,de,fr,es,pt_BR,ru,hi,id,th,vi}/messages.json` — 各 +87 keys（總 957 entries）

**翻譯品質策略**（沿用 Phase 10 階梯）：

| 等級 | 語言 | 策略 |
|------|------|------|
| 高品質 | `ja`、`ko` | 完整在地化，含 marketing tone |
| 結構翻譯 | `de`、`fr`、`es`、`pt_BR`、`ru` | 結構正確；`Workspace`、`Command Palette`、`Bookmark Tools`、`Smart Group`、`Reading List` 保留英文 |
| 保守翻譯 | `hi`、`id`、`th`、`vi` | 多保留英文 keyword 維持識別性；建議 v2 native speaker 校閱 |

**實作**：
- 腳本：`/Users/Tai.Tai/.claude/jobs/86ea5cf2/p11_i18n_fill.py`（Python batch fill；不入 repo，audit-able 可重現）
- 不覆寫既有 keys：`if key in data: continue`
- 驗證：14 語 252 keys union zero missing / zero extra；placeholder spot-check 100% 保留

### Phase 11b — Docs sync

**`AGENTS.md`**：
- `Key Files Navigator` 加 `aiManager.js`、`keyboardManager.js`、`apiManager.setStorageStrict`
- 新增 5 個區段：`Command Palette` / `Workspace` / `Bookmark Tools` / `Reading List Summary` / `Utils`
- `UI 子模組` 加 `tab/tabListeners.js`、`tab/splitViewRenderer.js`、`aiCleanupUI.js`
- `Testing 基礎建設` 新表格（jest.config.js + esbuild transform）
- Timestamp 更新 2026-05-29

**`GEMINI.md`**：
- `key_files` 列表 +17 個新檔（commandPalette × 4、workspace × 2、bookmark × 5、readingList × 2、utils × 2、keyboardManager、tab × 2、jest × 2、aiCleanupUI）
- `aiManager.js` description 擴充列出 Phase 4/8 新方法

**`CLAUDE.md`**：不動。CLAUDE.md 是補 Claude Code 環境專屬慣例（gh 路徑、skill trigger keyword、session 收尾規範），不是 architecture source of truth。

### Phase 11c — NOTE

- `.agent/notes/NOTE_20260529_phase11.md` — Phase 11 摘要 + **Phase 1–11 全 plan 整體回顧表**

### 重要決策說明

- **階梯式翻譯品質**：對 hi/id/th/vi 保留更多英文 keyword 是務實策略；Chrome i18n 實務上小語種 UI 常見此 pattern。v1 確保「所有 key 100% 對齊不遺漏」，marketing tone review 留 v2。
- **不重命名 schema keys**：所有翻譯加在既有 key 名下，不變動 messages.json schema，無 runtime 風險。
- **Python AST script 走 job dir 不入 repo**：mass-apply 操作的 reproducibility 重要但工具腳本不屬於專案資產（同 Phase 10 慣例）。
- **CLAUDE.md 維持不動**：架構 source of truth 已在 AGENTS.md，避免雙寫導致 drift。

---

## 🧪 測試 (Testing)

### 自動化檢查

- ✅ 14 個 `_locales/{lang}/messages.json` 通過 `json.load` round-trip
- ✅ 14 語 252 keys union 完全對齊（zero missing / zero extra）
- ✅ 5 個含 placeholder 的 keys spot-check（`aiCleanupFound` / `workspaceSwitchConfirmMessage` / `bmToolsNetworkRatioWarning` / `rlSummaryDescription` / `cmdPalettePlaceholder`）— `{count}` / `{ws}` / `{n}` / `{total}` / `{pct}` 100% 保留
- ⚠️ 本 phase 無 code 改動 — Puppeteer / unit test skip

### 手動驗證

1. `make` → `chrome://extensions` 載入未封裝 → Chrome 切到任一語（系統設定）應看到該語的 UI 字串
2. 開 sidepanel → ⌘K Command Palette → action / group 名稱應顯示對應語版本
3. ✨ Smart Group → empty group → 自動命名應觸發
4. 🧹 AI Cleanup（若有 model） → 建議清單頁應顯示對應語
5. Bookmark Tools modal → tags / duplicates / dead-link 3 tab 字串應顯示對應語

---

## ✅ 檢查清單 (Checklist)

- [x] 程式碼 / 文案遵循專案 style
- [x] 自動化檢查通過（JSON valid）
- [x] `.agent/notes/NOTE_20260529_phase11.md` 已寫
- [x] PR 描述包含英文版本
- [ ] **後續**（v2）：hi/id/th/vi 找 native speaker 校閱
- [ ] **後續**：12 個 README 全語完整 KW features section（v2）
- [ ] **後續**：`/why-not-native/` landing page 多語版本（v2）

---

## 🌐 English Version

### Summary

Phase 11 wraps up the entire plan: backfill all i18n keys accumulated through phases 4–9 and sync the new modules into the architecture index.

The user expanded the original Phase 11 scope: re-audit all 14 `_locales/{lang}/messages.json`, fill *every* key added in phases 1–10 across every language, no omissions allowed.

### Changes

#### Phase 11a — i18n alignment (957 translations)

- Audit: 252 union keys across 14 langs; 3 langs (en / zh_TW / zh_CN) complete, **11 langs each missing 87 keys** sourced from Phase 4–9 features
- Filled 957 entries (87 × 11) using a Python batch script
- Tiered translation quality (same ladder as Phase 10):
  - **High fidelity**: ja, ko — full localization with marketing tone
  - **Structural**: de, fr, es, pt_BR, ru — brand terms (Workspace / Command Palette / Bookmark Tools / Smart Group / Reading List) kept in English
  - **Conservative**: hi, id, th, vi — more English keywords retained for recognizability; v2 native review recommended
- Script: `/Users/Tai.Tai/.claude/jobs/86ea5cf2/p11_i18n_fill.py` (kept in job dir, not repo)
- Never overwrites existing keys; verified zero missing / zero extra across all 14 langs; placeholders ({count}/{ws}/{n}/{total}/{pct}) preserved verbatim

#### Phase 11b — Docs sync

- **AGENTS.md**: Key Files Navigator expanded; 5 new section tables (Command Palette / Workspace / Bookmark Tools / Reading List Summary / Utils); UI submodules added; jest infra table; timestamp bumped
- **GEMINI.md**: `key_files` list +17 new entries; `aiManager.js` description extended with Phase 4/8 methods
- **CLAUDE.md**: untouched. It's a Claude-Code-specific supplement (gh path, skill triggers, session wrap-up), not the architecture source of truth.

#### Phase 11c — NOTE

`.agent/notes/NOTE_20260529_phase11.md` includes a **Phase 1–11 full plan recap table**.

### Key decisions

- **Tiered translation quality**: pragmatic for hi/id/th/vi — Chrome i18n in practice often keeps English keywords in smaller languages. v1 guarantees zero missing keys; marketing-tone polish for v2.
- **No schema renames**: all translations attach to existing keys; zero runtime risk.
- **Python script in job dir, not repo**: reproducibility matters but tooling isn't a project asset (same convention as Phase 10).
- **CLAUDE.md left alone**: architecture source of truth lives in AGENTS.md; avoid the double-write drift.

### Testing

- 14 `messages.json` files pass `json.load` round-trip
- 14 langs 252 keys union: zero missing / zero extra
- 5 placeholder-bearing keys verified across all 11 langs: `{count}` / `{ws}` / `{n}` / `{total}` / `{pct}` 100% preserved
- ⚠️ No code changes — Puppeteer / unit tests skipped

### Related Issues

None. Phase 11 of plan B (compressed-puzzling-pine.md).
