### PR TITLE
feat(tags): tag color picker + tag: search filter + click-dot-to-filter

### DIFF
--- a/.agent/notes/NOTE_20260601_bookmark_tag_color_search.md
+++ b/.agent/notes/NOTE_20260601_bookmark_tag_color_search.md
@@ -1,0 +1,22 @@
+# NOTE 2026-06-01 — 書籤標籤強化：顏色 + tag: 搜尋
+
+## 背景
+批 A 的書籤標籤有兩個缺口（管理 UI 無法設定顏色；搜尋無法依標籤篩選），使其形同半成品。本次補齊。分支 `feat/bookmark-tag-color-and-search`（從合併後的 main，含 A–E）。
+
+spec：`docs/superpowers/specs/2026-06-01-bookmark-tag-color-and-search-design.md`；plan：`docs/superpowers/plans/2026-06-01-bookmark-tag-color-and-search.md`。
+
+## 做了什麼
+- **純函式（TDD）** `modules/utils/searchUtils.js`：`parseSearchQuery(query)`→`{keywords,tags}`（抽 `tag:單詞` 與 `tag:"含空白"`、tag 名小寫）、`bookmarkMatchesTags(have, required)`（AND、大小寫不敏感、精確名稱）。10 個新單元測試。
+- **顏色** `modules/modalManager.js` 新增 `showTagDialog({title,defaultName,defaultColor})`（仿 `showCreateGroupDialog`：名稱 input + 8 色票 + 鍵盤/focus trap）；`bookmarkToolsUI` 建立/編輯標籤改用它（編輯後 dispatch `refreshBookmarksRequired` 讓書籤列圓點換色）。`.tag-color-swatch[data-color]` 色值與 `.bm-tools__tag-chip` 一致。
+- **搜尋** `modules/searchManager.js`：`handleSearch` 用 `parseSearchQuery`；`filterBookmarks(keywords,regexes,tags)` 以 `kwOk && tagOk`（tagOk 用 `getTagsForBookmark`）篩選；空-both 才還原完整視圖；分頁/閱讀清單只吃 keywords（tag token 已分離，不受影響）。
+- **點圓點篩選** `modules/ui/bookmarkRenderer.js`：圓點加 `dataset.tagName`；委派 click 最前攔截 → 設 `#search-box` 值為 `tag:<name>`（含空白則加引號）+ dispatch input（觸發既有 debounced 搜尋）+ stopPropagation（不開書籤）。`.bookmark-tag-dot{cursor:pointer}`。
+- **i18n** `bmToolsEditTag` × 14 語系。
+
+## 驗證 / 狀態
+- 單元 228 綠（含 searchUtils 新測試）；`test:ci` 49 綠（含新 E2E `happy_path_bookmark_tag_color_search`）；`test:full` 102 passed / 0 failed；`make`/`make release` OK。
+- 整體 code review：ready to merge，無 Critical/Important。
+- 已知 Minor（非阻斷）：建立對話框標題沿用 `bmToolsCreateTagPrompt`（「New tag name」）略不順；標籤名含字面雙引號不完美 round-trip（spec 已列非目標）；tag-only 查詢不篩分頁/閱讀清單（符合意圖）。
+
+## 後續
+- 5 commit（`269653b`…`0fffd38`）；本批與 Drive 無關、無敏感權限，可獨立 merge。
+- 未了：批 E Drive 同步的 OAuth live 測試（待 owner，與本批無關）。

--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -761,6 +761,9 @@
   "bmToolsCreateTagPrompt": {
     "message": "Neuer Tag-Name"
   },
+  "bmToolsEditTag": {
+    "message": "Tag bearbeiten"
+  },
   "bmToolsDeadLinksIntro": {
     "message": "Scan versucht jedes http(s)-Lesezeichen via HEAD zu erreichen. Nur netzwerk-unerreichbare Links werden markiert (HTTP 404 kann ohne pro-Origin CORS nicht erkannt werden, siehe Notes)."
   },

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -872,6 +872,9 @@
   "bmToolsCreateTagPrompt": {
     "message": "New tag name"
   },
+  "bmToolsEditTag": {
+    "message": "Edit tag"
+  },
   "bmToolsDeleteTagTitle": {
     "message": "Delete tag"
   },

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -761,6 +761,9 @@
   "bmToolsCreateTagPrompt": {
     "message": "Nombre de la nueva etiqueta"
   },
+  "bmToolsEditTag": {
+    "message": "Editar etiqueta"
+  },
   "bmToolsDeadLinksIntro": {
     "message": "El escaneo intenta alcanzar cada marcador http(s) vía HEAD. Solo se marcan los enlaces inalcanzables por red (HTTP 404 no se puede detectar sin CORS por origen, ver notas)."
   },

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -761,6 +761,9 @@
   "bmToolsCreateTagPrompt": {
     "message": "Nom de la nouvelle étiquette"
   },
+  "bmToolsEditTag": {
+    "message": "Modifier l'étiquette"
+  },
   "bmToolsDeadLinksIntro": {
     "message": "Le scan tente d'atteindre chaque signet http(s) via HEAD. Seuls les liens inaccessibles via le réseau sont signalés (HTTP 404 ne peut pas être détecté sans CORS par origine, voir notes)."
   },

--- a/_locales/hi/messages.json
+++ b/_locales/hi/messages.json
@@ -761,6 +761,9 @@
   "bmToolsCreateTagPrompt": {
     "message": "नए tag का नाम"
   },
+  "bmToolsEditTag": {
+    "message": "टैग संपादित करें"
+  },
   "bmToolsDeadLinksIntro": {
     "message": "Scan HEAD से हर http(s) bookmark तक पहुंचने की कोशिश करता है। केवल network-unreachable links flag होते हैं (HTTP 404 per-origin CORS के बिना detect नहीं हो सकता, notes देखें)।"
   },

--- a/_locales/id/messages.json
+++ b/_locales/id/messages.json
@@ -761,6 +761,9 @@
   "bmToolsCreateTagPrompt": {
     "message": "Nama tag baru"
   },
+  "bmToolsEditTag": {
+    "message": "Edit tag"
+  },
   "bmToolsDeadLinksIntro": {
     "message": "Scan mencoba menjangkau setiap bookmark http(s) via HEAD. Hanya link yang tidak terjangkau jaringan yang ditandai (HTTP 404 tidak dapat dideteksi tanpa per-origin CORS, lihat notes)."
   },

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -761,6 +761,9 @@
   "bmToolsCreateTagPrompt": {
     "message": "新しいタグ名"
   },
+  "bmToolsEditTag": {
+    "message": "タグを編集"
+  },
   "bmToolsDeadLinksIntro": {
     "message": "スキャンは HEAD ですべての http(s) ブックマークに接続を試みます。ネットワーク到達不可のリンクのみフラグされます（HTTP 404 は CORS なしでは検出不可、ノート参照）。"
   },

--- a/_locales/ko/messages.json
+++ b/_locales/ko/messages.json
@@ -761,6 +761,9 @@
   "bmToolsCreateTagPrompt": {
     "message": "새 태그 이름"
   },
+  "bmToolsEditTag": {
+    "message": "태그 편집"
+  },
   "bmToolsDeadLinksIntro": {
     "message": "스캔은 HEAD 로 모든 http(s) 북마크에 도달을 시도합니다. 네트워크 도달 불가 링크만 표시됩니다(HTTP 404 는 CORS 없이는 감지 불가, 노트 참조)."
   },

--- a/_locales/pt_BR/messages.json
+++ b/_locales/pt_BR/messages.json
@@ -761,6 +761,9 @@
   "bmToolsCreateTagPrompt": {
     "message": "Nome da nova tag"
   },
+  "bmToolsEditTag": {
+    "message": "Editar etiqueta"
+  },
   "bmToolsDeadLinksIntro": {
     "message": "A varredura tenta alcançar cada favorito http(s) via HEAD. Apenas links inacessíveis pela rede são sinalizados (HTTP 404 não pode ser detectado sem CORS por origem, ver notas)."
   },

--- a/_locales/ru/messages.json
+++ b/_locales/ru/messages.json
@@ -761,6 +761,9 @@
   "bmToolsCreateTagPrompt": {
     "message": "Имя нового тега"
   },
+  "bmToolsEditTag": {
+    "message": "Изменить тег"
+  },
   "bmToolsDeadLinksIntro": {
     "message": "Сканирование пытается достичь каждую http(s)-закладку через HEAD. Только сетево-недостижимые ссылки помечаются (HTTP 404 нельзя обнаружить без per-origin CORS, см. notes)."
   },

--- a/_locales/th/messages.json
+++ b/_locales/th/messages.json
@@ -761,6 +761,9 @@
   "bmToolsCreateTagPrompt": {
     "message": "ชื่อ tag ใหม่"
   },
+  "bmToolsEditTag": {
+    "message": "แก้ไขแท็ก"
+  },
   "bmToolsDeadLinksIntro": {
     "message": "Scan พยายามเข้าถึงทุก http(s) bookmark ผ่าน HEAD เฉพาะ link ที่ network unreachable ถูกระบุ (HTTP 404 ตรวจไม่ได้หากไม่มี per-origin CORS, ดู notes)"
   },

--- a/_locales/vi/messages.json
+++ b/_locales/vi/messages.json
@@ -761,6 +761,9 @@
   "bmToolsCreateTagPrompt": {
     "message": "Tên tag mới"
   },
+  "bmToolsEditTag": {
+    "message": "Sửa thẻ"
+  },
   "bmToolsDeadLinksIntro": {
     "message": "Scan cố gắng tiếp cận mọi bookmark http(s) qua HEAD. Chỉ các link không thể tiếp cận qua mạng được đánh dấu (HTTP 404 không thể phát hiện mà không có per-origin CORS, xem notes)."
   },

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -869,6 +869,9 @@
   "bmToolsCreateTagPrompt": {
     "message": "新标签名称"
   },
+  "bmToolsEditTag": {
+    "message": "编辑标签"
+  },
   "bmToolsDeleteTagTitle": {
     "message": "删除标签"
   },

--- a/_locales/zh_TW/messages.json
+++ b/_locales/zh_TW/messages.json
@@ -869,6 +869,9 @@
   "bmToolsCreateTagPrompt": {
     "message": "新標籤名稱"
   },
+  "bmToolsEditTag": {
+    "message": "編輯標籤"
+  },
   "bmToolsDeleteTagTitle": {
     "message": "刪除標籤"
   },

--- a/docs/superpowers/plans/2026-06-01-bookmark-tag-color-and-search.md
+++ b/docs/superpowers/plans/2026-06-01-bookmark-tag-color-and-search.md
@@ -1,0 +1,125 @@
+# 書籤標籤強化 Implementation Plan
+
+> REQUIRED SUB-SKILL: superpowers:subagent-driven-development。Steps 用 checkbox。
+
+**Goal:** 標籤可選顏色 + `tag:` 搜尋語法（含點圓點篩選）。
+**Architecture:** 解析與比對抽成 `searchUtils.js` 純函式（TDD）；UI（色票 dialog、tag filter、點圓點）薄接線。
+**前置:** 分支 `feat/bookmark-tag-color-and-search`（from merged main）。測試：`npm run test:unit` / `test:ci` / `test:full`。
+
+---
+
+## T1: 純函式 parseSearchQuery + bookmarkMatchesTags（TDD）
+**Files:** `modules/utils/searchUtils.js`（追加 export）；`usecase_tests/unit_tests/searchUtils.test.mjs`（追加）
+
+- [ ] **失敗測試**（追加到 searchUtils.test.mjs）：
+```js
+import { parseSearchQuery, bookmarkMatchesTags } from '../../modules/utils/searchUtils.js';
+
+describe('parseSearchQuery', () => {
+  it('分離 tag: token 與一般關鍵字', () => {
+    expect(parseSearchQuery('react tag:工作')).toEqual({ keywords: ['react'], tags: ['工作'] });
+  });
+  it('支援引號包住含空白的標籤名', () => {
+    expect(parseSearchQuery('tag:"side pj" hooks')).toEqual({ keywords: ['hooks'], tags: ['side pj'] });
+  });
+  it('多個 tag: 累積、tag 名小寫化', () => {
+    expect(parseSearchQuery('tag:Work tag:Read')).toEqual({ keywords: [], tags: ['work', 'read'] });
+  });
+  it('空字串 → 皆空', () => {
+    expect(parseSearchQuery('   ')).toEqual({ keywords: [], tags: [] });
+  });
+  it('純關鍵字、無 tag', () => {
+    expect(parseSearchQuery('foo bar')).toEqual({ keywords: ['foo', 'bar'], tags: [] });
+  });
+});
+
+describe('bookmarkMatchesTags', () => {
+  it('需包含所有 required（AND、大小寫不敏感、精確名稱）', () => {
+    expect(bookmarkMatchesTags(['Work', 'Read'], ['work'])).toBe(true);
+    expect(bookmarkMatchesTags(['Work'], ['work', 'read'])).toBe(false);
+  });
+  it('required 為空 → true', () => {
+    expect(bookmarkMatchesTags(['Work'], [])).toBe(true);
+    expect(bookmarkMatchesTags([], [])).toBe(true);
+  });
+  it('精確比對，不做子字串', () => {
+    expect(bookmarkMatchesTags(['Workspace'], ['work'])).toBe(false);
+  });
+});
+```
+- [ ] 跑 `npm run test:unit -- searchUtils` 確認 FAIL。
+- [ ] **實作**（追加到 searchUtils.js）：
+```js
+/**
+ * 將搜尋字串拆成一般關鍵字與 tag: 篩選。
+ * 支援 tag:單詞 與 tag:"含空白名稱"；tag 名稱小寫化。
+ * @param {string} query
+ * @returns {{keywords: string[], tags: string[]}}
+ */
+export function parseSearchQuery(query) {
+    const tags = [];
+    if (typeof query !== 'string') return { keywords: [], tags };
+    // 先抽出 tag:"..." 與 tag:\S+
+    const rest = query.replace(/tag:"([^"]*)"|tag:(\S+)/gi, (_, quoted, bare) => {
+        const name = (quoted !== undefined ? quoted : bare).trim().toLowerCase();
+        if (name) tags.push(name);
+        return ' ';
+    });
+    const keywords = rest.toLowerCase().split(/\s+/).filter(k => k.length > 0);
+    return { keywords, tags };
+}
+
+/**
+ * 書籤是否含全部 required 標籤（AND、大小寫不敏感、精確名稱比對）。
+ * @param {string[]} bookmarkTagNames @param {string[]} requiredTagNames
+ * @returns {boolean}
+ */
+export function bookmarkMatchesTags(bookmarkTagNames, requiredTagNames) {
+    if (!requiredTagNames || requiredTagNames.length === 0) return true;
+    const have = new Set((bookmarkTagNames || []).map(n => String(n).toLowerCase()));
+    return requiredTagNames.every(req => have.has(String(req).toLowerCase()));
+}
+```
+- [ ] 跑 `npm run test:unit -- searchUtils` 綠；全 `test:unit` 無回歸。
+- [ ] Commit：`feat(search): parseSearchQuery + bookmarkMatchesTags pure helpers`
+
+## T2: showTagDialog + 標籤建立/編輯接色票
+**Files:** `modules/modalManager.js`（新增 showTagDialog）；`modules/bookmark/bookmarkToolsUI.js`
+
+- [ ] READ `modalManager.showCreateGroupDialog`（名稱 input + 色票 swatch + 鍵盤）與 `bookmarkToolsUI` 的 `renderTagsView`(create) 與 `buildTagRow`(rename)。
+- [ ] 新增 `export function showTagDialog({ title, defaultName='', defaultColor='blue' })` → Promise<{name,color}|null>，仿 showCreateGroupDialog：名稱 input（預填 defaultName）+ 一排色票（`tagManager.getPresetColors()` 的 8 色；色票背景用既有 `.bm-tools__tag-chip[data-color]` 對映的 hex，或直接套 data-color class）。預選 defaultColor。確認鍵 resolve {name:trim, color}；取消/overlay resolve null。沿用 createModal/removeModal + focus。
+- [ ] `bookmarkToolsUI`：
+  - create 按鈕：改呼叫 `modal.showTagDialog({title: 建立標籤})`，結果非空 → `tagManager.createTag({name,color})`，append row。
+  - `buildTagRow` 的 ✏️：改呼叫 `modal.showTagDialog({title:編輯標籤, defaultName:tag.name, defaultColor:tag.color})` → `tagManager.updateTag(id,{name,color})`，更新該列 chip 的 textContent + `dataset.color = color`，並 dispatch `refreshBookmarksRequired`（讓書籤列圓點換色）。
+- [ ] 驗證：`make` OK；`test:unit` 綠。Commit：`feat(tags): color picker when creating/editing a tag`
+
+## T3: searchManager 依 tag 篩選
+**Files:** `modules/searchManager.js`
+
+- [ ] import `parseSearchQuery, bookmarkMatchesTags`（from searchUtils）與 `tagManager`（getTagsForBookmark）。
+- [ ] `handleSearch`：`const { keywords, tags } = parseSearchQuery(ui.searchBox.value.trim());` regexes 仍只由 keywords 建；分頁/閱讀清單仍只吃 `keywords`（tag token 已分離，不影響它們）；`filterBookmarks(keywords, regexes, tags)`。空判斷改為 `keywords.length===0 && tags.length===0` 才視為「無查詢→還原完整視圖」。
+- [ ] `filterBookmarks(keywords, regexes, tags = [])`：早退條件改為 `keywords.length===0 && tags.length===0`。比對改為：`const kwOk = keywords.length===0 || (titleMatches||urlMatches); const tagOk = bookmarkMatchesTags(tagManager.getTagsForBookmark(item.id).map(t=>t.name), tags); return kwOk && tagOk;`（仍設定 `_titleMatches/_urlMatches` 供高亮；tag-only 時兩者皆 false、不高亮也 OK）。
+- [ ] 驗證 `make`、`test:unit`。Commit：`feat(search): filter bookmarks by tag: tokens`
+
+## T4: 點書籤圓點即篩選
+**Files:** `modules/ui/bookmarkRenderer.js`
+
+- [ ] 圓點渲染處（updateBookmarkElement 的 `.bookmark-tag-dot`）：加 `dot.dataset.tagName = tag.name`，並給游標提示（`cursor:pointer`，由 CSS）。
+- [ ] 在 `initBookmarkListeners` 的委派 click handler 最前面攔截：`const dot = e.target.closest('.bookmark-tag-dot'); if (dot) { e.preventDefault(); e.stopPropagation(); const name = dot.dataset.tagName || ''; const token = /\s/.test(name) ? 'tag:"'+name+'"' : 'tag:'+name; const box = document.getElementById(<search input id>); if (box){ box.value = token; box.dispatchEvent(new Event('input', {bubbles:true})); box.focus(); } return; }`（先確認搜尋框實際 id/選擇器——讀 sidepanel.html / searchUI；用既有 input 事件觸發 debounce 搜尋，不要直接 import handleSearch 以免循環）。
+- [ ] CSS：`.bookmark-tag-dot{cursor:pointer}`（sidepanel.css）。
+- [ ] 驗證 `make`。Commit：`feat(bookmark): click a tag dot to filter by that tag`
+
+## T5: i18n + E2E + 全量驗證 + 最終 review
+- [ ] i18n：新增 key（編輯標籤標題、顏色 等，~3-5 個）× 14 語系（en + 翻譯），JSON 驗證。
+- [ ] E2E（Puppeteer，沿用既有 setup）：
+  - 建立帶顏色標籤 → 該標籤 chip / 對書籤貼上後書籤列圓點為該色；編輯改色 → 更新。
+  - 對一書籤貼標籤，搜尋框輸入 `tag:<name>` → 只列該書籤；點該書籤圓點 → 搜尋框成 `tag:<name>` 並篩選。
+  跑兩次穩定。
+- [ ] 全量：`test:unit`、`test:ci`、`test:full`（全綠）、`make`/`make release`。
+- [ ] 文件：GEMINI key_files 視需要、`.agent/notes`；最終整體 code review。
+- [ ] Commit + 收尾（本批可獨立 merge——與 Drive 無關、不涉敏感權限）。
+
+## Self-Review
+- 覆蓋：顏色(T2)、tag: 搜尋(T1+T3)、點圓點(T4)、i18n/E2E(T5)。
+- 純函式 TDD（T1）；UI 走 make/E2E。
+- 風險：搜尋框 id/觸發方式以實際程式為準（T4 要先讀）；tag-only 查詢時分頁/閱讀清單不受影響（已分離 keywords）。

--- a/docs/superpowers/specs/2026-06-01-bookmark-tag-color-and-search-design.md
+++ b/docs/superpowers/specs/2026-06-01-bookmark-tag-color-and-search-design.md
@@ -1,0 +1,64 @@
+# 書籤標籤強化：顏色選擇 + tag: 搜尋篩選
+
+- **日期**：2026-06-01
+- **狀態**：設計待核可
+- **分支**：`feat/bookmark-tag-color-and-search`（從合併後的 main）
+- **背景**：批 A 加入了書籤標籤（多標籤、書籤列彩色圓點、Tags 管理分頁），但有兩個缺口讓它形同半成品：(1) 管理 UI 無法設定標籤顏色（資料層支援、UI 沒提供 → 全是預設藍），(2) 搜尋無法依標籤篩選。本次補齊。
+
+## 目標
+1. **標籤顏色**：建立／編輯標籤時可選顏色（8 色，沿用 `tagManager.getPresetColors()`）；書籤列圓點與 Tags 分頁 chip 立即反映。
+2. **tag: 搜尋篩選**：在搜尋框輸入 `tag:工作` 即只列出貼了該標籤的書籤；支援 `tag:"含空白 名稱"`；可與一般關鍵字併用（tag AND keyword）；點書籤列的標籤圓點即自動以該標籤篩選。
+
+### 非目標
+- 不改標籤資料結構（`{id,name,color,createdAt}` 已足夠）。
+- 不做標籤的階層/群組、不做分頁(tab)依標籤篩選（標籤只屬書籤）。
+
+## 現況事實（已驗證）
+| 項目 | 事實 | 出處 |
+|------|------|------|
+| 標籤資料層支援顏色 | `createTag({name,color})`、`updateTag(id,{color})`、`getPresetColors()`(8 色) | `tagManager.js:54-82` |
+| 管理 UI 無顏色 | 建立/改名都只 `modal.showPrompt`(名稱) | `bookmarkToolsUI.js:117,147` |
+| 色票 UI 範本 | `modalManager.showCreateGroupDialog`：名稱輸入 + 色票 swatch + 鍵盤導航 | `modalManager.js` |
+| 圓點渲染 | `bookmark-tag-dot[data-color]`、`title=tag.name`，於 `updateBookmarkElement` | `bookmarkRenderer.js`（批 A） |
+| 取書籤標籤 | `tagManager.getTagsForBookmark(id)` → `[{id,name,color}]` | `tagManager.js:41` |
+| 搜尋入口 | `handleSearch`：`query.split(/\s+/)` → keywords；`filterBookmarks(keywords,regexes)` | `searchManager.js:11-43,337` |
+| 書籤過濾 | 比對 `matchesAnyKeyword(title)`/`extractDomain(url)`；空 query → 還原完整視圖 | `searchManager.js:337-382` |
+| 純函式測試慣例 | `usecase_tests/unit_tests/*.test.mjs`（node、無 chrome） | — |
+
+## 設計
+
+### A. 標籤顏色
+- 新增 `modalManager.showTagDialog({ title, defaultName='', defaultColor='blue' })` → resolve `{name, color}` 或 `null`。
+  - 結構仿 `showCreateGroupDialog`：名稱 `<input>` + 一排色票（用 `tagManager.getPresetColors()` 的 8 色，色值對映既有 `.bm-tools__tag-chip[data-color]` 的 CSS），含鍵盤可選、focus trap（沿用 createModal）。
+- `bookmarkToolsUI`：
+  - **建立標籤**：`renderTagsView` 的 create 按鈕改呼叫 `showTagDialog({title:建立標籤})` → `createTag({name,color})`。
+  - **編輯標籤**：`buildTagRow` 的 rename(✏️) 按鈕改為「編輯」，呼叫 `showTagDialog({title:編輯標籤, defaultName:tag.name, defaultColor:tag.color})` → `updateTag(id,{name,color})`，並就地更新該列 chip 的 `data-color` 與文字。
+  - 變更標籤顏色後，書籤列圓點需反映：沿用既有 `refreshBookmarksRequired` 事件觸發重繪（圓點讀 `tag.color`）。
+- i18n：新增少量 key（編輯標籤標題、顏色標籤等），沿用 fallback；之後補 14 語系。
+
+### B. tag: 搜尋篩選
+- **純函式** `parseSearchQuery(query)` → `{ keywords: string[], tags: string[] }`：
+  - 抽出 `tag:"含空白"` 與 `tag:單詞` token（tag 名稱小寫化、去引號）放入 `tags`；其餘空白分隔詞放入 `keywords`。
+  - 例：`react tag:工作 tag:"side pj"` → `{keywords:['react'], tags:['工作','side pj']}`。
+- **純函式** `bookmarkMatchesTags(bookmarkTagNames, requiredTagNames)` → bool：requiredTagNames 皆需出現在 bookmarkTagNames（大小寫不敏感、**精確比對**名稱；AND）；requiredTagNames 為空 → true。
+- `handleSearch`：改用 `parseSearchQuery` 取得 `{keywords, tags}`；highlight regexes 只用 keywords（tag token 不高亮）；把 `tags` 傳入 `filterBookmarks`。空 query（keywords 與 tags 皆空）→ 維持現有「還原完整視圖」行為。
+- `filterBookmarks(keywords, regexes, tags=[])`：書籤需同時滿足
+  - keyword 條件：`keywords.length===0` 視為通過，否則 title/url 命中（沿用現有邏輯）；且
+  - tag 條件：`tags.length===0` 視為通過，否則 `bookmarkMatchesTags(getTagsForBookmark(item.id).map(t=>t.name), tags)`。
+  - 只有 tag、無 keyword 時：列出所有具該標籤的書籤（keyword 條件自動通過）。
+- **點圓點篩選**：`bookmark-tag-dot` 加 `data-tag-name`（=tag.name）；在書籤容器的委派 click 處理（`bookmarkRenderer` initBookmarkListeners）攔截圓點點擊 → 設 `searchBox.value = tag:<name>`（名稱含空白則加引號）→ 觸發搜尋（dispatch `input` 事件，沿用既有 debounce listener）。點擊不應同時觸發開啟書籤（stopPropagation）。
+
+## 影響面
+- 改：`modalManager.js`(showTagDialog)、`bookmarkToolsUI.js`(建立/編輯標籤接色票)、`searchManager.js`(parse + filter tags)、`bookmarkRenderer.js`(圓點 data-tag-name + 點擊篩選)、`sidepanel.css`(色票/編輯 UI 微調，多半可重用既有 swatch 樣式)、`_locales`(少量新 key)。
+- 不影響：標籤資料層、Drive 同步、其他搜尋（分頁/閱讀清單只比對 keyword，tag token 對它們無作用——需確認 tag-only 查詢時分頁/閱讀清單合理地不誤篩；做法：分頁/閱讀清單仍只吃 keywords，tag token 已被 parseSearchQuery 分離，故它們看到的是去掉 tag token 後的 keywords）。
+
+## 測試策略
+- 單元（TDD）：`parseSearchQuery`（單詞/引號/混合/僅 tag/空）、`bookmarkMatchesTags`（AND、大小寫、空集合、不符）。
+- E2E（Puppeteer，沿用既有 harness）：
+  - 建立帶顏色標籤 → 書籤列圓點為該色；編輯標籤改色 → 圓點更新。
+  - 對書籤貼標籤後，搜尋框輸入 `tag:<name>` → 只列出該書籤；點圓點 → 搜尋框填入 `tag:<name>` 並篩選。
+- 迴歸：`npm run test:ci`（含 main 已修好的 happy_path 測試）不破壞；`test:full` 全綠。
+
+## 後續備忘
+- #5 Drive 同步的 OAuth live 測試（待 owner）。
+- tag: 搜尋若未來要支援「OR / 排除(-tag:)」可再擴充 parseSearchQuery。

--- a/modules/bookmark/bookmarkToolsUI.js
+++ b/modules/bookmark/bookmarkToolsUI.js
@@ -114,12 +114,11 @@ function renderTagsView(root) {
     createBtn.className = 'bm-tools__create';
     createBtn.textContent = api.getMessage('bmToolsCreateTag') || '+ New tag';
     createBtn.addEventListener('click', async () => {
-        const name = await modal.showPrompt({
-            title: api.getMessage('bmToolsCreateTagPrompt') || 'New tag name',
-            defaultValue: '',
+        const res = await modal.showTagDialog({
+            title: api.getMessage('bmToolsCreateTagPrompt') || 'New tag',
         });
-        if (!name || !name.trim()) return;
-        const tag = await tagManager.createTag({ name: name.trim() });
+        if (!res || !res.name) return;
+        const tag = await tagManager.createTag({ name: res.name, color: res.color });
         const empty = list.querySelector('.bm-tools__empty');
         if (empty) empty.remove();
         list.appendChild(buildTagRow(tag, list));
@@ -143,18 +142,22 @@ function buildTagRow(tag, listEl) {
     count.textContent = `${bookmarkCount} bookmark(s)`;
     row.appendChild(count);
 
-    const renameBtn = iconBtn('✏️', api.getMessage('workspaceRename') || 'Rename', async () => {
-        const newName = await modal.showPrompt({
-            title: api.getMessage('workspaceRename') || 'Rename',
-            defaultValue: tag.name,
+    const editBtn = iconBtn('✏️', api.getMessage('bmToolsEditTag') || 'Edit tag', async () => {
+        const res = await modal.showTagDialog({
+            title: api.getMessage('bmToolsEditTag') || 'Edit tag',
+            defaultName: tag.name,
+            defaultColor: tag.color,
         });
-        if (newName && newName.trim()) {
-            await tagManager.updateTag(tag.id, { name: newName.trim() });
-            tag.name = newName.trim();
-            chip.textContent = tag.name;
-        }
+        if (!res || !res.name) return;
+        await tagManager.updateTag(tag.id, { name: res.name, color: res.color });
+        tag.name = res.name;
+        tag.color = res.color;
+        chip.textContent = tag.name;
+        chip.dataset.color = tag.color;
+        // Re-render bookmark rows so their tag dots pick up the new color.
+        document.dispatchEvent(new CustomEvent('refreshBookmarksRequired'));
     });
-    row.appendChild(renameBtn);
+    row.appendChild(editBtn);
 
     const deleteBtn = iconBtn('🗑️', api.getMessage('workspaceDelete') || 'Delete', async () => {
         const ok = await modal.showConfirm({

--- a/modules/modalManager.js
+++ b/modules/modalManager.js
@@ -1,6 +1,9 @@
 import * as api from './apiManager.js';
 import { escapeHtml } from './utils/textUtils.js';
 import { GROUP_COLORS } from './ui/groupColors.js';
+// tagManager only imports apiManager (no modalManager/tagManager cycle), so this
+// import is safe. We only need the preset color name list here.
+import { getPresetColors } from './bookmark/tagManager.js';
 
 /**
  * 追蹤目前開啟的 Modal 相關資訊，用於 Focus 管理
@@ -691,6 +694,121 @@ export function showCreateGroupDialog() {
             const title = input.value.trim();
             if (title) {
                 cleanupAndResolve({ title, color: selectedColor });
+            } else {
+                input.focus();
+            }
+        };
+
+        const cancelBtn = modalContent.querySelector('.cancel-btn');
+        cancelBtn.onclick = () => cleanupAndResolve(null);
+        overlay.onclick = (e) => {
+            if (e.target === overlay) {
+                cleanupAndResolve(null);
+            }
+        };
+    });
+}
+
+/**
+ * Name + color picker dialog for creating / editing a bookmark tag.
+ * Mirrors showCreateGroupDialog: a name input plus a row of color swatches with
+ * click + keyboard (Enter/Space to select, arrows to move) selection.
+ *
+ * @param {{ title: string, defaultName?: string, defaultColor?: string }} args
+ * @returns {Promise<{name: string, color: string} | null>}
+ */
+export function showTagDialog({ title, defaultName = '', defaultColor = 'blue' }) {
+    return new Promise((resolve) => {
+        const presetColors = getPresetColors();
+        let selectedColor = presetColors.includes(defaultColor) ? defaultColor : presetColors[0];
+
+        const form = document.createElement('form');
+        form.noValidate = true;
+        form.className = 'create-group-form';
+
+        const colorSwatches = presetColors.map((colorName) => `
+            <div class="color-swatch tag-color-swatch ${colorName === selectedColor ? 'selected' : ''}"
+                 data-color="${colorName}"
+                 tabindex="0"
+                 role="radio"
+                 aria-checked="${colorName === selectedColor}"
+                 aria-label="${colorName}"
+                 title="${colorName}"></div>
+        `).join('');
+
+        form.innerHTML = `
+            <h3 class="modal-title">${escapeHtml(title)}</h3>
+            <input type="text" class="modal-input" value="${escapeHtml(defaultName)}">
+            <div class="color-swatches-container" role="radiogroup">${colorSwatches}</div>
+            <div class="modal-buttons">
+                <button type="button" class="modal-button cancel-btn">${api.getMessage("cancelButton") || 'Cancel'}</button>
+                <button type="submit" class="modal-button confirm-btn primary">${api.getMessage("saveButton") || api.getMessage("confirmButton") || 'Save'}</button>
+            </div>
+        `;
+
+        const { overlay, modalContent } = createModal(form);
+
+        const input = modalContent.querySelector('.modal-input');
+        input.focus();
+        input.select();
+
+        const swatchesContainer = modalContent.querySelector('.color-swatches-container');
+
+        const selectSwatch = (target) => {
+            const previouslySelected = swatchesContainer.querySelector('.selected');
+            if (previouslySelected) {
+                previouslySelected.classList.remove('selected');
+                previouslySelected.setAttribute('aria-checked', 'false');
+            }
+            target.classList.add('selected');
+            target.setAttribute('aria-checked', 'true');
+            selectedColor = target.dataset.color;
+        };
+
+        swatchesContainer.addEventListener('click', (e) => {
+            if (e.target.classList.contains('color-swatch')) {
+                selectSwatch(e.target);
+            }
+        });
+
+        swatchesContainer.addEventListener('keydown', (e) => {
+            if ((e.key === 'Enter' || e.key === ' ') && e.target.classList.contains('color-swatch')) {
+                e.preventDefault();
+                selectSwatch(e.target);
+            }
+
+            if (['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(e.key) && e.target.classList.contains('color-swatch')) {
+                e.preventDefault();
+                e.stopPropagation(); // Stop global handler
+
+                const allSwatches = Array.from(swatchesContainer.querySelectorAll('.color-swatch'));
+                const index = allSwatches.indexOf(e.target);
+                let nextIndex = index;
+
+                if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
+                    nextIndex = index + 1;
+                    if (nextIndex >= allSwatches.length) nextIndex = 0;
+                } else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
+                    nextIndex = index - 1;
+                    if (nextIndex < 0) nextIndex = allSwatches.length - 1;
+                }
+
+                if (nextIndex >= 0 && nextIndex < allSwatches.length) {
+                    allSwatches[nextIndex].focus();
+                }
+            }
+        });
+
+        const cleanupAndResolve = (value) => {
+            removeModal(overlay);
+            resolve(value);
+        };
+
+        form.onsubmit = (e) => {
+            e.preventDefault();
+            const name = input.value.trim();
+            if (name) {
+                cleanupAndResolve({ name, color: selectedColor });
             } else {
                 input.focus();
             }

--- a/modules/searchManager.js
+++ b/modules/searchManager.js
@@ -5,16 +5,18 @@ import { getTabCache, getTabElementsCache, getGroupHeaderElementsCache } from '.
 import { getOtherTabCache, getOtherTabElementsCache, getOtherGroupHeaderElementsCache, getOtherWindowFolderElementsCache } from './ui/otherWindowRenderer.js';
 import { highlightText, escapeRegExp } from './utils/textUtils.js';
 import { debounce } from './utils/functionUtils.js';
-import { matchesAnyKeyword, extractDomain } from './utils/searchUtils.js';
+import { matchesAnyKeyword, extractDomain, parseSearchQuery, bookmarkMatchesTags } from './utils/searchUtils.js';
+import * as tagManager from './bookmark/tagManager.js';
 
 // 主搜尋處理函式
 async function handleSearch() {
-    const query = ui.searchBox.value.trim();
-
-    // 將查詢字串分割成多個關鍵字（空白分隔）
-    const keywords = query.toLowerCase().split(/\s+/).filter(k => k.length > 0);
+    // 解析查詢：分離一般關鍵字與 tag: 篩選
+    // tag token 已被抽離，因此分頁／閱讀清單／其他視窗只會收到 keywords，
+    // 不受 tag: 查詢影響（tag 僅作用於書籤）。
+    const { keywords, tags } = parseSearchQuery(ui.searchBox.value.trim());
 
     // 預先編譯所有正則表達式，避免在迴圈中重複編譯
+    // 只用 keywords 編譯（tag 不需要高亮）
     let regexes = [];
     if (keywords.length > 0) {
         regexes = keywords.map(keyword => new RegExp(`(${escapeRegExp(keyword)})`, 'gi'));
@@ -24,7 +26,7 @@ async function handleSearch() {
     const tabCount = filterTabsAndGroups(keywords);
     const otherWindowsTabCount = filterOtherWindowsTabs(keywords);
     const readingListCount = filterReadingList(keywords, regexes);
-    const bookmarkCount = await filterBookmarks(keywords, regexes);
+    const bookmarkCount = await filterBookmarks(keywords, regexes, tags);
 
     // 高亮匹配文字
     if (keywords.length > 0) {
@@ -334,14 +336,15 @@ let isFiltering = false;
 let bookmarkSearchGeneration = 0;
 
 // 過濾書籤，回傳可見書籤數量 (使用 Cache 進行搜尋)
-async function filterBookmarks(keywords, regexes = []) {
+async function filterBookmarks(keywords, regexes = [], tags = []) {
     // Increment generation for every call; capture it to detect staleness after await
     const thisGeneration = ++bookmarkSearchGeneration;
 
-    // 如果沒有關鍵字，直接返回（不重新渲染）
+    // 如果沒有關鍵字也沒有 tag，直接返回（不重新渲染）
     // 書籤已經在 refreshBookmarks 中渲染好了
-    // 如果沒有關鍵字，檢查是否需要重置視圖
-    if (keywords.length === 0) {
+    // 只有在 keywords 與 tags 都為空時才重置視圖；
+    // 純 tag: 查詢（keywords 為空、tags 非空）需繼續往下走 tag 過濾。
+    if (keywords.length === 0 && tags.length === 0) {
         if (isFiltering) {
             // 從過濾狀態變為無過濾狀態（使用者清除了搜尋）
             isFiltering = false;
@@ -371,7 +374,14 @@ async function filterBookmarks(keywords, regexes = []) {
         // 記錄匹配類型
         item._titleMatches = titleMatches;
         item._urlMatches = urlMatches;
-        return titleMatches || urlMatches;
+        // 關鍵字與 tag 採 AND 邏輯：
+        // - 無 keywords 時 kwOk 對所有書籤為 true（純 tag: 查詢列出全部該標籤書籤）
+        // - 無 tags 時 tagOk 對所有書籤為 true（一般關鍵字查詢不受 tag 影響）
+        const kwOk = keywords.length === 0 ? true : (titleMatches || urlMatches);
+        const tagOk = tags.length === 0 ? true : bookmarkMatchesTags(
+            tagManager.getTagsForBookmark(item.id).map(t => t.name), tags
+        );
+        return kwOk && tagOk;
     });
 
     if (matchingItems.length === 0) {

--- a/modules/ui/bookmarkRenderer.js
+++ b/modules/ui/bookmarkRenderer.js
@@ -180,6 +180,24 @@ function initBookmarkListeners(container) {
     };
 
     container.addEventListener('click', async (e) => {
+        // 0. Handle Tag Dot Click (filter search by that tag)
+        const tagDot = e.target.closest('.bookmark-tag-dot');
+        if (tagDot) {
+            e.preventDefault();
+            e.stopPropagation();
+            const name = tagDot.dataset.tagName || '';
+            if (name) {
+                const token = /\s/.test(name) ? `tag:"${name}"` : `tag:${name}`;
+                const box = document.getElementById('search-box');
+                if (box) {
+                    box.value = token;
+                    box.dispatchEvent(new Event('input', { bubbles: true }));
+                    box.focus();
+                }
+            }
+            return;
+        }
+
         // 1. Handle Action Buttons (Edit, Delete, Add Folder)
         const btn = getActionBtn(e.target);
         if (btn) {
@@ -512,6 +530,7 @@ function updateBookmarkElement(item, node, { highlightRegexes = [] } = {}) {
             const dot = document.createElement('span');
             dot.className = 'bookmark-tag-dot';
             dot.dataset.color = tag.color;
+            dot.dataset.tagName = tag.name;
             dot.title = tag.name;
             tagContainer.appendChild(dot);
         }

--- a/modules/utils/searchUtils.js
+++ b/modules/utils/searchUtils.js
@@ -41,3 +41,33 @@ export function extractDomain(url) {
         return match ? match[1] : '';
     }
 }
+
+/**
+ * 將搜尋字串拆成一般關鍵字與 tag: 篩選。
+ * 支援 tag:單詞 與 tag:"含空白名稱"；tag 名稱去引號、小寫化。其餘空白分隔詞為關鍵字（小寫）。
+ * @param {string} query
+ * @returns {{keywords: string[], tags: string[]}}
+ */
+export function parseSearchQuery(query) {
+    const tags = [];
+    if (typeof query !== 'string') return { keywords: [], tags };
+    const rest = query.replace(/tag:"([^"]*)"|tag:(\S+)/gi, (_, quoted, bare) => {
+        const name = (quoted !== undefined ? quoted : bare).trim().toLowerCase();
+        if (name) tags.push(name);
+        return ' ';
+    });
+    const keywords = rest.toLowerCase().split(/\s+/).filter(k => k.length > 0);
+    return { keywords, tags };
+}
+
+/**
+ * 書籤是否含全部 required 標籤（AND、大小寫不敏感、精確名稱比對）。
+ * @param {string[]} bookmarkTagNames 書籤目前的標籤名稱
+ * @param {string[]} requiredTagNames 查詢要求的標籤名稱
+ * @returns {boolean}
+ */
+export function bookmarkMatchesTags(bookmarkTagNames, requiredTagNames) {
+    if (!requiredTagNames || requiredTagNames.length === 0) return true;
+    const have = new Set((bookmarkTagNames || []).map(n => String(n).toLowerCase()));
+    return requiredTagNames.every(req => have.has(String(req).toLowerCase()));
+}

--- a/sidepanel.css
+++ b/sidepanel.css
@@ -1221,6 +1221,17 @@ mark.url-match {
     border-color: var(--accent-color);
 }
 
+/* Tag color swatches (showTagDialog). Reuse .color-swatch shape + .selected ring;
+   backgrounds mirror the .bm-tools__tag-chip[data-color] palette. */
+.tag-color-swatch[data-color="grey"]   { background: #5f6368; }
+.tag-color-swatch[data-color="blue"]   { background: #1a73e8; }
+.tag-color-swatch[data-color="red"]    { background: #d93025; }
+.tag-color-swatch[data-color="yellow"] { background: #f9ab00; }
+.tag-color-swatch[data-color="green"]  { background: #1e8e3e; }
+.tag-color-swatch[data-color="pink"]   { background: #f538a0; }
+.tag-color-swatch[data-color="purple"] { background: #a142f4; }
+.tag-color-swatch[data-color="cyan"]   { background: #007b83; }
+
 /* --- Linked Tabs Panel Styles --- */
 .linked-tabs-list {
     display: flex;

--- a/sidepanel.css
+++ b/sidepanel.css
@@ -3334,7 +3334,8 @@ mark.url-match {
 
 /* 書籤列上的標籤圓點 */
 .bookmark-tags { display: inline-flex; gap: 3px; align-items: center; margin: 0 6px; }
-.bookmark-tag-dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+.bookmark-tag-dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; cursor: pointer; transition: transform 0.1s ease; }
+.bookmark-tag-dot:hover { transform: scale(1.25); }
 .bookmark-tag-dot[data-color="grey"]   { background: #5f6368; }
 .bookmark-tag-dot[data-color="blue"]   { background: #1a73e8; }
 .bookmark-tag-dot[data-color="red"]    { background: #d93025; }

--- a/usecase_tests/puppeteer_tests/happy_path_bookmark_tag_color_search.test.js
+++ b/usecase_tests/puppeteer_tests/happy_path_bookmark_tag_color_search.test.js
@@ -1,0 +1,150 @@
+const { setupBrowser, teardownBrowser, expandBookmarksBar } = require('./setup');
+
+/**
+ * E2E coverage for the bookmark-tag color + tag: search enhancements:
+ *   1. Tag color dot — a tag seeded with color 'red' renders a
+ *      .bookmark-tag-dot[data-color="red"] on its bookmark row.
+ *   2. tag: search — typing `tag:Work` filters the bookmark list down to the
+ *      tagged bookmark; an untagged bookmark is removed from the DOM.
+ *   3. click-dot-to-filter — clicking a .bookmark-tag-dot sets #search-box to
+ *      `tag:Work` and filters the list to the tagged bookmark.
+ *
+ * Determinism: tags + bookmarkTags bindings are seeded directly into
+ * chrome.storage.local (the dot reflects tag.color regardless of how the tag
+ * was created), so we never have to drive the flaky showTagDialog color picker.
+ * tagManager.initTags() reads both keys on load, so we reload after seeding.
+ */
+describe('Bookmark Tag Color + tag: Search Use Case', () => {
+    let browser;
+    let page;
+
+    let workBookmarkId;
+    let plainBookmarkId;
+
+    const TAG = { id: 't_work', name: 'Work', color: 'red', createdAt: 1700000000000 };
+
+    beforeAll(async () => {
+        const setup = await setupBrowser();
+        browser = setup.browser;
+        page = setup.page;
+        await page.waitForSelector('#bookmark-list', { timeout: 15000 });
+    }, 120000);
+
+    afterAll(async () => {
+        // Best-effort cleanup so this suite doesn't pollute sibling tests.
+        try {
+            await page.evaluate(() => new Promise(resolve => {
+                chrome.storage.local.remove(['tags', 'bookmarkTags'], resolve);
+            }));
+        } catch (e) { }
+        for (const id of [workBookmarkId, plainBookmarkId]) {
+            if (!id) continue;
+            try {
+                await page.evaluate((bid) => new Promise(resolve => {
+                    chrome.bookmarks.remove(bid, resolve);
+                }), id);
+            } catch (e) { }
+        }
+        await teardownBrowser(browser);
+    });
+
+    /** Seed two bookmarks + a colored tag + the binding, then reload. */
+    async function seedFixture() {
+        const ids = await page.evaluate(() => {
+            const create = (title, url) => new Promise(resolve => {
+                chrome.bookmarks.create({ parentId: '1', title, url }, (n) => resolve(n.id));
+            });
+            return (async () => {
+                const work = await create('Tag Color Work Bookmark', 'https://example.com/tag-color-work');
+                const plain = await create('Tag Color Plain Bookmark', 'https://example.com/tag-color-plain');
+                return { work, plain };
+            })();
+        });
+        workBookmarkId = ids.work;
+        plainBookmarkId = ids.plain;
+
+        await page.evaluate((tag, workId) => new Promise(resolve => {
+            chrome.storage.local.set({
+                tags: { [tag.id]: tag },
+                bookmarkTags: { [workId]: [tag.id] },
+            }, resolve);
+        }), TAG, workBookmarkId);
+
+        // Reload so initTags() picks up the seeded tags + bindings.
+        await page.reload();
+        await page.waitForSelector('#bookmark-list', { timeout: 10000 });
+        await expandBookmarksBar(page);
+
+        await page.waitForSelector(`.bookmark-item[data-bookmark-id="${workBookmarkId}"]`, { timeout: 10000 });
+        await page.waitForSelector(`.bookmark-item[data-bookmark-id="${plainBookmarkId}"]`, { timeout: 10000 });
+    }
+
+    /** Set #search-box value and fire the input event the searchManager listens for. */
+    async function typeSearch(value) {
+        await page.evaluate((v) => {
+            const box = document.getElementById('search-box');
+            box.value = v;
+            box.dispatchEvent(new Event('input', { bubbles: true }));
+        }, value);
+    }
+
+    test('tag color dot, tag: search filter, and click-dot-to-filter', async () => {
+        await seedFixture();
+
+        const workSelector = `.bookmark-item[data-bookmark-id="${workBookmarkId}"]`;
+        const plainSelector = `.bookmark-item[data-bookmark-id="${plainBookmarkId}"]`;
+
+        // ---- 1. Tag color dot ----------------------------------------------
+        // The seeded tag has color 'red'; the dot must reflect it.
+        await page.waitForSelector(`${workSelector} .bookmark-tag-dot[data-color="red"]`, { timeout: 10000 });
+        const dotInfo = await page.$eval(
+            `${workSelector} .bookmark-tag-dot`,
+            (dot) => ({ color: dot.dataset.color, name: dot.dataset.tagName })
+        );
+        expect(dotInfo.color).toBe('red');
+        expect(dotInfo.name).toBe('Work');
+        // The untagged bookmark must have no dot.
+        const plainDotCount = await page.$$eval(`${plainSelector} .bookmark-tag-dot`, (d) => d.length);
+        expect(plainDotCount).toBe(0);
+
+        // ---- 2. tag: search filter -----------------------------------------
+        // A `tag:Work` query re-renders the tree with only the tagged bookmark;
+        // the untagged bookmark's row is removed from the DOM.
+        await typeSearch('tag:Work');
+        await page.waitForFunction(
+            (wSel, pSel) => !!document.querySelector(wSel) && !document.querySelector(pSel),
+            { timeout: 10000 },
+            workSelector, plainSelector
+        );
+        expect(await page.$(workSelector)).not.toBeNull();
+        expect(await page.$(plainSelector)).toBeNull();
+
+        // Clear the search and confirm both bookmarks come back.
+        await typeSearch('');
+        await page.waitForFunction(
+            (wSel, pSel) => !!document.querySelector(wSel) && !!document.querySelector(pSel),
+            { timeout: 10000 },
+            workSelector, plainSelector
+        );
+        await expandBookmarksBar(page);
+        await page.waitForSelector(`${workSelector} .bookmark-tag-dot[data-color="red"]`, { timeout: 10000 });
+
+        // ---- 3. click-dot-to-filter ----------------------------------------
+        // Clicking the dot must set #search-box to `tag:Work` and filter the list.
+        await page.click(`${workSelector} .bookmark-tag-dot`);
+        await page.waitForFunction(
+            () => document.getElementById('search-box').value === 'tag:Work',
+            { timeout: 5000 }
+        );
+        const boxValue = await page.$eval('#search-box', (el) => el.value);
+        expect(boxValue).toBe('tag:Work');
+
+        await page.waitForFunction(
+            (wSel, pSel) => !!document.querySelector(wSel) && !document.querySelector(pSel),
+            { timeout: 10000 },
+            workSelector, plainSelector
+        );
+        expect(await page.$(workSelector)).not.toBeNull();
+        expect(await page.$(plainSelector)).toBeNull();
+    }, 120000);
+});

--- a/usecase_tests/unit_tests/searchUtils.test.mjs
+++ b/usecase_tests/unit_tests/searchUtils.test.mjs
@@ -1,4 +1,5 @@
 import { matchesAnyKeyword, extractDomain } from '../../modules/utils/searchUtils.js';
+import { parseSearchQuery, bookmarkMatchesTags } from '../../modules/utils/searchUtils.js';
 
 describe('searchManager.matchesAnyKeyword', () => {
     it('returns true when keyword list is empty', () => {
@@ -69,4 +70,43 @@ describe('searchManager.extractDomain', () => {
     it('returns empty string for completely malformed input', () => {
         expect(extractDomain('!!!')).toBe('!!!'); // regex fallback returns the leading non-/ chars
     });
+});
+
+describe('parseSearchQuery', () => {
+  it('分離 tag: token 與一般關鍵字', () => {
+    expect(parseSearchQuery('react tag:工作')).toEqual({ keywords: ['react'], tags: ['工作'] });
+  });
+  it('支援引號包住含空白的標籤名', () => {
+    expect(parseSearchQuery('tag:"side pj" hooks')).toEqual({ keywords: ['hooks'], tags: ['side pj'] });
+  });
+  it('多個 tag: 累積、tag 名小寫化', () => {
+    expect(parseSearchQuery('tag:Work tag:Read')).toEqual({ keywords: [], tags: ['work', 'read'] });
+  });
+  it('空字串 → 皆空', () => {
+    expect(parseSearchQuery('   ')).toEqual({ keywords: [], tags: [] });
+  });
+  it('純關鍵字、無 tag', () => {
+    expect(parseSearchQuery('foo bar')).toEqual({ keywords: ['foo', 'bar'], tags: [] });
+  });
+  it('非字串輸入 → 皆空（防禦）', () => {
+    expect(parseSearchQuery(null)).toEqual({ keywords: [], tags: [] });
+  });
+});
+
+describe('bookmarkMatchesTags', () => {
+  it('需包含所有 required（AND、大小寫不敏感、精確名稱）', () => {
+    expect(bookmarkMatchesTags(['Work', 'Read'], ['work'])).toBe(true);
+    expect(bookmarkMatchesTags(['Work'], ['work', 'read'])).toBe(false);
+  });
+  it('required 為空 → true', () => {
+    expect(bookmarkMatchesTags(['Work'], [])).toBe(true);
+    expect(bookmarkMatchesTags([], [])).toBe(true);
+  });
+  it('精確比對，不做子字串', () => {
+    expect(bookmarkMatchesTags(['Workspace'], ['work'])).toBe(false);
+  });
+  it('bookmarkTagNames 為空/缺 → 只有 required 也空才 true', () => {
+    expect(bookmarkMatchesTags(undefined, ['work'])).toBe(false);
+    expect(bookmarkMatchesTags(undefined, [])).toBe(true);
+  });
 });


### PR DESCRIPTION
## 摘要 (Summary)

補齊批 A 書籤標籤的兩個缺口，讓標籤真正好用：
1. **標籤顏色**：建立／編輯標籤時可選 8 種顏色（資料層原本就支援、只缺 UI）；書籤列圓點與 Tags 分頁 chip 立即反映。
2. **`tag:` 搜尋篩選**：搜尋框輸入 `tag:工作`（或 `tag:"含空白 名稱"`）即只列出貼了該標籤的書籤；可與關鍵字併用（AND）；**點書籤列的標籤圓點**即自動以該標籤篩選。

## 變更內容 (Changes)
- **純函式 (TDD)** `searchUtils.js`：`parseSearchQuery`（分離 `tag:` token 與關鍵字）、`bookmarkMatchesTags`（AND、大小寫不敏感、精確比對）。+10 單元測試。
- **顏色** `modalManager.showTagDialog`（名稱 + 8 色票，仿 showCreateGroupDialog）；`bookmarkToolsUI` 建立/編輯標籤接色票，編輯後 `refreshBookmarksRequired` 讓書籤列圓點換色。
- **搜尋** `searchManager`：`handleSearch` 用 `parseSearchQuery`；`filterBookmarks` 以 `kwOk && tagOk` 篩選（tag 用 `getTagsForBookmark`）；分頁/閱讀清單不受 tag token 影響。
- **點圓點** `bookmarkRenderer`：圓點加 `data-tag-name` + 委派 click 設 `#search-box` 為 `tag:<name>` 並觸發既有搜尋（stopPropagation 不開書籤）。
- **i18n** `bmToolsEditTag` × 14 語系。

## 測試 (Testing)
- 單元 **228** 綠（含 searchUtils 新測試）。
- E2E：新增 `happy_path_bookmark_tag_color_search`（圓點顏色 + `tag:` 篩選 + 點圓點），兩次穩定。
- `test:ci` 49 綠、`test:full` **102 passed / 0 failed**、`make` / `make release` OK。
- 整體 code review：ready to merge（無 Critical/Important）。

### 已知 Minor（非阻斷）
- 建立對話框標題沿用 `bmToolsCreateTagPrompt`（「New tag name」）略不順——可後續換成專屬標題 key。
- 標籤名含字面雙引號不完美 round-trip（spec 已將進階解析列為非目標）。

---

## English
Closes the two gaps left by batch A's bookmark tags: (1) **per-tag color** — pick from 8 colors when creating/editing a tag (data layer already supported it; only the UI was missing); bookmark-row dots + Tags-tab chips reflect it immediately. (2) **`tag:` search filter** — type `tag:work` (or `tag:"name with space"`) to list only bookmarks with that tag (combinable with keywords via AND); **clicking a bookmark's tag dot** auto-filters by it.

Pure helpers `parseSearchQuery`/`bookmarkMatchesTags` (TDD, +10 unit tests); `showTagDialog` color picker; `filterBookmarks` keyword-AND-tag filtering; click-dot → `#search-box` `tag:` token → same filter path. Unit 228 green, E2E added (2× stable), `test:full` 102 passed / 0 failed, builds OK. Whole-feature review: ready to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
