### PR TITLE
feat(ui): Material 3 視覺一致化 — 工作區單鈕 + 全面 emoji→SVG + M3 token

### DIFF
--- a/.agent/notes/NOTE_20260602_m3_ui_overhaul.md
+++ b/.agent/notes/NOTE_20260602_m3_ui_overhaul.md
@@ -1,0 +1,71 @@
+# NOTE 2026-06-02 — Material 3 UI 重構（feat/m3-ui-overhaul）
+
+## 背景
+PR#151（spotlight）合併後,使用者回報三類 UI 問題並要求改善:
+1. 工作區列頭部冗餘（下拉 + 齒輪兩個控制項）。
+2. 全介面 emoji 圖示廉價、風格不一。
+3. 整體視覺風格不一致（圓角、線條、動畫、focus 散亂）。
+
+決策（經 AskUserQuestion 確認）:① dialog 列點擊即切換 ② Material Symbols Outlined
+③ 替換範圍涵蓋側邊欄/Spotlight/設定頁/工作區圖示 ④ M3「更全面」、**色彩主題全保留**。
+分支:自最新 main 開 `feat/m3-ui-overhaul`,獨立 PR。計畫檔:`~/.claude/plans/piped-juggling-scone.md`。
+
+## 階段（每階段 commit、保持測試綠）
+- **P1**（`39d8512`）sidepanel.css `:root` 新增 M3 token:shape scale（--arc-radius-xs/sm/md/lg/full）、
+  state layer 不透明度與覆蓋色（color-mix over 主題 token）、elevation 階（1/3/5 alias 既有 shadow）、
+  統一 focus ring、motion 語意 alias。純加法。
+- **P2**（`39d8512`）`modules/icons.js` 改 Material Symbols Outlined（viewBox `0 -960 960 960`、
+  fill=currentColor）。`ICONS` map（40 icon,以 gstatic 端點抓取、驗證 960 座標系）+
+  `renderIcon`/`renderIconEl`/`hasIcon`;既有 12 個 `*_ICON_SVG` 沿用同名匯出、改以 Material
+  Symbols 重繪、尺寸不變,呼叫端不需更動。`.m3-icon` 基礎類別。
+- **P3**（`ffc358d`）emoji→SVG 全面替換:
+  - 3a chevron 狀態化:單一 expand_more SVG + `is-collapsed` class（CSS rotate -90deg）取代
+    `▶/▼` textContent;`dragDropManager` 拖曳展開改讀 `aria-expanded`;6 個 E2E + `setup.js`
+    （新增 `waitForChevron`）改判 class/aria。
+  - 3b 側邊欄動作鈕:`data-icon` 屬性 + sidepanel.js 注入;動作鈕拆 `.btn-icon`/`.btn-label`,
+    `data-i18n` 移到 label span（避免 textContent=message 洗掉圖示）;14 locale 去動作鈕 emoji。
+  - 3c Spotlight/命令列/Ask AI:actions.js icon→icon-id;buildRow dispatch 加 hasIcon 分支
+    （favicon img → icon-id SVG → 文字）;dataProvider/nlSearch/spotlight onerror 改 SVG。
+  - 3d 設定頁:AI 狀態徽章/RSS 控制/重啟提示/低對比警告改 SVG;aiGrouperUI 下載態改更新
+    `.btn-label`;14 locale 清理 prose emoji。
+- **P4**（`3c43e1c`）工作區列收斂為單一 `#workspace-switch-btn`→開管理 dialog;切換搬進
+  dialog（每列 `.workspace-manage__switch` 點擊即切換,`performSwitch`,成功後關 dialog）;
+  rename/delete/cloud 改 Material Symbols;`workspaceManager.resolveWorkspaceIcon`（icon-id→SVG、
+  舊 emoji→經跳脫文字、其餘→work）+ `isValidWorkspaceIcon`（放寬守衛接受 icon-id 或 <=4 emoji,
+  仍拒任意長遠端字串）;PRESET_ICONS 改 icon-id。
+- **P5**（`80a495f`）套用 token 至元件 + 修對抗式 review 發現:
+  - 圓角/elevation/focus-ring/state-layer-pressed 套用至 input/button/modal/menu/列/工作區鈕。
+  - **修 [major]** sidepanel.js `manage-workspaces` 指向已移除 id → 改 `#workspace-switch-btn`;
+    `#settings-toggle` Material Symbols(fill) 的 stroke 著色失效 → 改 color;清單列雙 focus ring →
+    unified ring 僅作用於 `<button>`。
+  - **修 [minor]** driveSyncBadge 的 ↻/☁︎/⚠ → Material Symbols(sync/cloud/warning,
+    glyph→iconId + renderIcon + escapeHtml,同步單元測試);工作區 dialog 改 scoped close handle;
+    renderIconEl 防 null + label 跳脫;ws-emoji 尺寸對齊。
+
+## 驗證
+- `test:unit` **239 綠**(含改寫的 driveSyncBadge 測試);四 entrypoint + sidepanel.css esbuild 解析 OK;
+  `make` dev build 含所有新檔。所有 icon-id 引用皆存在(腳本核對 **0 遺漏**)。
+- E2E:核心套件(chevron toggle、tab_to_bookmark、empty_folder、search_group_expand、
+  workspace_group_restore、sidepanel_load、spotlight)逐一綠。
+- **已知 flake**:`scroll_position_on_tab_click` 在 `npm test`(maxWorkers=2,40+ 套件並行)下
+  常逾時(129s),但 **solo 0.5s 通過**(已 4 次)——屬機器資源 starvation、非本次回歸
+  (timeout 非斷言失敗;serial maxWorkers=1 用以取得權威乾淨紀錄)。
+
+## 對抗式 review（每階段獨立 workflow,3 視角）
+- icon 系統 / 完整性 / 安全(data: SVG via <img> = secure static mode、textContent/escapeHtml 無 XSS)。
+- 工作區 P4 流程 / 向後相容 / 無殘留舊 DOM 引用。
+- CSS/M3/a11y 回歸(token 解析、跨主題 color-mix、focus 不重疊/不裁切、reduced-motion 涵蓋 chevron)。
+
+## 已知取捨 / 後續（非阻斷）
+- **AI 分頁群組「名稱」的 emoji**（`aiManager.js` prompt 第 ~338 行刻意指示 AI 為群組加 emoji
+  前綴）**保留**:Chrome 原生分頁群組標題無法用 SVG、且屬內容生成功能。如要移除需改 prompt
+  行為,待使用者確認。
+- `.header-action-btn` 基底為 danger-red:`#ai-cleanup-btn`/`#bookmark-tools-btn` 沿用紅色
+  （僅 `#ai-group-btn` 有 info-blue override）。屬**既有**樣式,非本次造成;如要中性化非破壞性
+  動作鈕色彩,為可選 follow-up（使用者要求保留色彩,故未動）。
+- 部分 M3 token（radius-xs/full、state-layer-hover/accent、easing-emphasized）作為完整 scale
+  保留,目前未全部引用（無害）。
+
+## MV3 合規
+inline SVG 經 innerHTML 為合法 markup（manifest CSP `script-src 'self'; object-src 'none'` 不需變更）;
+無外部字型/CDN（Material Symbols path 內嵌）;workspace/textUtils/icons 於 SW 情境僅匯入不執行 DOM API。

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -74,7 +74,7 @@ key_files:
   - file_path: modules/ui/readingListRenderer.js
     description: "[UI] 閱讀清單渲染。負責閱讀清單項目的 DOM 生成、事件處理（點擊/刪除/切換已讀）、展開收合、鍵盤導航、新項目標籤、排序功能 (日期/標題)。"
   - file_path: modules/icons.js
-    description: "[UI] SVG 圖示集中管理。匯出所有 UI 使用的 SVG 圖示常數，避免重複定義。"
+    description: "[UI] Icon 系統(M3)。以 Material Symbols Outlined(viewBox 0 -960 960 960, fill=currentColor)集中管理；ICONS map(~40 icon)+ renderIcon/renderIconEl/hasIcon helper;既有 *_ICON_SVG 常數沿用同名匯出(改以 Material Symbols 重繪)。全 UI emoji 圖示改用此系統(inline SVG via innerHTML)。"
   - file_path: modules/aiManager.js
     description: "[AI] 本機 AI 模型管理。封裝 LanguageModel (Prompt API) 與 Summarizer API；提供 tab grouping、頁面摘要、AI 群組自動命名 (generateGroupName)、AI tab cleanup 建議 (generateCleanupSuggestions)、reading-list 摘要 (summarizeText)、自然語言搜尋的 reranker (runPrompt，使用獨立 nlLanguageModelSession)。"
   - file_path: modules/ui/aiGrouperUI.js
@@ -102,9 +102,9 @@ key_files:
   - file_path: modules/commandPalette/nlSearch.js
     description: "[AI] 自然語言搜尋。Phase 8b 新增；使用 Chrome Prompt API 作 reranker（非 filter），透過 preFilterByQuery 用 indexOf scoring 降低候選後再送 LLM。"
   - file_path: modules/workspace/workspaceManager.js
-    description: "[功能] Workspace 業務邏輯。Phase 6 新增、Phase 9 重構儲存架構；分離 metadata (chrome.storage.sync, 8KB/key 限制) 與 tabSnapshot (chrome.storage.local)，含 legacy windowNames 一次性遷移與 onChanged 跨裝置同步。Phase 12(批C) 快照捕捉 tab group(groupKey/title/color)、切換時 best-effort 重建 group（純函式 buildSnapshotFromTabs / clusterCreatedTabsByGroup）。Drive sync (批E) 新增 isWorkspaceBound(查 windowWorkspaceMap 是否綁定) 與 applyRemoteWorkspace(把 Drive 拉回的 workspace 寫入本地，不開分頁、不 bumpRev、rev/updatedAt 直接取自 remote)。"
+    description: "[功能] Workspace 業務邏輯。Phase 6 新增、Phase 9 重構儲存架構；分離 metadata (chrome.storage.sync, 8KB/key 限制) 與 tabSnapshot (chrome.storage.local)，含 legacy windowNames 一次性遷移與 onChanged 跨裝置同步。Phase 12(批C) 快照捕捉 tab group(groupKey/title/color)、切換時 best-effort 重建 group（純函式 buildSnapshotFromTabs / clusterCreatedTabsByGroup）。Drive sync (批E) 新增 isWorkspaceBound(查 windowWorkspaceMap 是否綁定) 與 applyRemoteWorkspace(把 Drive 拉回的 workspace 寫入本地，不開分頁、不 bumpRev、rev/updatedAt 直接取自 remote)。M3 重構:icon 改存 Material Symbols icon-id(PRESET_ICONS),resolveWorkspaceIcon 相容舊版 emoji(icon-id→SVG/舊 emoji→跳脫文字),isValidWorkspaceIcon 守衛接受 icon-id 或 <=4 emoji。"
   - file_path: modules/workspace/workspaceUI.js
-    description: "[UI] Workspace 切換器與管理介面。Phase 6 新增；下拉切換 + 管理 modal + 切換確認 (含 unbound tabs 自動 auto-save 防資料遺失)。"
+    description: "[UI] Workspace 切換器與管理介面。M3 重構後:工作區列為單一 #workspace-switch-btn(名稱置中、無 emoji)→開管理 dialog;切換在 dialog 內(每列 .workspace-manage__switch 點擊即切換 performSwitch + 確認,含 unbound tabs auto-save 防資料遺失);rename/delete/cloud 用 Material Symbols。"
   - file_path: modules/sync/syncProvider.js
     description: "[同步] SyncProvider 介面定義（版本化 KV：isConnected/list/read/write/remove，read/write 帶 server version 樂觀鎖）。Phase 13(批E) 新增；提供 NoopSyncProvider（同步關閉時的 inert 預設，全部安全 no-op，保留 local-only 行為）與 createFakeSyncProvider（純 Map 記憶體模擬 + __failNext 故障注入，供單元/整合測試在 Node 跑、無 chrome/fetch/OAuth 依賴）。"
   - file_path: modules/sync/driveAuth.js

--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -1139,5 +1139,17 @@
   },
   "workspaceSyncedTitle": {
     "message": "Mit Google Drive synchronisiert"
+  },
+  "densitySectionHeader": {
+    "message": "Listenabstand"
+  },
+  "densityOptionCompact": {
+    "message": "Kompakt"
+  },
+  "densityOptionCozy": {
+    "message": "Normal (Standard)"
+  },
+  "densityOptionComfortable": {
+    "message": "Komfortabel"
   }
 }

--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -622,10 +622,10 @@
     }
   },
   "smartGroupingBtnText": {
-    "message": "✨ Smart-Gruppierung"
+    "message": "Smart-Gruppierung"
   },
   "smartGroupingBtnTitle": {
-    "message": "✨ Nicht klassifizierte Tabs intelligent gruppieren"
+    "message": "Nicht klassifizierte Tabs intelligent gruppieren"
   },
   "toastUndoBtn": {
     "message": "Rückgängig"
@@ -637,10 +637,10 @@
     "message": "AI-Modell ist nicht bereit. Bitte stellen Sie sicher, dass Ihr Chrome Gemini Nano unterstützt."
   },
   "tooFewTabsToGroup": {
-    "message": "Zu wenige nicht klassifizierte Tabs zum Gruppieren ✨"
+    "message": "Zu wenige nicht klassifizierte Tabs zum Gruppieren"
   },
   "autoGroupingSuccess": {
-    "message": "✨ Tabs erfolgreich gruppiert!"
+    "message": "Tabs erfolgreich gruppiert!"
   },
   "noTabsGrouped": {
     "message": "Es wurden keine Tabs erfolgreich gruppiert."
@@ -649,7 +649,7 @@
     "message": "Ein Fehler ist aufgetreten: "
   },
   "unknownCategory": {
-    "message": "📦 Unbekannte Kategorie"
+    "message": "Unbekannte Kategorie"
   },
   "aiGroupingToggleLabel": {
     "message": "Intelligente automatische Gruppierung (Erfordert Gemini Nano)"
@@ -700,7 +700,7 @@
     "message": "Überprüfen Sie den Download-Fortschritt von \"Optimization Guide On Device Model\"."
   },
   "aiSetupRestartNote": {
-    "message": "⚠️ Starten Sie Chrome nach der Änderung der obigen Einstellungen neu."
+    "message": "Starten Sie Chrome nach der Änderung der obigen Einstellungen neu."
   },
   "aiSetupOpenLink": {
     "message": "Öffnen"
@@ -718,7 +718,7 @@
     "message": "Tabs werden analysiert..."
   },
   "aiCleanupBtnText": {
-    "message": "🧹 Aufräumen"
+    "message": "Aufräumen"
   },
   "aiCleanupBtnTitle": {
     "message": "KI-vorgeschlagene Tab-Bereinigung"
@@ -739,7 +739,7 @@
     "message": "KI schlägt {count} Tab(s) zum Schließen vor. Deaktivieren Sie die, die Sie behalten möchten."
   },
   "aiCleanupNeedsDownload": {
-    "message": "KI-Modell ist noch nicht heruntergeladen. Klicken Sie zuerst ✨ Smart Group, um den Download zu starten."
+    "message": "KI-Modell ist noch nicht heruntergeladen. Klicken Sie zuerst Smart Group, um den Download zu starten."
   },
   "aiCleanupSectionHeader": {
     "message": "Tabs, die Sie schließen könnten"
@@ -748,7 +748,7 @@
     "message": "Alle auswählen"
   },
   "aiCleanupToggleLabel": {
-    "message": "🧹 Tab-Bereinigung-Schaltfläche anzeigen"
+    "message": "Tab-Bereinigung-Schaltfläche anzeigen"
   },
   "bmToolsConfirmRemove": {
     "message": "Ausgewählte entfernen"
@@ -889,7 +889,7 @@
     "message": "KI fragen: Tabs oder Lesezeichen finden"
   },
   "cmdPaletteAskAiUnavailable": {
-    "message": "KI-Modell ist noch nicht heruntergeladen. Lösen Sie zuerst ✨ Smart Group zum Herunterladen aus und versuchen Sie es erneut."
+    "message": "KI-Modell ist noch nicht heruntergeladen. Lösen Sie zuerst Smart Group zum Herunterladen aus und versuchen Sie es erneut."
   },
   "cmdPaletteEmpty": {
     "message": "Keine Ergebnisse"

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1142,5 +1142,17 @@
   },
   "workspaceSyncedTitle": {
     "message": "Synced to Google Drive"
+  },
+  "densitySectionHeader": {
+    "message": "List spacing"
+  },
+  "densityOptionCompact": {
+    "message": "Compact"
+  },
+  "densityOptionCozy": {
+    "message": "Cozy (default)"
+  },
+  "densityOptionComfortable": {
+    "message": "Comfortable"
   }
 }

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -625,10 +625,10 @@
     }
   },
   "smartGroupingBtnText": {
-    "message": "✨ Smart Group"
+    "message": "Smart Group"
   },
   "smartGroupingBtnTitle": {
-    "message": "✨ Smart Auto-Group Unclassified Tabs"
+    "message": "Smart Auto-Group Unclassified Tabs"
   },
   "toastUndoBtn": {
     "message": "Undo"
@@ -640,10 +640,10 @@
     "message": "AI model is not ready. Please ensure your Chrome supports Gemini Nano."
   },
   "tooFewTabsToGroup": {
-    "message": "Too few unclassified tabs to group ✨"
+    "message": "Too few unclassified tabs to group"
   },
   "autoGroupingSuccess": {
-    "message": "✨ Tabs grouped successfully!"
+    "message": "Tabs grouped successfully!"
   },
   "noTabsGrouped": {
     "message": "No tabs were successfully grouped."
@@ -652,7 +652,7 @@
     "message": "Error occurred: "
   },
   "unknownCategory": {
-    "message": "📦 Unknown Category"
+    "message": "Unknown Category"
   },
   "aiGroupingToggleLabel": {
     "message": "Smart Auto-Grouping (Requires Gemini Nano)"
@@ -676,13 +676,13 @@
     "message": "When you create a new tab group without a title, AI suggests a short label (Emoji + name). Runs only when the local model is already downloaded."
   },
   "aiCleanupToggleLabel": {
-    "message": "Show 🧹 Tab Cleanup button"
+    "message": "Show Tab Cleanup button"
   },
   "aiCleanupDescription": {
     "message": "Adds a button next to Smart Group that asks AI which tabs you can probably close."
   },
   "aiCleanupBtnText": {
-    "message": "🧹 Cleanup"
+    "message": "Cleanup"
   },
   "aiCleanupBtnTitle": {
     "message": "AI-suggested tab cleanup"
@@ -694,7 +694,7 @@
     "message": "Analyzing tabs..."
   },
   "aiCleanupNeedsDownload": {
-    "message": "AI model is not downloaded yet. Click ✨ Smart Group first to start the download."
+    "message": "AI model is not downloaded yet. Click Smart Group first to start the download."
   },
   "aiCleanupEmpty": {
     "message": "Your tabs look tidy — nothing to clean up."
@@ -745,7 +745,7 @@
     "message": "Check \"Optimization Guide On Device Model\" download progress."
   },
   "aiSetupRestartNote": {
-    "message": "⚠️ Restart Chrome after changing the flags above."
+    "message": "Restart Chrome after changing the flags above."
   },
   "aiSetupOpenLink": {
     "message": "Open"
@@ -973,7 +973,7 @@
     "message": "AI suggestions"
   },
   "cmdPaletteAskAiUnavailable": {
-    "message": "AI model is not downloaded yet. Trigger ✨ Smart Group first to download, then try again."
+    "message": "AI model is not downloaded yet. Trigger Smart Group first to download, then try again."
   },
   "cmdPaletteAskAiNoMatch": {
     "message": "AI found no good matches."

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -1139,5 +1139,17 @@
   },
   "workspaceSyncedTitle": {
     "message": "Sincronizado con Google Drive"
+  },
+  "densitySectionHeader": {
+    "message": "Espaciado de lista"
+  },
+  "densityOptionCompact": {
+    "message": "Compacto"
+  },
+  "densityOptionCozy": {
+    "message": "Normal (predeterminado)"
+  },
+  "densityOptionComfortable": {
+    "message": "Cómodo"
   }
 }

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -622,10 +622,10 @@
     }
   },
   "smartGroupingBtnText": {
-    "message": "✨ Agrupación Inteligente"
+    "message": "Agrupación Inteligente"
   },
   "smartGroupingBtnTitle": {
-    "message": "✨ Agrupar pestañas no clasificadas inteligentemente"
+    "message": "Agrupar pestañas no clasificadas inteligentemente"
   },
   "toastUndoBtn": {
     "message": "Deshacer"
@@ -637,10 +637,10 @@
     "message": "El modelo de IA no está listo. Asegúrese de que su Chrome admita Gemini Nano."
   },
   "tooFewTabsToGroup": {
-    "message": "Muy pocas pestañas no clasificadas para agrupar ✨"
+    "message": "Muy pocas pestañas no clasificadas para agrupar"
   },
   "autoGroupingSuccess": {
-    "message": "✨ ¡Pestañas agrupadas con éxito!"
+    "message": "¡Pestañas agrupadas con éxito!"
   },
   "noTabsGrouped": {
     "message": "Ninguna pestaña fue agrupada con éxito."
@@ -649,7 +649,7 @@
     "message": "Ocurrió un error: "
   },
   "unknownCategory": {
-    "message": "📦 Categoría Desconocida"
+    "message": "Categoría Desconocida"
   },
   "aiGroupingToggleLabel": {
     "message": "Agrupación automática inteligente (Requiere Gemini Nano)"
@@ -700,7 +700,7 @@
     "message": "Comprueba el progreso de descarga de \"Optimization Guide On Device Model\"."
   },
   "aiSetupRestartNote": {
-    "message": "⚠️ Reinicia Chrome después de cambiar la configuración anterior."
+    "message": "Reinicia Chrome después de cambiar la configuración anterior."
   },
   "aiSetupOpenLink": {
     "message": "Abrir"
@@ -718,7 +718,7 @@
     "message": "Analizando pestañas..."
   },
   "aiCleanupBtnText": {
-    "message": "🧹 Limpiar"
+    "message": "Limpiar"
   },
   "aiCleanupBtnTitle": {
     "message": "Limpieza de pestañas sugerida por IA"
@@ -739,7 +739,7 @@
     "message": "La IA sugiere {count} pestaña(s) que puedes cerrar. Desmarca las que quieras conservar."
   },
   "aiCleanupNeedsDownload": {
-    "message": "El modelo IA aún no está descargado. Haz clic primero en ✨ Smart Group para iniciar la descarga."
+    "message": "El modelo IA aún no está descargado. Haz clic primero en Smart Group para iniciar la descarga."
   },
   "aiCleanupSectionHeader": {
     "message": "Pestañas que podrías cerrar"
@@ -748,7 +748,7 @@
     "message": "Seleccionar todo"
   },
   "aiCleanupToggleLabel": {
-    "message": "Mostrar botón 🧹 Limpieza de pestañas"
+    "message": "Mostrar botón Limpieza de pestañas"
   },
   "bmToolsConfirmRemove": {
     "message": "Eliminar selección"
@@ -889,7 +889,7 @@
     "message": "Pedir a la IA: encontrar pestañas o marcadores"
   },
   "cmdPaletteAskAiUnavailable": {
-    "message": "El modelo IA aún no está descargado. Activa primero ✨ Smart Group para descargar y luego vuelve a intentarlo."
+    "message": "El modelo IA aún no está descargado. Activa primero Smart Group para descargar y luego vuelve a intentarlo."
   },
   "cmdPaletteEmpty": {
     "message": "Sin resultados"

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -1139,5 +1139,17 @@
   },
   "workspaceSyncedTitle": {
     "message": "Synchronisé sur Google Drive"
+  },
+  "densitySectionHeader": {
+    "message": "Espacement des listes"
+  },
+  "densityOptionCompact": {
+    "message": "Compact"
+  },
+  "densityOptionCozy": {
+    "message": "Normal (par défaut)"
+  },
+  "densityOptionComfortable": {
+    "message": "Confortable"
   }
 }

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -622,10 +622,10 @@
     }
   },
   "smartGroupingBtnText": {
-    "message": "✨ Groupement Intelligent"
+    "message": "Groupement Intelligent"
   },
   "smartGroupingBtnTitle": {
-    "message": "✨ Grouper intelligemment les onglets non classés"
+    "message": "Grouper intelligemment les onglets non classés"
   },
   "toastUndoBtn": {
     "message": "Annuler"
@@ -637,10 +637,10 @@
     "message": "Le modèle d'IA n'est pas prêt. Veuillez vous assurer que votre Chrome prend en charge Gemini Nano."
   },
   "tooFewTabsToGroup": {
-    "message": "Trop peu d'onglets non classés pour être groupés ✨"
+    "message": "Trop peu d'onglets non classés pour être groupés"
   },
   "autoGroupingSuccess": {
-    "message": "✨ Onglets groupés avec succès !"
+    "message": "Onglets groupés avec succès!"
   },
   "noTabsGrouped": {
     "message": "Aucun onglet n'a été groupé avec succès."
@@ -649,7 +649,7 @@
     "message": "Une erreur s'est produite : "
   },
   "unknownCategory": {
-    "message": "📦 Catégorie Inconnue"
+    "message": "Catégorie Inconnue"
   },
   "aiGroupingToggleLabel": {
     "message": "Regroupement automatique intelligent (Nécessite Gemini Nano)"
@@ -700,7 +700,7 @@
     "message": "Vérifiez la progression du téléchargement de \"Optimization Guide On Device Model\"."
   },
   "aiSetupRestartNote": {
-    "message": "⚠️ Redémarrez Chrome après avoir modifié les paramètres ci-dessus."
+    "message": "Redémarrez Chrome après avoir modifié les paramètres ci-dessus."
   },
   "aiSetupOpenLink": {
     "message": "Ouvrir"
@@ -718,7 +718,7 @@
     "message": "Analyse des onglets..."
   },
   "aiCleanupBtnText": {
-    "message": "🧹 Nettoyer"
+    "message": "Nettoyer"
   },
   "aiCleanupBtnTitle": {
     "message": "Nettoyage d'onglets suggéré par IA"
@@ -739,7 +739,7 @@
     "message": "L'IA suggère {count} onglet(s) que vous pouvez fermer. Décochez ceux que vous voulez garder."
   },
   "aiCleanupNeedsDownload": {
-    "message": "Le modèle IA n'est pas encore téléchargé. Cliquez d'abord sur ✨ Smart Group pour démarrer le téléchargement."
+    "message": "Le modèle IA n'est pas encore téléchargé. Cliquez d'abord sur Smart Group pour démarrer le téléchargement."
   },
   "aiCleanupSectionHeader": {
     "message": "Onglets que vous pourriez fermer"
@@ -748,7 +748,7 @@
     "message": "Tout sélectionner"
   },
   "aiCleanupToggleLabel": {
-    "message": "Afficher le bouton 🧹 Nettoyage d'onglets"
+    "message": "Afficher le bouton Nettoyage d'onglets"
   },
   "bmToolsConfirmRemove": {
     "message": "Supprimer la sélection"
@@ -889,7 +889,7 @@
     "message": "Demander à l'IA : trouver des onglets ou signets"
   },
   "cmdPaletteAskAiUnavailable": {
-    "message": "Le modèle IA n'est pas encore téléchargé. Déclenchez d'abord ✨ Smart Group pour télécharger, puis réessayez."
+    "message": "Le modèle IA n'est pas encore téléchargé. Déclenchez d'abord Smart Group pour télécharger, puis réessayez."
   },
   "cmdPaletteEmpty": {
     "message": "Aucun résultat"

--- a/_locales/hi/messages.json
+++ b/_locales/hi/messages.json
@@ -1139,5 +1139,17 @@
   },
   "workspaceSyncedTitle": {
     "message": "Google Drive से सिंक किया गया"
+  },
+  "densitySectionHeader": {
+    "message": "सूची रिक्ति"
+  },
+  "densityOptionCompact": {
+    "message": "सघन"
+  },
+  "densityOptionCozy": {
+    "message": "सामान्य (डिफ़ॉल्ट)"
+  },
+  "densityOptionComfortable": {
+    "message": "आरामदायक"
   }
 }

--- a/_locales/hi/messages.json
+++ b/_locales/hi/messages.json
@@ -622,10 +622,10 @@
     }
   },
   "smartGroupingBtnText": {
-    "message": "✨ स्मार्ट ग्रुप"
+    "message": "स्मार्ट ग्रुप"
   },
   "smartGroupingBtnTitle": {
-    "message": "✨ अवर्गीकृत टैब को स्मार्ट तरीके से ग्रुप करें"
+    "message": "अवर्गीकृत टैब को स्मार्ट तरीके से ग्रुप करें"
   },
   "toastUndoBtn": {
     "message": "पूर्ववत करें"
@@ -637,10 +637,10 @@
     "message": "AI मॉडल तैयार नहीं है। कृपया सुनिश्चित करें कि आपका Chrome Gemini Nano का समर्थन करता है।"
   },
   "tooFewTabsToGroup": {
-    "message": "ग्रुप करने के लिए बहुत कम अवर्गीकृत टैब ✨"
+    "message": "ग्रुप करने के लिए बहुत कम अवर्गीकृत टैब"
   },
   "autoGroupingSuccess": {
-    "message": "✨ टैब सफलतापूर्वक ग्रुप किए गए!"
+    "message": "टैब सफलतापूर्वक ग्रुप किए गए!"
   },
   "noTabsGrouped": {
     "message": "किसी भी टैब को सफलतापूर्वक ग्रुप नहीं किया गया।"
@@ -649,7 +649,7 @@
     "message": "त्रुटि हुई: "
   },
   "unknownCategory": {
-    "message": "📦 अज्ञात श्रेणी"
+    "message": "अज्ञात श्रेणी"
   },
   "aiGroupingToggleLabel": {
     "message": "स्मार्ट ऑटो-ग्रुपिंग (Gemini Nano की आवश्यकता है)"
@@ -700,7 +700,7 @@
     "message": "\"Optimization Guide On Device Model\" की डाउनलोड प्रगति जाँचें।"
   },
   "aiSetupRestartNote": {
-    "message": "⚠️ उपर दी गई सेटिंग बदलने के बाद Chrome को पुनः प्रारंभ करें।"
+    "message": "उपर दी गई सेटिंग बदलने के बाद Chrome को पुनः प्रारंभ करें।"
   },
   "aiSetupOpenLink": {
     "message": "खोलें"
@@ -718,7 +718,7 @@
     "message": "Tabs analyze हो रहे हैं..."
   },
   "aiCleanupBtnText": {
-    "message": "🧹 Cleanup"
+    "message": "Cleanup"
   },
   "aiCleanupBtnTitle": {
     "message": "AI द्वारा सुझाया Tab Cleanup"
@@ -739,7 +739,7 @@
     "message": "AI {count} tab(s) बंद करने का सुझाव देता है। जिन्हें रखना है उनसे tick हटा दें।"
   },
   "aiCleanupNeedsDownload": {
-    "message": "AI model अभी download नहीं हुआ है। पहले ✨ Smart Group click करें download शुरू करने के लिए।"
+    "message": "AI model अभी download नहीं हुआ है। पहले Smart Group click करें download शुरू करने के लिए।"
   },
   "aiCleanupSectionHeader": {
     "message": "जिन Tabs को आप बंद कर सकते हैं"
@@ -748,7 +748,7 @@
     "message": "सभी चुनें"
   },
   "aiCleanupToggleLabel": {
-    "message": "🧹 Tab Cleanup button दिखाएं"
+    "message": "Tab Cleanup button दिखाएं"
   },
   "bmToolsConfirmRemove": {
     "message": "चुने हुए हटाएं"
@@ -889,7 +889,7 @@
     "message": "AI से पूछें: tabs या bookmarks ढूंढें"
   },
   "cmdPaletteAskAiUnavailable": {
-    "message": "AI model अभी download नहीं हुआ है। पहले ✨ Smart Group से download trigger करें, फिर try करें।"
+    "message": "AI model अभी download नहीं हुआ है। पहले Smart Group से download trigger करें, फिर try करें।"
   },
   "cmdPaletteEmpty": {
     "message": "कोई results नहीं"

--- a/_locales/id/messages.json
+++ b/_locales/id/messages.json
@@ -622,10 +622,10 @@
     }
   },
   "smartGroupingBtnText": {
-    "message": "✨ Pengelompokan Pintar"
+    "message": "Pengelompokan Pintar"
   },
   "smartGroupingBtnTitle": {
-    "message": "✨ Kelompokkan Tab yang Belum Diklasifikasikan secara Pintar"
+    "message": "Kelompokkan Tab yang Belum Diklasifikasikan secara Pintar"
   },
   "toastUndoBtn": {
     "message": "Batal"
@@ -637,10 +637,10 @@
     "message": "Model AI belum siap. Pastikan Chrome Anda mendukung Gemini Nano."
   },
   "tooFewTabsToGroup": {
-    "message": "Terlalu sedikit tab yang belum diklasifikasikan untuk dikelompokkan ✨"
+    "message": "Terlalu sedikit tab yang belum diklasifikasikan untuk dikelompokkan"
   },
   "autoGroupingSuccess": {
-    "message": "✨ Tab berhasil dikelompokkan!"
+    "message": "Tab berhasil dikelompokkan!"
   },
   "noTabsGrouped": {
     "message": "Tidak ada tab yang berhasil dikelompokkan."
@@ -649,7 +649,7 @@
     "message": "Terjadi kesalahan: "
   },
   "unknownCategory": {
-    "message": "📦 Kategori Tidak Diketahui"
+    "message": "Kategori Tidak Diketahui"
   },
   "aiGroupingToggleLabel": {
     "message": "Pengelompokan Otomatis Cerdas (Memerlukan Gemini Nano)"
@@ -700,7 +700,7 @@
     "message": "Periksa kemajuan unduhan \"Optimization Guide On Device Model\"."
   },
   "aiSetupRestartNote": {
-    "message": "⚠️ Mulai ulang Chrome setelah mengubah pengaturan di atas."
+    "message": "Mulai ulang Chrome setelah mengubah pengaturan di atas."
   },
   "aiSetupOpenLink": {
     "message": "Buka"
@@ -718,7 +718,7 @@
     "message": "Menganalisis tab..."
   },
   "aiCleanupBtnText": {
-    "message": "🧹 Cleanup"
+    "message": "Cleanup"
   },
   "aiCleanupBtnTitle": {
     "message": "Tab cleanup yang disarankan AI"
@@ -739,7 +739,7 @@
     "message": "AI menyarankan {count} tab yang mungkin bisa Anda tutup. Hapus centang yang ingin Anda simpan."
   },
   "aiCleanupNeedsDownload": {
-    "message": "Model AI belum diunduh. Klik ✨ Smart Group terlebih dahulu untuk memulai unduhan."
+    "message": "Model AI belum diunduh. Klik Smart Group terlebih dahulu untuk memulai unduhan."
   },
   "aiCleanupSectionHeader": {
     "message": "Tab yang mungkin bisa ditutup"
@@ -748,7 +748,7 @@
     "message": "Pilih semua"
   },
   "aiCleanupToggleLabel": {
-    "message": "Tampilkan tombol 🧹 Tab Cleanup"
+    "message": "Tampilkan tombol Tab Cleanup"
   },
   "bmToolsConfirmRemove": {
     "message": "Hapus pilihan"
@@ -889,7 +889,7 @@
     "message": "Minta AI: temukan tab atau bookmark"
   },
   "cmdPaletteAskAiUnavailable": {
-    "message": "Model AI belum diunduh. Picu ✨ Smart Group terlebih dahulu untuk mengunduh, lalu coba lagi."
+    "message": "Model AI belum diunduh. Picu Smart Group terlebih dahulu untuk mengunduh, lalu coba lagi."
   },
   "cmdPaletteEmpty": {
     "message": "Tidak ada hasil"

--- a/_locales/id/messages.json
+++ b/_locales/id/messages.json
@@ -1139,5 +1139,17 @@
   },
   "workspaceSyncedTitle": {
     "message": "Tersinkron ke Google Drive"
+  },
+  "densitySectionHeader": {
+    "message": "Jarak daftar"
+  },
+  "densityOptionCompact": {
+    "message": "Padat"
+  },
+  "densityOptionCozy": {
+    "message": "Normal (default)"
+  },
+  "densityOptionComfortable": {
+    "message": "Lega"
   }
 }

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -622,10 +622,10 @@
     }
   },
   "smartGroupingBtnText": {
-    "message": "✨ スマートグループ化"
+    "message": "スマートグループ化"
   },
   "smartGroupingBtnTitle": {
-    "message": "✨ 未分類のタブをスマートにグループ化"
+    "message": "未分類のタブをスマートにグループ化"
   },
   "toastUndoBtn": {
     "message": "元に戻す"
@@ -637,10 +637,10 @@
     "message": "AIモデルの準備ができていません。ChromeがGemini Nanoをサポートしているか確認してください。"
   },
   "tooFewTabsToGroup": {
-    "message": "グループ化する未分類のタブが少なすぎます ✨"
+    "message": "グループ化する未分類のタブが少なすぎます"
   },
   "autoGroupingSuccess": {
-    "message": "✨ タブが正常にグループ化されました！"
+    "message": "タブが正常にグループ化されました！"
   },
   "noTabsGrouped": {
     "message": "正常にグループ化されたタブはありませんでした。"
@@ -649,7 +649,7 @@
     "message": "エラーが発生しました: "
   },
   "unknownCategory": {
-    "message": "📦 不明なカテゴリ"
+    "message": "不明なカテゴリ"
   },
   "aiGroupingToggleLabel": {
     "message": "スマート自動グループ化 (Gemini Nanoが必要)"
@@ -700,7 +700,7 @@
     "message": "「Optimization Guide On Device Model」のダウンロード状況を確認できます。"
   },
   "aiSetupRestartNote": {
-    "message": "⚠️ 上記の設定を変更した後、Chrome を再起動してください。"
+    "message": "上記の設定を変更した後、Chrome を再起動してください。"
   },
   "aiSetupOpenLink": {
     "message": "開く"
@@ -718,7 +718,7 @@
     "message": "タブを分析中..."
   },
   "aiCleanupBtnText": {
-    "message": "🧹 整理"
+    "message": "整理"
   },
   "aiCleanupBtnTitle": {
     "message": "AI タブ整理提案"
@@ -739,7 +739,7 @@
     "message": "AI は {count} 個のタブを閉じてよいと提案しています。残したいタブのチェックを外してください。"
   },
   "aiCleanupNeedsDownload": {
-    "message": "AI モデルがまだダウンロードされていません。まず ✨ Smart Group をクリックしてダウンロードを開始してください。"
+    "message": "AI モデルがまだダウンロードされていません。まず Smart Group をクリックしてダウンロードを開始してください。"
   },
   "aiCleanupSectionHeader": {
     "message": "閉じてよいタブ"
@@ -748,7 +748,7 @@
     "message": "すべて選択"
   },
   "aiCleanupToggleLabel": {
-    "message": "🧹 タブ整理ボタンを表示"
+    "message": "タブ整理ボタンを表示"
   },
   "bmToolsConfirmRemove": {
     "message": "選択を削除"
@@ -889,7 +889,7 @@
     "message": "AI に依頼：タブやブックマークを探す"
   },
   "cmdPaletteAskAiUnavailable": {
-    "message": "AI モデルがまだダウンロードされていません。まず ✨ Smart Group でダウンロードしてから再試行してください。"
+    "message": "AI モデルがまだダウンロードされていません。まず Smart Group でダウンロードしてから再試行してください。"
   },
   "cmdPaletteEmpty": {
     "message": "結果なし"

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -1139,5 +1139,17 @@
   },
   "workspaceSyncedTitle": {
     "message": "Google ドライブに同期済み"
+  },
+  "densitySectionHeader": {
+    "message": "行間隔"
+  },
+  "densityOptionCompact": {
+    "message": "コンパクト"
+  },
+  "densityOptionCozy": {
+    "message": "標準（既定）"
+  },
+  "densityOptionComfortable": {
+    "message": "ゆったり"
   }
 }

--- a/_locales/ko/messages.json
+++ b/_locales/ko/messages.json
@@ -622,10 +622,10 @@
     }
   },
   "smartGroupingBtnText": {
-    "message": "✨ 스마트 그룹화"
+    "message": "스마트 그룹화"
   },
   "smartGroupingBtnTitle": {
-    "message": "✨ 분류되지 않은 탭 스마트 그룹화"
+    "message": "분류되지 않은 탭 스마트 그룹화"
   },
   "toastUndoBtn": {
     "message": "실행 취소"
@@ -637,10 +637,10 @@
     "message": "AI 모델이 준비되지 않았습니다. Chrome에서 Gemini Nano를 지원하는지 확인하세요."
   },
   "tooFewTabsToGroup": {
-    "message": "그룹화할 분류되지 않은 탭이 너무 적습니다 ✨"
+    "message": "그룹화할 분류되지 않은 탭이 너무 적습니다"
   },
   "autoGroupingSuccess": {
-    "message": "✨ 탭이 성공적으로 그룹화되었습니다!"
+    "message": "탭이 성공적으로 그룹화되었습니다!"
   },
   "noTabsGrouped": {
     "message": "성공적으로 그룹화된 탭이 없습니다."
@@ -649,7 +649,7 @@
     "message": "오류가 발생했습니다: "
   },
   "unknownCategory": {
-    "message": "📦 알 수 없는 카테고리"
+    "message": "알 수 없는 카테고리"
   },
   "aiGroupingToggleLabel": {
     "message": "스마트 자동 그룹화 (Gemini Nano 필요)"
@@ -700,7 +700,7 @@
     "message": "\"Optimization Guide On Device Model\" 다운로드 진행 상황을 확인할 수 있습니다."
   },
   "aiSetupRestartNote": {
-    "message": "⚠️ 위 설정을 변경한 후 Chrome을 다시 시작하세요."
+    "message": "위 설정을 변경한 후 Chrome을 다시 시작하세요."
   },
   "aiSetupOpenLink": {
     "message": "열기"
@@ -718,7 +718,7 @@
     "message": "탭 분석 중..."
   },
   "aiCleanupBtnText": {
-    "message": "🧹 정리"
+    "message": "정리"
   },
   "aiCleanupBtnTitle": {
     "message": "AI 탭 정리 제안"
@@ -739,7 +739,7 @@
     "message": "AI 가 닫을 수 있는 탭 {count} 개를 제안합니다. 유지하고 싶은 항목의 체크를 해제하세요."
   },
   "aiCleanupNeedsDownload": {
-    "message": "AI 모델이 아직 다운로드되지 않았습니다. 먼저 ✨ Smart Group 을 클릭해서 다운로드를 시작하세요."
+    "message": "AI 모델이 아직 다운로드되지 않았습니다. 먼저 Smart Group 을 클릭해서 다운로드를 시작하세요."
   },
   "aiCleanupSectionHeader": {
     "message": "닫을 수 있는 탭"
@@ -748,7 +748,7 @@
     "message": "모두 선택"
   },
   "aiCleanupToggleLabel": {
-    "message": "🧹 탭 정리 버튼 표시"
+    "message": "탭 정리 버튼 표시"
   },
   "bmToolsConfirmRemove": {
     "message": "선택 삭제"
@@ -889,7 +889,7 @@
     "message": "AI 에게 요청: 탭이나 북마크 찾기"
   },
   "cmdPaletteAskAiUnavailable": {
-    "message": "AI 모델이 아직 다운로드되지 않았습니다. 먼저 ✨ Smart Group 으로 다운로드를 트리거하고 다시 시도하세요."
+    "message": "AI 모델이 아직 다운로드되지 않았습니다. 먼저 Smart Group 으로 다운로드를 트리거하고 다시 시도하세요."
   },
   "cmdPaletteEmpty": {
     "message": "결과 없음"

--- a/_locales/ko/messages.json
+++ b/_locales/ko/messages.json
@@ -1139,5 +1139,17 @@
   },
   "workspaceSyncedTitle": {
     "message": "Google 드라이브에 동기화됨"
+  },
+  "densitySectionHeader": {
+    "message": "목록 간격"
+  },
+  "densityOptionCompact": {
+    "message": "좁게"
+  },
+  "densityOptionCozy": {
+    "message": "보통(기본)"
+  },
+  "densityOptionComfortable": {
+    "message": "넓게"
   }
 }

--- a/_locales/pt_BR/messages.json
+++ b/_locales/pt_BR/messages.json
@@ -1139,5 +1139,17 @@
   },
   "workspaceSyncedTitle": {
     "message": "Sincronizado com o Google Drive"
+  },
+  "densitySectionHeader": {
+    "message": "Espaçamento da lista"
+  },
+  "densityOptionCompact": {
+    "message": "Compacto"
+  },
+  "densityOptionCozy": {
+    "message": "Normal (padrão)"
+  },
+  "densityOptionComfortable": {
+    "message": "Confortável"
   }
 }

--- a/_locales/pt_BR/messages.json
+++ b/_locales/pt_BR/messages.json
@@ -622,10 +622,10 @@
     }
   },
   "smartGroupingBtnText": {
-    "message": "✨ Agrupamento Inteligente"
+    "message": "Agrupamento Inteligente"
   },
   "smartGroupingBtnTitle": {
-    "message": "✨ Agrupar guias não classificadas de forma inteligente"
+    "message": "Agrupar guias não classificadas de forma inteligente"
   },
   "toastUndoBtn": {
     "message": "Desfazer"
@@ -637,10 +637,10 @@
     "message": "O modelo de IA não está pronto. Certifique-se de que seu Chrome suporta Gemini Nano."
   },
   "tooFewTabsToGroup": {
-    "message": "Muito poucas guias não classificadas para agrupar ✨"
+    "message": "Muito poucas guias não classificadas para agrupar"
   },
   "autoGroupingSuccess": {
-    "message": "✨ Guias agrupadas com sucesso!"
+    "message": "Guias agrupadas com sucesso!"
   },
   "noTabsGrouped": {
     "message": "Nenhuma guia foi agrupada com sucesso."
@@ -649,7 +649,7 @@
     "message": "Ocorreu um erro: "
   },
   "unknownCategory": {
-    "message": "📦 Categoria Desconhecida"
+    "message": "Categoria Desconhecida"
   },
   "aiGroupingToggleLabel": {
     "message": "Agrupamento automático inteligente (Requer Gemini Nano)"
@@ -700,7 +700,7 @@
     "message": "Verifique o progresso do download de \"Optimization Guide On Device Model\"."
   },
   "aiSetupRestartNote": {
-    "message": "⚠️ Reinicie o Chrome após alterar as configurações acima."
+    "message": "Reinicie o Chrome após alterar as configurações acima."
   },
   "aiSetupOpenLink": {
     "message": "Abrir"
@@ -718,7 +718,7 @@
     "message": "Analisando abas..."
   },
   "aiCleanupBtnText": {
-    "message": "🧹 Limpar"
+    "message": "Limpar"
   },
   "aiCleanupBtnTitle": {
     "message": "Limpeza de abas sugerida por IA"
@@ -739,7 +739,7 @@
     "message": "A IA sugere {count} aba(s) que você provavelmente pode fechar. Desmarque as que quiser manter."
   },
   "aiCleanupNeedsDownload": {
-    "message": "O modelo IA ainda não foi baixado. Clique primeiro em ✨ Smart Group para iniciar o download."
+    "message": "O modelo IA ainda não foi baixado. Clique primeiro em Smart Group para iniciar o download."
   },
   "aiCleanupSectionHeader": {
     "message": "Abas que você poderia fechar"
@@ -748,7 +748,7 @@
     "message": "Selecionar tudo"
   },
   "aiCleanupToggleLabel": {
-    "message": "Mostrar botão 🧹 Limpeza de abas"
+    "message": "Mostrar botão Limpeza de abas"
   },
   "bmToolsConfirmRemove": {
     "message": "Remover selecionados"
@@ -889,7 +889,7 @@
     "message": "Pedir à IA: encontrar abas ou favoritos"
   },
   "cmdPaletteAskAiUnavailable": {
-    "message": "O modelo IA ainda não foi baixado. Acione primeiro ✨ Smart Group para baixar, depois tente novamente."
+    "message": "O modelo IA ainda não foi baixado. Acione primeiro Smart Group para baixar, depois tente novamente."
   },
   "cmdPaletteEmpty": {
     "message": "Sem resultados"

--- a/_locales/ru/messages.json
+++ b/_locales/ru/messages.json
@@ -622,10 +622,10 @@
     }
   },
   "smartGroupingBtnText": {
-    "message": "✨ Умная группировка"
+    "message": "Умная группировка"
   },
   "smartGroupingBtnTitle": {
-    "message": "✨ Умная группировка неклассифицированных вкладок"
+    "message": "Умная группировка неклассифицированных вкладок"
   },
   "toastUndoBtn": {
     "message": "Отменить"
@@ -637,10 +637,10 @@
     "message": "Модель ИИ не готова. Убедитесь, что ваш Chrome поддерживает Gemini Nano."
   },
   "tooFewTabsToGroup": {
-    "message": "Слишком мало неклассифицированных вкладок для группировки ✨"
+    "message": "Слишком мало неклассифицированных вкладок для группировки"
   },
   "autoGroupingSuccess": {
-    "message": "✨ Вкладки успешно сгруппированы!"
+    "message": "Вкладки успешно сгруппированы!"
   },
   "noTabsGrouped": {
     "message": "Ни одна вкладка не была успешно сгруппирована."
@@ -649,7 +649,7 @@
     "message": "Произошла ошибка: "
   },
   "unknownCategory": {
-    "message": "📦 Неизвестная категория"
+    "message": "Неизвестная категория"
   },
   "aiGroupingToggleLabel": {
     "message": "Умная автоматическая группировка (Требуется Gemini Nano)"
@@ -700,7 +700,7 @@
     "message": "Проверьте прогресс загрузки \"Optimization Guide On Device Model\"."
   },
   "aiSetupRestartNote": {
-    "message": "⚠️ Перезапустите Chrome после изменения указанных выше настроек."
+    "message": "Перезапустите Chrome после изменения указанных выше настроек."
   },
   "aiSetupOpenLink": {
     "message": "Открыть"
@@ -718,7 +718,7 @@
     "message": "Анализ вкладок..."
   },
   "aiCleanupBtnText": {
-    "message": "🧹 Очистка"
+    "message": "Очистка"
   },
   "aiCleanupBtnTitle": {
     "message": "Очистка вкладок, предложенная AI"
@@ -739,7 +739,7 @@
     "message": "AI предлагает {count} вкладку(вкладок) к закрытию. Снимите галочку с тех, что хотите оставить."
   },
   "aiCleanupNeedsDownload": {
-    "message": "Модель AI ещё не загружена. Сначала нажмите ✨ Smart Group для запуска загрузки."
+    "message": "Модель AI ещё не загружена. Сначала нажмите Smart Group для запуска загрузки."
   },
   "aiCleanupSectionHeader": {
     "message": "Вкладки, которые можно закрыть"
@@ -748,7 +748,7 @@
     "message": "Выбрать всё"
   },
   "aiCleanupToggleLabel": {
-    "message": "Показать кнопку 🧹 Очистка вкладок"
+    "message": "Показать кнопку Очистка вкладок"
   },
   "bmToolsConfirmRemove": {
     "message": "Удалить выбранное"
@@ -889,7 +889,7 @@
     "message": "Попросить AI: найти вкладки или закладки"
   },
   "cmdPaletteAskAiUnavailable": {
-    "message": "Модель AI ещё не загружена. Сначала запустите ✨ Smart Group для загрузки и попробуйте снова."
+    "message": "Модель AI ещё не загружена. Сначала запустите Smart Group для загрузки и попробуйте снова."
   },
   "cmdPaletteEmpty": {
     "message": "Нет результатов"

--- a/_locales/ru/messages.json
+++ b/_locales/ru/messages.json
@@ -1139,5 +1139,17 @@
   },
   "workspaceSyncedTitle": {
     "message": "Синхронизировано с Google Диском"
+  },
+  "densitySectionHeader": {
+    "message": "Интервал списка"
+  },
+  "densityOptionCompact": {
+    "message": "Компактно"
+  },
+  "densityOptionCozy": {
+    "message": "Обычно (по умолчанию)"
+  },
+  "densityOptionComfortable": {
+    "message": "Свободно"
   }
 }

--- a/_locales/th/messages.json
+++ b/_locales/th/messages.json
@@ -1139,5 +1139,17 @@
   },
   "workspaceSyncedTitle": {
     "message": "ซิงค์ไปยัง Google ไดรฟ์แล้ว"
+  },
+  "densitySectionHeader": {
+    "message": "ระยะห่างรายการ"
+  },
+  "densityOptionCompact": {
+    "message": "กระชับ"
+  },
+  "densityOptionCozy": {
+    "message": "ปกติ (ค่าเริ่มต้น)"
+  },
+  "densityOptionComfortable": {
+    "message": "สบาย"
   }
 }

--- a/_locales/th/messages.json
+++ b/_locales/th/messages.json
@@ -622,10 +622,10 @@
     }
   },
   "smartGroupingBtnText": {
-    "message": "✨ จัดกลุ่มอัจฉริยะ"
+    "message": "จัดกลุ่มอัจฉริยะ"
   },
   "smartGroupingBtnTitle": {
-    "message": "✨ จัดกลุ่มแท็บที่ยังไม่แยกประเภทอย่างอัจฉริยะ"
+    "message": "จัดกลุ่มแท็บที่ยังไม่แยกประเภทอย่างอัจฉริยะ"
   },
   "toastUndoBtn": {
     "message": "เลิกทำ"
@@ -637,10 +637,10 @@
     "message": "โมเดล AI ยังไม่พร้อมใช้งาน โปรดตรวจสอบว่า Chrome ของคุณรองรับ Gemini Nano"
   },
   "tooFewTabsToGroup": {
-    "message": "มีแท็บที่ยังไม่แยกประเภทน้อยเกินไปที่จะจัดกลุ่ม ✨"
+    "message": "มีแท็บที่ยังไม่แยกประเภทน้อยเกินไปที่จะจัดกลุ่ม"
   },
   "autoGroupingSuccess": {
-    "message": "✨ จัดกลุ่มแท็บสำเร็จแล้ว!"
+    "message": "จัดกลุ่มแท็บสำเร็จแล้ว!"
   },
   "noTabsGrouped": {
     "message": "ไม่มีแท็บที่จัดกลุ่มสำเร็จ"
@@ -649,7 +649,7 @@
     "message": "เกิดข้อผิดพลาด: "
   },
   "unknownCategory": {
-    "message": "📦 หมวดหมู่ที่ไม่รู้จัก"
+    "message": "หมวดหมู่ที่ไม่รู้จัก"
   },
   "aiGroupingToggleLabel": {
     "message": "การจัดกลุ่มอัตโนมัติอัจฉริยะ (ต้องการ Gemini Nano)"
@@ -700,7 +700,7 @@
     "message": "ตรวจสอบความคืบหน้าการดาวน์โหลด \"Optimization Guide On Device Model\""
   },
   "aiSetupRestartNote": {
-    "message": "⚠️ รีสตาร์ท Chrome หลังจากเปลี่ยนการตั้งค่าด้านบน"
+    "message": "รีสตาร์ท Chrome หลังจากเปลี่ยนการตั้งค่าด้านบน"
   },
   "aiSetupOpenLink": {
     "message": "เปิด"
@@ -718,7 +718,7 @@
     "message": "กำลังวิเคราะห์ tabs..."
   },
   "aiCleanupBtnText": {
-    "message": "🧹 Cleanup"
+    "message": "Cleanup"
   },
   "aiCleanupBtnTitle": {
     "message": "AI แนะนำ Tab Cleanup"
@@ -739,7 +739,7 @@
     "message": "AI แนะนำ {count} tab ที่ปิดได้ ยกเลิกการเลือก tab ที่ต้องการเก็บ"
   },
   "aiCleanupNeedsDownload": {
-    "message": "AI model ยังไม่ดาวน์โหลด คลิก ✨ Smart Group ก่อนเพื่อเริ่มดาวน์โหลด"
+    "message": "AI model ยังไม่ดาวน์โหลด คลิก Smart Group ก่อนเพื่อเริ่มดาวน์โหลด"
   },
   "aiCleanupSectionHeader": {
     "message": "Tabs ที่อาจปิดได้"
@@ -748,7 +748,7 @@
     "message": "เลือกทั้งหมด"
   },
   "aiCleanupToggleLabel": {
-    "message": "แสดงปุ่ม 🧹 Tab Cleanup"
+    "message": "แสดงปุ่ม Tab Cleanup"
   },
   "bmToolsConfirmRemove": {
     "message": "ลบที่เลือก"
@@ -889,7 +889,7 @@
     "message": "ถาม AI: หา tabs หรือ bookmarks"
   },
   "cmdPaletteAskAiUnavailable": {
-    "message": "AI model ยังไม่ดาวน์โหลด เรียก ✨ Smart Group ก่อนเพื่อดาวน์โหลด แล้วลองอีกครั้ง"
+    "message": "AI model ยังไม่ดาวน์โหลด เรียก Smart Group ก่อนเพื่อดาวน์โหลด แล้วลองอีกครั้ง"
   },
   "cmdPaletteEmpty": {
     "message": "ไม่มีผลลัพธ์"

--- a/_locales/vi/messages.json
+++ b/_locales/vi/messages.json
@@ -622,10 +622,10 @@
     }
   },
   "smartGroupingBtnText": {
-    "message": "✨ Nhóm Thông Minh"
+    "message": "Nhóm Thông Minh"
   },
   "smartGroupingBtnTitle": {
-    "message": "✨ Nhóm các thẻ chưa phân loại một cách thông minh"
+    "message": "Nhóm các thẻ chưa phân loại một cách thông minh"
   },
   "toastUndoBtn": {
     "message": "Hoàn tác"
@@ -637,10 +637,10 @@
     "message": "Mô hình AI chưa sẵn sàng. Vui lòng đảm bảo Chrome của bạn hỗ trợ Gemini Nano."
   },
   "tooFewTabsToGroup": {
-    "message": "Quá ít thẻ chưa phân loại để nhóm ✨"
+    "message": "Quá ít thẻ chưa phân loại để nhóm"
   },
   "autoGroupingSuccess": {
-    "message": "✨ Các thẻ đã được nhóm thành công!"
+    "message": "Các thẻ đã được nhóm thành công!"
   },
   "noTabsGrouped": {
     "message": "Không có thẻ nào được nhóm thành công."
@@ -649,7 +649,7 @@
     "message": "Đã xảy ra lỗi: "
   },
   "unknownCategory": {
-    "message": "📦 Danh mục không xác định"
+    "message": "Danh mục không xác định"
   },
   "aiGroupingToggleLabel": {
     "message": "Gom nhóm tự động thông minh (Yêu cầu Gemini Nano)"
@@ -700,7 +700,7 @@
     "message": "Kiểm tra tiến trình tải xuống \"Optimization Guide On Device Model\"."
   },
   "aiSetupRestartNote": {
-    "message": "⚠️ Khởi động lại Chrome sau khi thay đổi các cài đặt trên."
+    "message": "Khởi động lại Chrome sau khi thay đổi các cài đặt trên."
   },
   "aiSetupOpenLink": {
     "message": "Mở"
@@ -718,7 +718,7 @@
     "message": "Đang phân tích tabs..."
   },
   "aiCleanupBtnText": {
-    "message": "🧹 Cleanup"
+    "message": "Cleanup"
   },
   "aiCleanupBtnTitle": {
     "message": "Tab cleanup do AI gợi ý"
@@ -739,7 +739,7 @@
     "message": "AI gợi ý {count} tab có thể đóng. Bỏ chọn những cái bạn muốn giữ."
   },
   "aiCleanupNeedsDownload": {
-    "message": "Model AI chưa được tải. Nhấn ✨ Smart Group trước để bắt đầu tải."
+    "message": "Model AI chưa được tải. Nhấn Smart Group trước để bắt đầu tải."
   },
   "aiCleanupSectionHeader": {
     "message": "Tabs có thể đóng"
@@ -748,7 +748,7 @@
     "message": "Chọn tất cả"
   },
   "aiCleanupToggleLabel": {
-    "message": "Hiển thị nút 🧹 Tab Cleanup"
+    "message": "Hiển thị nút Tab Cleanup"
   },
   "bmToolsConfirmRemove": {
     "message": "Xóa đã chọn"
@@ -889,7 +889,7 @@
     "message": "Yêu cầu AI: tìm tabs hoặc bookmarks"
   },
   "cmdPaletteAskAiUnavailable": {
-    "message": "Model AI chưa được tải. Kích hoạt ✨ Smart Group trước để tải, rồi thử lại."
+    "message": "Model AI chưa được tải. Kích hoạt Smart Group trước để tải, rồi thử lại."
   },
   "cmdPaletteEmpty": {
     "message": "Không có kết quả"

--- a/_locales/vi/messages.json
+++ b/_locales/vi/messages.json
@@ -1139,5 +1139,17 @@
   },
   "workspaceSyncedTitle": {
     "message": "Đã đồng bộ với Google Drive"
+  },
+  "densitySectionHeader": {
+    "message": "Khoảng cách danh sách"
+  },
+  "densityOptionCompact": {
+    "message": "Gọn"
+  },
+  "densityOptionCozy": {
+    "message": "Vừa (mặc định)"
+  },
+  "densityOptionComfortable": {
+    "message": "Thoáng"
   }
 }

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -622,10 +622,10 @@
     }
   },
   "smartGroupingBtnText": {
-    "message": "✨ 智能整理"
+    "message": "智能整理"
   },
   "smartGroupingBtnTitle": {
-    "message": "✨ 智能整理未分类标签页"
+    "message": "智能整理未分类标签页"
   },
   "toastUndoBtn": {
     "message": "撤销 (Undo)"
@@ -637,10 +637,10 @@
     "message": "AI 模型尚未准备好，请确认您的 Chrome 支持 Gemini Nano。"
   },
   "tooFewTabsToGroup": {
-    "message": "未分类的标签页数量过少，无需整理 ✨"
+    "message": "未分类的标签页数量过少，无需整理"
   },
   "autoGroupingSuccess": {
-    "message": "✨ 标签页整理完成！"
+    "message": "标签页整理完成！"
   },
   "noTabsGrouped": {
     "message": "没有标签页被成功归类。"
@@ -649,7 +649,7 @@
     "message": "发生错误："
   },
   "unknownCategory": {
-    "message": "📦 未知分类"
+    "message": "未知分类"
   },
   "aiGroupingToggleLabel": {
     "message": "智能自动分组 (需 Gemini Nano)"
@@ -673,13 +673,13 @@
     "message": "当你创建一个没有名称的新标签页群组时，AI 会自动生成一个简短的标签（Emoji + 名称）。仅在本地模型已下载完成时生效。"
   },
   "aiCleanupToggleLabel": {
-    "message": "显示 🧹 标签页清理按钮"
+    "message": "显示 标签页清理按钮"
   },
   "aiCleanupDescription": {
     "message": "在「智能整理」旁加一个按钮，让 AI 建议你可能可以关闭的标签页。"
   },
   "aiCleanupBtnText": {
-    "message": "🧹 清理"
+    "message": "清理"
   },
   "aiCleanupBtnTitle": {
     "message": "AI 标签页清理建议"
@@ -691,7 +691,7 @@
     "message": "分析标签页中..."
   },
   "aiCleanupNeedsDownload": {
-    "message": "AI 模型尚未下载。请先点击 ✨ 智能整理 开始下载。"
+    "message": "AI 模型尚未下载。请先点击 智能整理 开始下载。"
   },
   "aiCleanupEmpty": {
     "message": "你的标签页很整洁，没有需要清理的项目。"
@@ -742,7 +742,7 @@
     "message": "查看「Optimization Guide On Device Model」的下载进度。"
   },
   "aiSetupRestartNote": {
-    "message": "⚠️ 更改以上设置后，请重新启动 Chrome。"
+    "message": "更改以上设置后，请重新启动 Chrome。"
   },
   "aiSetupOpenLink": {
     "message": "打开"
@@ -970,7 +970,7 @@
     "message": "AI 建议"
   },
   "cmdPaletteAskAiUnavailable": {
-    "message": "AI 模型尚未下载。请先点 ✨ 智能整理 触发下载后再试。"
+    "message": "AI 模型尚未下载。请先点 智能整理 触发下载后再试。"
   },
   "cmdPaletteAskAiNoMatch": {
     "message": "AI 找不到合适的结果。"

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -1139,5 +1139,17 @@
   },
   "workspaceSyncedTitle": {
     "message": "已同步至 Google 云端硬盘"
+  },
+  "densitySectionHeader": {
+    "message": "列表间距"
+  },
+  "densityOptionCompact": {
+    "message": "紧凑"
+  },
+  "densityOptionCozy": {
+    "message": "适中（默认）"
+  },
+  "densityOptionComfortable": {
+    "message": "宽松"
   }
 }

--- a/_locales/zh_TW/messages.json
+++ b/_locales/zh_TW/messages.json
@@ -622,10 +622,10 @@
     }
   },
   "smartGroupingBtnText": {
-    "message": "✨ 智慧整理"
+    "message": "智慧整理"
   },
   "smartGroupingBtnTitle": {
-    "message": "✨ 智慧整理未分類分頁"
+    "message": "智慧整理未分類分頁"
   },
   "toastUndoBtn": {
     "message": "復原 (Undo)"
@@ -637,10 +637,10 @@
     "message": "AI 模型尚未準備好，請確認您的 Chrome 支援 Gemini Nano。"
   },
   "tooFewTabsToGroup": {
-    "message": "未分類的分頁數量過少，無需整理 ✨"
+    "message": "未分類的分頁數量過少，無需整理"
   },
   "autoGroupingSuccess": {
-    "message": "✨ 分頁整理完成！"
+    "message": "分頁整理完成！"
   },
   "noTabsGrouped": {
     "message": "沒有分頁被成功歸類。"
@@ -649,7 +649,7 @@
     "message": "發生錯誤："
   },
   "unknownCategory": {
-    "message": "📦 未知分類"
+    "message": "未知分類"
   },
   "aiGroupingToggleLabel": {
     "message": "Smart Auto-Grouping (需 Gemini Nano)"
@@ -673,13 +673,13 @@
     "message": "當你建立一個沒有名稱的新分頁群組時，AI 會自動產生一個簡短的標籤（Emoji + 名稱）。僅在本地模型已下載完成時生效。"
   },
   "aiCleanupToggleLabel": {
-    "message": "顯示 🧹 分頁清理按鈕"
+    "message": "顯示 分頁清理按鈕"
   },
   "aiCleanupDescription": {
     "message": "在「智慧整理」旁加一個按鈕，讓 AI 建議你可能可以關閉的分頁。"
   },
   "aiCleanupBtnText": {
-    "message": "🧹 清理"
+    "message": "清理"
   },
   "aiCleanupBtnTitle": {
     "message": "AI 分頁清理建議"
@@ -691,7 +691,7 @@
     "message": "分析分頁中..."
   },
   "aiCleanupNeedsDownload": {
-    "message": "AI 模型尚未下載。請先點擊 ✨ 智慧整理 開始下載。"
+    "message": "AI 模型尚未下載。請先點擊 智慧整理 開始下載。"
   },
   "aiCleanupEmpty": {
     "message": "你的分頁很整潔，沒有需要清理的項目。"
@@ -742,7 +742,7 @@
     "message": "查看「Optimization Guide On Device Model」的下載進度。"
   },
   "aiSetupRestartNote": {
-    "message": "⚠️ 更改以上設定後，請重新啟動 Chrome。"
+    "message": "更改以上設定後，請重新啟動 Chrome。"
   },
   "aiSetupOpenLink": {
     "message": "開啟"
@@ -970,7 +970,7 @@
     "message": "AI 建議"
   },
   "cmdPaletteAskAiUnavailable": {
-    "message": "AI 模型尚未下載。請先點 ✨ 智慧整理 觸發下載後再試。"
+    "message": "AI 模型尚未下載。請先點 智慧整理 觸發下載後再試。"
   },
   "cmdPaletteAskAiNoMatch": {
     "message": "AI 找不到合適的結果。"

--- a/_locales/zh_TW/messages.json
+++ b/_locales/zh_TW/messages.json
@@ -1139,5 +1139,17 @@
   },
   "workspaceSyncedTitle": {
     "message": "已同步至 Google 雲端硬碟"
+  },
+  "densitySectionHeader": {
+    "message": "列表間距"
+  },
+  "densityOptionCompact": {
+    "message": "緊湊"
+  },
+  "densityOptionCozy": {
+    "message": "適中（預設）"
+  },
+  "densityOptionComfortable": {
+    "message": "寬鬆"
   }
 }

--- a/background.js
+++ b/background.js
@@ -358,26 +358,6 @@ let spotlightWindowId = null;
 // 兩次皆見 spotlightWindowId==null 而各開一個視窗。此旗標確保同時間只開一個。
 let spotlightCreating = false;
 
-// 最近聚焦的 normal 視窗快取(由 chrome.windows.onFocusChanged 維護)。
-// 用途:sidePanel.open 需要 user gesture,而 MV3 service worker 中 onCommand 的
-// user activation 無法穩定撐過 await(Chromium 已知限制,曾於 ~127 回歸、128/129+
-// 修復,官方建議永不依賴)。故全螢幕判斷改讀此「同步可得」的快取,讓全螢幕 fallback
-// 能在任何 await 之前同步呼叫 sidePanel.open,避免 gesture 失效而靜默 reject。
-let lastFocusedNormal = { id: null, fullscreen: false };
-
-function isFullscreenState(s) {
-    return s === 'fullscreen' || s === 'locked-fullscreen';
-}
-
-/** fire-and-forget 刷新 lastFocusedNormal(查當前 normal 視窗的全螢幕狀態)。不需 gesture。 */
-function refreshLastFocusedNormal() {
-    chrome.windows.getLastFocused({ windowTypes: ['normal'] }).then((w) => {
-        if (w && typeof w.id === 'number') {
-            lastFocusedNormal = { id: w.id, fullscreen: isFullscreenState(w.state) };
-        }
-    }).catch(() => {});
-}
-
 /** SW 重啟會遺失 spotlightWindowId;以 popup 視窗 url 比對找回既有 Spotlight。 */
 async function findExistingSpotlight() {
     try {
@@ -390,47 +370,13 @@ async function findExistingSpotlight() {
     return null;
 }
 
-// 快捷鍵入口。注意:必須由 onCommand 同步呼叫(其前不可有 await),否則全螢幕分支的
-// sidePanel.open 會失去 user gesture。本函式刻意「非 async」:gesture-critical 路徑全程
-// 不 await,async 收尾(popup 建立)委派給 openSpotlightPopup。
-function openSpotlight() {
-    // 全螢幕 fallback:macOS 原生全螢幕下 Chrome 自成一個 Space,開新 popup 會被系統丟到
-    // 別的 Space(畫面整個切走)。改開側邊欄並聚焦其搜尋框(側邊欄屬瀏覽器視窗內、不跨
-    // Space)。以同步快取(lastFocusedNormal)判斷全螢幕,讓 sidePanel.open 能在任何
-    // await 前同步呼叫以保留 user gesture;旗標寫入採 fire-and-forget(不 await),避免在
-    // open 前讓 gesture 失效。
-    //
-    // 已知取捨:SW 冷啟動後首次按鍵時快取仍為初始值(fullscreen:false),全螢幕使用者首
-    // 按會落到 popup 路徑(可能跳 Space);但 openSpotlightPopup 會刷新快取,次按即修正為
-    // 側邊欄。這仍優於修正前「gesture 失效 → 完全無反應」。本分支刻意不設 spotlightCreating
-    // 防重入鎖:沒有要建立的視窗,sidePanel.open 與 focus 皆冪等,連按無害。
-    if (lastFocusedNormal.fullscreen && typeof lastFocusedNormal.id === 'number') {
-        const winId = lastFocusedNormal.id;
-        chrome.storage.session.set({ pendingSearchFocus: { ts: Date.now() } }).catch(() => {});
-        chrome.sidePanel.open({ windowId: winId }).catch((err) => {
-            // 萬一 open 失敗(權限/視窗已關/快取過期),清除旗標並退回 popup,
-            // 確保快捷鍵不會靜默無反應。
-            chrome.storage.session.remove('pendingSearchFocus').catch(() => {});
-            console.warn('[spotlight] sidePanel fallback failed, opening popup:', err && err.message ? err.message : err);
-            openSpotlightPopup();
-        });
-        // open() 之後再 fire-and-forget 刷新快取:使用者若已悄悄離開全螢幕(無 focus 變更、
-        // onFocusChanged 不觸發),此處更新讓下次按鍵正確回到 popup。
-        refreshLastFocusedNormal();
-        return;
-    }
-    openSpotlightPopup();
-}
-
-async function openSpotlightPopup() {
+// 快捷鍵入口:一律開置中 popup(不論是否全螢幕)。每次行為一致、ESC 關閉後可靠重開。
+// (注:macOS 原生全螢幕下 popup 可能被系統移到別的 Space,屬使用者選擇接受的取捨。)
+async function openSpotlight() {
     if (spotlightCreating) return;
     spotlightCreating = true;
     try {
         const origin = await chrome.windows.getLastFocused({ windowTypes: ['normal'] }).catch(() => null);
-        // 順手刷新快取,供下次全螢幕判斷使用(SW 冷啟動後首次的自我修正路徑)。
-        if (origin && typeof origin.id === 'number') {
-            lastFocusedNormal = { id: origin.id, fullscreen: isFullscreenState(origin.state) };
-        }
 
         if (spotlightWindowId == null) spotlightWindowId = await findExistingSpotlight();
         if (spotlightWindowId != null) {
@@ -455,19 +401,11 @@ async function openSpotlightPopup() {
     }
 }
 
-// 失焦自動關閉(排除短暫無焦點 WINDOW_ID_NONE);同時維護 lastFocusedNormal 快取,
-// 供 openSpotlight 的全螢幕判斷在 onCommand 中同步取用(見快取宣告處的說明)。
-chrome.windows.onFocusChanged.addListener(async (winId) => {
+// 失焦自動關閉(排除短暫無焦點 WINDOW_ID_NONE)
+chrome.windows.onFocusChanged.addListener((winId) => {
     if (spotlightWindowId != null && winId !== spotlightWindowId && winId !== chrome.windows.WINDOW_ID_NONE) {
         chrome.windows.remove(spotlightWindowId).catch(() => {});
     }
-    if (winId === chrome.windows.WINDOW_ID_NONE) return;
-    try {
-        const w = await chrome.windows.get(winId);
-        if (w && w.type === 'normal') {
-            lastFocusedNormal = { id: w.id, fullscreen: isFullscreenState(w.state) };
-        }
-    } catch { /* 視窗可能已關閉,忽略 */ }
 });
 chrome.windows.onRemoved.addListener((winId) => {
     if (winId === spotlightWindowId) spotlightWindowId = null;
@@ -475,8 +413,7 @@ chrome.windows.onRemoved.addListener((winId) => {
 
 // 監聽快捷鍵指令
 chrome.commands.onCommand.addListener(async (command) => {
-  // 同步呼叫(不可 await):保留 user gesture 給全螢幕分支的 sidePanel.open。
-  if (command === 'open-search') { openSpotlight(); return; }
+  if (command === 'open-search') { await openSpotlight(); return; }
   if (command === 'create-new-tab-right') {
     // 查詢當前作用中的分頁
     const [currentTab] = await chrome.tabs.query({ active: true, currentWindow: true });

--- a/modules/aiManager.js
+++ b/modules/aiManager.js
@@ -381,7 +381,7 @@ ${tabsData}`;
 
     // Fallback if parsing fails or all retries exhausted
     return [{
-        theme: api.getMessage('unknownCategory') || "📦 未知分類",
+        theme: api.getMessage('unknownCategory') || "未知分類",
         tabIds: processingTabs.map(t => t.id)
     }];
 }

--- a/modules/commandPalette/actions.js
+++ b/modules/commandPalette/actions.js
@@ -20,7 +20,7 @@ export function buildActions() {
         {
             id: 'action-smart-group',
             type: 'action',
-            icon: '✨',
+            icon: 'auto_awesome',
             titleKey: 'cmdPaletteActionSmartGroup',
             isVisible: () => state.isAiGroupingVisible(),
             handler: () => requestPanelAction('smart-group'),
@@ -28,7 +28,7 @@ export function buildActions() {
         {
             id: 'action-ai-cleanup',
             type: 'action',
-            icon: '🧹',
+            icon: 'cleaning_services',
             titleKey: 'cmdPaletteActionAiCleanup',
             isVisible: () => state.isAiCleanupVisible(),
             handler: () => requestPanelAction('ai-cleanup'),
@@ -36,7 +36,7 @@ export function buildActions() {
         {
             id: 'action-new-tab-right',
             type: 'action',
-            icon: '➕',
+            icon: 'add',
             titleKey: 'cmdPaletteActionNewTabRight',
             handler: async () => {
                 const winId = await resolveTargetWindowId();
@@ -50,42 +50,42 @@ export function buildActions() {
         {
             id: 'action-refresh-bookmarks',
             type: 'action',
-            icon: '🔄',
+            icon: 'refresh',
             titleKey: 'cmdPaletteActionRefreshBookmarks',
             handler: () => requestPanelAction('refresh-bookmarks'),
         },
         {
             id: 'action-open-settings',
             type: 'action',
-            icon: '⚙️',
+            icon: 'settings',
             titleKey: 'cmdPaletteActionSettings',
             handler: () => chrome.runtime.openOptionsPage(),
         },
         {
             id: 'action-create-workspace',
             type: 'action',
-            icon: '💼',
+            icon: 'work',
             titleKey: 'cmdPaletteActionCreateWorkspace',
             handler: () => requestPanelAction('create-workspace'),
         },
         {
             id: 'action-manage-workspaces',
             type: 'action',
-            icon: '📦',
+            icon: 'inventory_2',
             titleKey: 'cmdPaletteActionManageWorkspaces',
             handler: () => requestPanelAction('manage-workspaces'),
         },
         {
             id: 'action-bookmark-tools',
             type: 'action',
-            icon: '🛠️',
+            icon: 'build',
             titleKey: 'cmdPaletteActionBookmarkTools',
             handler: () => requestPanelAction('bookmark-tools'),
         },
         {
             id: 'action-ask-ai-search',
             type: 'action',
-            icon: '🤖',
+            icon: 'smart_toy',
             titleKey: 'cmdPaletteActionAskAi',
             handler: () => requestPanelAction('ask-ai-search'),
         },

--- a/modules/commandPalette/dataProvider.js
+++ b/modules/commandPalette/dataProvider.js
@@ -70,7 +70,7 @@ async function getTabResults(q) {
         .map(t => ({
             id: 'tab-' + t.id,
             type: 'tab',
-            icon: t.favIconUrl || '🌐',
+            icon: t.favIconUrl || 'language',
             title: t.title || '(untitled)',
             subtitle: t.url,
             handler: async () => {
@@ -87,7 +87,7 @@ function getBookmarkResults(q) {
         .map(b => ({
             id: 'bookmark-' + b.id,
             type: 'bookmark',
-            icon: '🔖',
+            icon: 'bookmark',
             title: b.title || '(untitled)',
             subtitle: b.url,
             handler: () => openUrlInOrigin(b.url),
@@ -100,7 +100,7 @@ async function getReadingListResults(q) {
         .map(e => ({
             id: 'reading-' + e.url,
             type: 'reading-list',
-            icon: '📚',
+            icon: 'menu_book',
             title: e.title || '(untitled)',
             subtitle: e.url,
             handler: () => openUrlInOrigin(e.url),

--- a/modules/commandPalette/nlSearch.js
+++ b/modules/commandPalette/nlSearch.js
@@ -17,6 +17,7 @@ import * as state from '../stateManager.js';
 import * as aiManager from '../aiManager.js';
 import * as modal from '../modalManager.js';
 import * as readingListManager from '../readingListManager.js';
+import { renderIcon } from '../icons.js';
 
 const MAX_CANDIDATES = 30;
 const MAX_RESULTS = 8;
@@ -182,7 +183,7 @@ export async function openAskAiDialog() {
         const msg = document.createElement('div');
         msg.className = 'cmd-palette-empty';
         msg.textContent = api.getMessage('cmdPaletteAskAiUnavailable')
-            || 'AI model is not downloaded yet. Trigger ✨ Smart Group first to download, then try again.';
+            || 'AI model is not downloaded yet. Trigger Smart Group first to download, then try again.';
         root.appendChild(msg);
         return;
     }
@@ -203,7 +204,10 @@ export async function openAskAiDialog() {
 
         const icon = document.createElement('span');
         icon.className = 'cmd-palette-icon';
-        icon.textContent = item.type === 'tab' ? '🌐' : item.type === 'bookmark' ? '🔖' : '📚';
+        icon.innerHTML = renderIcon(
+            item.type === 'tab' ? 'language' : item.type === 'bookmark' ? 'bookmark' : 'menu_book',
+            { size: 16 }
+        );
 
         const meta = document.createElement('div');
         meta.className = 'cmd-palette-meta';

--- a/modules/dragDropManager.js
+++ b/modules/dragDropManager.js
@@ -70,7 +70,7 @@ function initializeBookmarkSortable(refreshBookmarks, updateTabList) {
             const { related } = evt;
             if (related && related.classList) {
                 const isCollapsedFolder = related.classList.contains('bookmark-folder') &&
-                    related.querySelector('.bookmark-icon')?.textContent === '▶';
+                    related.getAttribute('aria-expanded') === 'false';
                 if (isCollapsedFolder) {
                     folderOpenTimer = setTimeout(() => {
                         related.click();

--- a/modules/icons.js
+++ b/modules/icons.js
@@ -67,14 +67,18 @@ export function hasIcon(name) {
 export function renderIcon(name, { size = 16, className = 'm3-icon', label } = {}) {
     const inner = ICONS[name];
     if (!inner) return '';
-    const a11y = label ? `role="img" aria-label="${label}"` : 'aria-hidden="true"';
+    // label 跳脫,使函式對未來傳入動態/不可信 label 的呼叫端也安全(現無此用法)。
+    const safeLabel = label != null ? String(label).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;') : '';
+    const a11y = label ? `role="img" aria-label="${safeLabel}"` : 'aria-hidden="true"';
     return `<svg class="${className}" xmlns="http://www.w3.org/2000/svg" width="${size}" height="${size}" viewBox="0 -960 960 960" fill="currentColor" ${a11y}>${inner}</svg>`;
 }
 
-/** 同 renderIcon,但回傳 HTMLElement(供以節點建構的呼叫端)。 */
+/** 同 renderIcon,但回傳 HTMLElement(供以節點建構的呼叫端)。未知名稱 fallback 至 'language'
+ *  以保證不回傳 null(避免 replaceWith(null) 誤刪節點)。 */
 export function renderIconEl(name, opts) {
+    const html = renderIcon(name, opts) || renderIcon('language', opts);
     const tpl = document.createElement('template');
-    tpl.innerHTML = renderIcon(name, opts).trim();
+    tpl.innerHTML = html.trim();
     return tpl.content.firstElementChild;
 }
 

--- a/modules/icons.js
+++ b/modules/icons.js
@@ -1,24 +1,93 @@
-export const EDIT_ICON_SVG = `<svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"></path><path d="m15 5 4 4"></path></svg>`;
+/**
+ * Icon 系統 — Material Symbols Outlined (官方 M3, Apache-2.0)。
+ * 每個 icon 為 viewBox "0 -960 960 960" 的 fill 型 path,色彩由父層 color 經
+ * fill="currentColor" 繼承、尺寸由 width/height 決定。經 element.innerHTML 注入
+ * (MV3 CSP 下 inline SVG 為合法 markup,無需外部字型/CDN)。
+ *
+ * 用法:renderIcon('settings', {size:16}) 取得 SVG 字串;renderIconEl(...) 取得
+ * 對應 Element。既有 *_ICON_SVG 常數沿用同名匯出(改以 Material Symbols 重繪)。
+ */
 
-export const ADD_TO_GROUP_ICON_SVG = `<svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M4 6H2v14c0 1.1.9 2 2 2h14v-2H4V6zm16-4H8c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm-1 9h-4v4h-2v-4H9V9h4V5h2v4h4v2z"/></svg>`;
+// name -> 內層 markup (Material Symbols Outlined 24px,viewBox 0 -960 960 960)
+const ICONS = {
+    'edit': '<path d="M200-200h57l391-391-57-57-391 391v57Zm-80 80v-170l528-527q12-11 26.5-17t30.5-6q16 0 31 6t26 18l55 56q12 11 17.5 26t5.5 30q0 16-5.5 30.5T817-647L290-120H120Zm640-584-56-56 56 56Zm-141 85-28-29 57 57-29-28Z"/>',
+    'add_box': '<path d="M440-280h80v-160h160v-80H520v-160h-80v160H280v80h160v160ZM200-120q-33 0-56.5-23.5T120-200v-560q0-33 23.5-56.5T200-840h560q33 0 56.5 23.5T840-760v560q0 33-23.5 56.5T760-120H200Zm0-80h560v-560H200v560Zm0-560v560-560Z"/>',
+    'bookmark': '<path d="M200-120v-640q0-33 23.5-56.5T280-840h400q33 0 56.5 23.5T760-760v640L480-240 200-120Zm80-122 200-86 200 86v-518H280v518Zm0-518h400-400Z"/>',
+    'content_copy': '<path d="M360-240q-33 0-56.5-23.5T280-320v-480q0-33 23.5-56.5T360-880h360q33 0 56.5 23.5T800-800v480q0 33-23.5 56.5T720-240H360Zm0-80h360v-480H360v480ZM200-80q-33 0-56.5-23.5T120-160v-560h80v560h440v80H200Zm160-240v-480 480Z"/>',
+    'link': '<path d="M440-280H280q-83 0-141.5-58.5T80-480q0-83 58.5-141.5T280-680h160v80H280q-50 0-85 35t-35 85q0 50 35 85t85 35h160v80ZM320-440v-80h320v80H320Zm200 160v-80h160q50 0 85-35t35-85q0-50-35-85t-85-35H520v-80h160q83 0 141.5 58.5T880-480q0 83-58.5 141.5T680-280H520Z"/>',
+    'search_off': '<path d="M138.5-138.5Q80-197 80-280t58.5-141.5Q197-480 280-480t141.5 58.5Q480-363 480-280t-58.5 141.5Q363-80 280-80t-141.5-58.5ZM824-120 568-376q-12-13-25.5-26.5T516-428q38-24 61-64t23-88q0-75-52.5-127.5T420-760q-75 0-127.5 52.5T240-580q0 6 .5 11.5T242-557q-18 2-39.5 8T164-535q-2-11-3-22t-1-23q0-109 75.5-184.5T420-840q109 0 184.5 75.5T680-580q0 43-13.5 81.5T629-428l251 252-56 56Zm-615-61 71-71 70 71 29-28-71-71 71-71-28-28-71 71-71-71-28 28 71 71-71 71 28 28Z"/>',
+    'folder': '<path d="M160-160q-33 0-56.5-23.5T80-240v-480q0-33 23.5-56.5T160-800h240l80 80h320q33 0 56.5 23.5T880-640v400q0 33-23.5 56.5T800-160H160Zm0-80h640v-400H447l-80-80H160v480Zm0 0v-480 480Z"/>',
+    'folder_open': '<path d="M160-160q-33 0-56.5-23.5T80-240v-480q0-33 23.5-56.5T160-800h240l80 80h320q33 0 56.5 23.5T880-640H447l-80-80H160v480l96-320h684L837-217q-8 26-29.5 41.5T760-160H160Zm84-80h516l72-240H316l-72 240Zm0 0 72-240-72 240Zm-84-400v-80 80Z"/>',
+    'check': '<path d="M382-240 154-468l57-57 171 171 367-367 57 57-424 424Z"/>',
+    'schedule': '<path d="m612-292 56-56-148-148v-184h-80v216l172 172ZM480-80q-83 0-156-31.5T197-197q-54-54-85.5-127T80-480q0-83 31.5-156T197-763q54-54 127-85.5T480-880q83 0 156 31.5T763-763q54 54 85.5 127T880-480q0 83-31.5 156T763-197q-54 54-127 85.5T480-80Zm0-400Zm0 320q133 0 226.5-93.5T800-480q0-133-93.5-226.5T480-800q-133 0-226.5 93.5T160-480q0 133 93.5 226.5T480-160Z"/>',
+    'menu_book': '<path d="M560-564v-68q33-14 67.5-21t72.5-7q26 0 51 4t49 10v64q-24-9-48.5-13.5T700-600q-38 0-73 9.5T560-564Zm0 220v-68q33-14 67.5-21t72.5-7q26 0 51 4t49 10v64q-24-9-48.5-13.5T700-380q-38 0-73 9t-67 27Zm0-110v-68q33-14 67.5-21t72.5-7q26 0 51 4t49 10v64q-24-9-48.5-13.5T700-490q-38 0-73 9.5T560-454ZM260-320q47 0 91.5 10.5T440-278v-394q-41-24-87-36t-93-12q-36 0-71.5 7T120-692v396q35-12 69.5-18t70.5-6Zm260 42q44-21 88.5-31.5T700-320q36 0 70.5 6t69.5 18v-396q-33-14-68.5-21t-71.5-7q-47 0-93 12t-87 36v394Zm-40 118q-48-38-104-59t-116-21q-42 0-82.5 11T100-198q-21 11-40.5-1T40-234v-482q0-11 5.5-21T62-752q46-24 96-36t102-12q58 0 113.5 15T480-740q51-30 106.5-45T700-800q52 0 102 12t96 36q11 5 16.5 15t5.5 21v482q0 23-19.5 35t-40.5 1q-37-20-77.5-31T700-240q-60 0-116 21t-104 59ZM280-494Z"/>',
+    'expand_more': '<path d="M480-345 240-585l56-56 184 184 184-184 56 56-240 240Z"/>',
+    'add': '<path d="M440-440H200v-80h240v-240h80v240h240v80H520v240h-80v-240Z"/>',
+    'auto_awesome': '<path d="m760-600-50-110-110-50 110-50 50-110 50 110 110 50-110 50-50 110Zm0 560-50-110-110-50 110-50 50-110 50 110 110 50-110 50-50 110ZM360-160 260-380 40-480l220-100 100-220 100 220 220 100-220 100-100 220Zm0-194 40-86 86-40-86-40-40-86-40 86-86 40 86 40 40 86Zm0-126Z"/>',
+    'cleaning_services': '<path d="M120-40v-280q0-83 58.5-141.5T320-520h40v-320q0-33 23.5-56.5T440-920h80q33 0 56.5 23.5T600-840v320h40q83 0 141.5 58.5T840-320v280H120Zm80-80h80v-120q0-17 11.5-28.5T320-280q17 0 28.5 11.5T360-240v120h80v-120q0-17 11.5-28.5T480-280q17 0 28.5 11.5T520-240v120h80v-120q0-17 11.5-28.5T640-280q17 0 28.5 11.5T680-240v120h80v-200q0-50-35-85t-85-35H320q-50 0-85 35t-35 85v200Zm320-400v-320h-80v320h80Zm0 0h-80 80Z"/>',
+    'build': '<path d="M686-132 444-376q-20 8-40.5 12t-43.5 4q-100 0-170-70t-70-170q0-36 10-68.5t28-61.5l146 146 72-72-146-146q29-18 61.5-28t68.5-10q100 0 170 70t70 170q0 23-4 43.5T584-516l244 242q12 12 12 29t-12 29l-84 84q-12 12-29 12t-29-12Zm29-85 27-27-256-256q18-20 26-46.5t8-53.5q0-60-38.5-104.5T386-758l74 74q12 12 12 28t-12 28L332-500q-12 12-28 12t-28-12l-74-74q9 57 53.5 95.5T360-440q26 0 52-8t47-25l256 256ZM472-488Z"/>',
+    'settings': '<path d="m370-80-16-128q-13-5-24.5-12T307-235l-119 50L78-375l103-78q-1-7-1-13.5v-27q0-6.5 1-13.5L78-585l110-190 119 50q11-8 23-15t24-12l16-128h220l16 128q13 5 24.5 12t22.5 15l119-50 110 190-103 78q1 7 1 13.5v27q0 6.5-2 13.5l103 78-110 190-118-50q-11 8-23 15t-24 12L590-80H370Zm70-80h79l14-106q31-8 57.5-23.5T639-327l99 41 39-68-86-65q5-14 7-29.5t2-31.5q0-16-2-31.5t-7-29.5l86-65-39-68-99 42q-22-23-48.5-38.5T533-694l-13-106h-79l-14 106q-31 8-57.5 23.5T321-633l-99-41-39 68 86 64q-5 15-7 30t-2 32q0 16 2 31t7 30l-86 65 39 68 99-42q22 23 48.5 38.5T427-266l13 106Zm42-180q58 0 99-41t41-99q0-58-41-99t-99-41q-59 0-99.5 41T342-480q0 58 40.5 99t99.5 41Zm-2-140Z"/>',
+    'refresh': '<path d="M480-160q-134 0-227-93t-93-227q0-134 93-227t227-93q69 0 132 28.5T720-690v-110h80v280H520v-80h168q-32-56-87.5-88T480-720q-100 0-170 70t-70 170q0 100 70 170t170 70q77 0 139-44t87-116h84q-28 106-114 173t-196 67Z"/>',
+    'smart_toy': '<path d="M160-360q-50 0-85-35t-35-85q0-50 35-85t85-35v-80q0-33 23.5-56.5T240-760h120q0-50 35-85t85-35q50 0 85 35t35 85h120q33 0 56.5 23.5T800-680v80q50 0 85 35t35 85q0 50-35 85t-85 35v160q0 33-23.5 56.5T720-120H240q-33 0-56.5-23.5T160-200v-160Zm242.5-97.5Q420-475 420-500t-17.5-42.5Q385-560 360-560t-42.5 17.5Q300-525 300-500t17.5 42.5Q335-440 360-440t42.5-17.5Zm240 0Q660-475 660-500t-17.5-42.5Q625-560 600-560t-42.5 17.5Q540-525 540-500t17.5 42.5Q575-440 600-440t42.5-17.5ZM320-280h320v-80H320v80Zm-80 80h480v-480H240v480Zm240-240Z"/>',
+    'inventory_2': '<path d="M200-80q-33 0-56.5-23.5T120-160v-451q-18-11-29-28.5T80-680v-120q0-33 23.5-56.5T160-880h640q33 0 56.5 23.5T880-800v120q0 23-11 40.5T840-611v451q0 33-23.5 56.5T760-80H200Zm0-520v440h560v-440H200Zm-40-80h640v-120H160v120Zm200 280h240v-80H360v80Zm120 20Z"/>',
+    'work': '<path d="M160-120q-33 0-56.5-23.5T80-200v-440q0-33 23.5-56.5T160-720h160v-80q0-33 23.5-56.5T400-880h160q33 0 56.5 23.5T640-800v80h160q33 0 56.5 23.5T880-640v440q0 33-23.5 56.5T800-120H160Zm0-80h640v-440H160v440Zm240-520h160v-80H400v80ZM160-200v-440 440Z"/>',
+    'language': '<path d="M325-111.5q-73-31.5-127.5-86t-86-127.5Q80-398 80-480.5t31.5-155q31.5-72.5 86-127t127.5-86Q398-880 480.5-880t155 31.5q72.5 31.5 127 86t86 127Q880-563 880-480.5T848.5-325q-31.5 73-86 127.5t-127 86Q563-80 480.5-80T325-111.5ZM480-162q26-36 45-75t31-83H404q12 44 31 83t45 75Zm-104-16q-18-33-31.5-68.5T322-320H204q29 50 72.5 87t99.5 55Zm208 0q56-18 99.5-55t72.5-87H638q-9 38-22.5 73.5T584-178ZM170-400h136q-3-20-4.5-39.5T300-480q0-21 1.5-40.5T306-560H170q-5 20-7.5 39.5T160-480q0 21 2.5 40.5T170-400Zm216 0h188q3-20 4.5-39.5T580-480q0-21-1.5-40.5T574-560H386q-3 20-4.5 39.5T380-480q0 21 1.5 40.5T386-400Zm268 0h136q5-20 7.5-39.5T800-480q0-21-2.5-40.5T790-560H654q3 20 4.5 39.5T660-480q0 21-1.5 40.5T654-400Zm-16-240h118q-29-50-72.5-87T584-782q18 33 31.5 68.5T638-640Zm-234 0h152q-12-44-31-83t-45-75q-26 36-45 75t-31 83Zm-200 0h118q9-38 22.5-73.5T376-782q-56 18-99.5 55T204-640Z"/>',
+    'cloud': '<path d="M260-160q-91 0-155.5-63T40-377q0-78 47-139t123-78q25-92 100-149t170-57q117 0 198.5 81.5T760-520q69 8 114.5 59.5T920-340q0 75-52.5 127.5T740-160H260Zm0-80h480q42 0 71-29t29-71q0-42-29-71t-71-29h-60v-80q0-83-58.5-141.5T480-720q-83 0-141.5 58.5T280-520h-20q-58 0-99 41t-41 99q0 58 41 99t99 41Zm220-240Z"/>',
+    'sync': '<path d="M160-160v-80h110l-16-14q-52-46-73-105t-21-119q0-111 66.5-197.5T400-790v84q-72 26-116 88.5T240-478q0 45 17 87.5t53 78.5l10 10v-98h80v240H160Zm400-10v-84q72-26 116-88.5T720-482q0-45-17-87.5T650-648l-10-10v98h-80v-240h240v80H690l16 14q49 49 71.5 106.5T800-482q0 111-66.5 197.5T560-170Z"/>',
+    'warning': '<path d="m40-120 440-760 440 760H40Zm138-80h604L480-720 178-200Zm330.5-51.5Q520-263 520-280t-11.5-28.5Q497-320 480-320t-28.5 11.5Q440-297 440-280t11.5 28.5Q463-240 480-240t28.5-11.5ZM440-360h80v-200h-80v200Zm40-100Z"/>',
+    'check_circle': '<path d="m424-296 282-282-56-56-226 226-114-114-56 56 170 170Zm56 216q-83 0-156-31.5T197-197q-54-54-85.5-127T80-480q0-83 31.5-156T197-763q54-54 127-85.5T480-880q83 0 156 31.5T763-763q54 54 85.5 127T880-480q0 83-31.5 156T763-197q-54 54-127 85.5T480-80Zm0-80q134 0 227-93t93-227q0-134-93-227t-227-93q-134 0-227 93t-93 227q0 134 93 227t227 93Zm0-320Z"/>',
+    'download': '<path d="M480-320 280-520l56-58 104 104v-326h80v326l104-104 56 58-200 200ZM240-160q-33 0-56.5-23.5T160-240v-120h80v120h480v-120h80v120q0 33-23.5 56.5T720-160H240Z"/>',
+    'cancel': '<path d="m336-280 144-144 144 144 56-56-144-144 144-144-56-56-144 144-144-144-56 56 144 144-144 144 56 56ZM480-80q-83 0-156-31.5T197-197q-54-54-85.5-127T80-480q0-83 31.5-156T197-763q54-54 127-85.5T480-880q83 0 156 31.5T763-763q54 54 85.5 127T880-480q0 83-31.5 156T763-197q-54 54-127 85.5T480-80Zm0-80q134 0 227-93t93-227q0-134-93-227t-227-93q-134 0-227 93t-93 227q0 134 93 227t227 93Zm0-320Z"/>',
+    'open_in_new': '<path d="M200-120q-33 0-56.5-23.5T120-200v-560q0-33 23.5-56.5T200-840h280v80H200v560h560v-280h80v280q0 33-23.5 56.5T760-120H200Zm188-212-56-56 372-372H560v-80h280v280h-80v-144L388-332Z"/>',
+    'pause': '<path d="M520-200v-560h240v560H520Zm-320 0v-560h240v560H200Zm400-80h80v-400h-80v400Zm-320 0h80v-400h-80v400Zm0-400v400-400Zm320 0v400-400Z"/>',
+    'play_arrow': '<path d="M320-200v-560l440 280-440 280Zm80-280Zm0 134 210-134-210-134v268Z"/>',
+    'close': '<path d="m256-200-56-56 224-224-224-224 56-56 224 224 224-224 56 56-224 224 224 224-56 56-224-224-224 224Z"/>',
+    'track_changes': '<path d="M324-111.5Q251-143 197-197t-85.5-127Q80-397 80-480t31.5-156Q143-709 197-763t127-85.5Q397-880 480-880h40v331q18 11 29 28.5t11 40.5q0 33-23.5 56.5T480-400q-33 0-56.5-23.5T400-480q0-23 11-41t29-28v-86q-52 14-86 56.5T320-480q0 66 47 113t113 47q66 0 113-47t47-113q0-36-14.5-66.5T586-600l57-57q35 33 56 78.5t21 98.5q0 100-70 170t-170 70q-100 0-170-70t-70-170q0-90 57-156.5T440-717v-81q-119 15-199.5 105T160-480q0 134 93 227t227 93q134 0 227-93t93-227q0-69-27-129t-74-104l57-57q57 55 90.5 129.5T880-480q0 83-31.5 156T763-197q-54 54-127 85.5T480-80q-83 0-156-31.5Z"/>',
+    'science': '<path d="M200-120q-51 0-72.5-45.5T138-250l222-270v-240h-40q-17 0-28.5-11.5T280-800q0-17 11.5-28.5T320-840h320q17 0 28.5 11.5T680-800q0 17-11.5 28.5T640-760h-40v240l222 270q32 39 10.5 84.5T760-120H200Zm0-80h560L520-492v-268h-80v268L200-200Zm280-280Z"/>',
+    'palette': '<path d="M480-80q-82 0-155-31.5t-127.5-86Q143-252 111.5-325T80-480q0-83 32.5-156t88-127Q256-817 330-848.5T488-880q80 0 151 27.5t124.5 76q53.5 48.5 85 115T880-518q0 115-70 176.5T640-280h-74q-9 0-12.5 5t-3.5 11q0 12 15 34.5t15 51.5q0 50-27.5 74T480-80Zm0-400Zm-177 23q17-17 17-43t-17-43q-17-17-43-17t-43 17q-17 17-17 43t17 43q17 17 43 17t43-17Zm120-160q17-17 17-43t-17-43q-17-17-43-17t-43 17q-17 17-17 43t17 43q17 17 43 17t43-17Zm200 0q17-17 17-43t-17-43q-17-17-43-17t-43 17q-17 17-17 43t17 43q17 17 43 17t43-17Zm120 160q17-17 17-43t-17-43q-17-17-43-17t-43 17q-17 17-17 43t17 43q17 17 43 17t43-17ZM480-160q9 0 14.5-5t5.5-13q0-14-15-33t-15-57q0-42 29-67t71-25h70q66 0 113-38.5T800-518q0-121-92.5-201.5T488-800q-136 0-232 93t-96 227q0 133 93.5 226.5T480-160Z"/>',
+    'rocket_launch': '<path d="m226-559 78 33q14-28 29-54t33-52l-56-11-84 84Zm142 83 114 113q42-16 90-49t90-75q70-70 109.5-155.5T806-800q-72-5-158 34.5T492-656q-42 42-75 90t-49 90Zm155-121.5q0-33.5 23-56.5t57-23q34 0 57 23t23 56.5q0 33.5-23 56.5t-57 23q-34 0-57-23t-23-56.5ZM565-220l84-84-11-56q-26 18-52 32.5T532-299l33 79Zm313-653q19 121-23.5 235.5T708-419l20 99q4 20-2 39t-20 33L538-80l-84-197-171-171-197-84 167-168q14-14 33.5-20t39.5-2l99 20q104-104 218-147t235-24ZM157-321q35-35 85.5-35.5T328-322q35 35 34.5 85.5T327-151q-25 25-83.5 43T82-76q14-103 32-161.5t43-83.5Zm57 56q-10 10-20 36.5T180-175q27-4 53.5-13.5T270-208q12-12 13-29t-11-29q-12-12-29-11.5T214-265Z"/>',
+    'home': '<path d="M240-200h120v-240h240v240h120v-360L480-740 240-560v360Zm-80 80v-480l320-240 320 240v480H520v-240h-80v240H160Zm320-350Z"/>',
+    'shopping_cart': '<path d="M223.5-103.5Q200-127 200-160t23.5-56.5Q247-240 280-240t56.5 23.5Q360-193 360-160t-23.5 56.5Q313-80 280-80t-56.5-23.5Zm400 0Q600-127 600-160t23.5-56.5Q647-240 680-240t56.5 23.5Q760-193 760-160t-23.5 56.5Q713-80 680-80t-56.5-23.5ZM246-720l96 200h280l110-200H246Zm-38-80h590q23 0 35 20.5t1 41.5L692-482q-11 20-29.5 31T622-440H324l-44 80h480v80H280q-45 0-68-39.5t-2-78.5l54-98-144-304H40v-80h130l38 80Zm134 280h280-280Z"/>',
+    'hourglass_empty': '<path d="M320-160h320v-120q0-66-47-113t-113-47q-66 0-113 47t-47 113v120Zm273-407q47-47 47-113v-120H320v120q0 66 47 113t113 47q66 0 113-47ZM160-80v-80h80v-120q0-61 28.5-114.5T348-480q-51-32-79.5-85.5T240-680v-120h-80v-80h640v80h-80v120q0 61-28.5 114.5T612-480q51 32 79.5 85.5T720-280v120h80v80H160Z"/>',
+    'delete': '<path d="M280-120q-33 0-56.5-23.5T200-200v-520h-40v-80h200v-40h240v40h200v80h-40v520q0 33-23.5 56.5T680-120H280Zm400-600H280v520h400v-520ZM360-280h80v-360h-80v360Zm160 0h80v-360h-80v360ZM280-720v520-520Z"/>',
+};
 
-export const BOOKMARK_ICON_SVG = `<svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"></path></svg>`;
+/** 是否為已註冊的 icon 名稱 (供 spotlight 等判斷 icon-id vs 文字)。 */
+export function hasIcon(name) {
+    return Object.prototype.hasOwnProperty.call(ICONS, name);
+}
 
-export const COPY_ICON_SVG = `<svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>`;
+/**
+ * 取得 icon 的 SVG 字串。
+ * @param {string} name ICONS 的 key
+ * @param {{size?:number, className?:string, label?:string}} [opts]
+ *   size 寬高(px,預設 16);className(預設 'm3-icon');label 有值則設 role/aria-label,否則 aria-hidden。
+ * @returns {string} SVG 字串;name 不存在時回傳空字串。
+ */
+export function renderIcon(name, { size = 16, className = 'm3-icon', label } = {}) {
+    const inner = ICONS[name];
+    if (!inner) return '';
+    const a11y = label ? `role="img" aria-label="${label}"` : 'aria-hidden="true"';
+    return `<svg class="${className}" xmlns="http://www.w3.org/2000/svg" width="${size}" height="${size}" viewBox="0 -960 960 960" fill="currentColor" ${a11y}>${inner}</svg>`;
+}
 
-export const LINKED_TAB_ICON_SVG = `<svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.72"></path><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.72-1.72"></path></svg>`;
+/** 同 renderIcon,但回傳 HTMLElement(供以節點建構的呼叫端)。 */
+export function renderIconEl(name, opts) {
+    const tpl = document.createElement('template');
+    tpl.innerHTML = renderIcon(name, opts).trim();
+    return tpl.content.firstElementChild;
+}
 
-export const SEARCH_NO_RESULTS_ICON_SVG = `<svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line><line x1="11" y1="8" x2="11" y2="14"></line><line x1="8" y1="11" x2="14" y2="11"></line></svg>`;
-
-export const EMPTY_FOLDER_ICON_SVG = `<svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"></path></svg>`;
-
-// Reading List Icons
-export const CHECK_ICON_SVG = `<svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg>`;
-
-export const CLOCK_ICON_SVG = `<svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"></circle><polyline points="12 6 12 12 16 14"></polyline></svg>`;
-
-export const READING_LIST_ICON_SVG = `<svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="8" y1="6" x2="21" y2="6"></line><line x1="8" y1="12" x2="21" y2="12"></line><line x1="8" y1="18" x2="21" y2="18"></line><line x1="3" y1="6" x2="3.01" y2="6"></line><line x1="3" y1="12" x2="3.01" y2="12"></line><line x1="3" y1="18" x2="3.01" y2="18"></line></svg>`;
-
-export const CHEVRON_DOWN_ICON_SVG = `<svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"></polyline></svg>`;
-
-export const PLUS_ICON_SVG = `<svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"></line><line x1="5" y1="12" x2="19" y2="12"></line></svg>`;
+// --- 既有常數 (沿用匯出名,改以 Material Symbols 重繪,尺寸維持原值) ---
+export const EDIT_ICON_SVG = renderIcon('edit', { size: 16 });
+export const ADD_TO_GROUP_ICON_SVG = renderIcon('add_box', { size: 16 });
+export const BOOKMARK_ICON_SVG = renderIcon('bookmark', { size: 16 });
+export const COPY_ICON_SVG = renderIcon('content_copy', { size: 16 });
+export const LINKED_TAB_ICON_SVG = renderIcon('link', { size: 14 });
+export const SEARCH_NO_RESULTS_ICON_SVG = renderIcon('search_off', { size: 48 });
+export const EMPTY_FOLDER_ICON_SVG = renderIcon('folder', { size: 14 });
+export const CHECK_ICON_SVG = renderIcon('check', { size: 14 });
+export const CLOCK_ICON_SVG = renderIcon('schedule', { size: 12 });
+export const READING_LIST_ICON_SVG = renderIcon('menu_book', { size: 16 });
+export const CHEVRON_DOWN_ICON_SVG = renderIcon('expand_more', { size: 14 });
+export const PLUS_ICON_SVG = renderIcon('add', { size: 16 });

--- a/modules/modalManager.js
+++ b/modules/modalManager.js
@@ -1,6 +1,7 @@
 import * as api from './apiManager.js';
 import { escapeHtml } from './utils/textUtils.js';
 import { GROUP_COLORS } from './ui/groupColors.js';
+import { renderIcon } from './icons.js';
 // tagManager only imports apiManager (no modalManager/tagManager cycle), so this
 // import is safe. We only need the preset color name list here.
 import { getPresetColors } from './bookmark/tagManager.js';
@@ -391,8 +392,8 @@ export function showAddToBookmarkDialog({ name, url }) {
                     folderItem.setAttribute('role', 'button'); // Accessibility role
 
                     const icon = document.createElement('span');
-                    icon.className = 'bookmark-icon';
-                    icon.textContent = '▼'; // Always expanded
+                    icon.className = 'bookmark-icon is-chevron'; // 樹狀挑選器恆展開
+                    icon.innerHTML = renderIcon('expand_more', { size: 16 });
 
                     const title = document.createElement('span');
                     title.className = 'bookmark-title';
@@ -549,7 +550,7 @@ export function pickFolder({ title } = {}) {
         allItem.className = 'bookmark-folder selected';
         allItem.tabIndex = 0;
         allItem.setAttribute('role', 'button');
-        allItem.innerHTML = `<span class="bookmark-icon">▼</span><span class="bookmark-title"></span>`;
+        allItem.innerHTML = `<span class="bookmark-icon is-chevron">${renderIcon('expand_more', { size: 16 })}</span><span class="bookmark-title"></span>`;
         allItem.querySelector('.bookmark-title').textContent = selected.path;
         allItem.addEventListener('click', () => pick(null, allItem.querySelector('.bookmark-title').textContent, allItem));
         allItem.addEventListener('keydown', (e) => {
@@ -570,7 +571,7 @@ export function pickFolder({ title } = {}) {
                 folderItem.tabIndex = 0;
                 folderItem.setAttribute('role', 'button');
                 const titleText = node.title || api.getMessage('bookmarksBar') || 'Bookmarks Bar';
-                folderItem.innerHTML = `<span class="bookmark-icon">▼</span><span class="bookmark-title"></span>`;
+                folderItem.innerHTML = `<span class="bookmark-icon is-chevron">${renderIcon('expand_more', { size: 16 })}</span><span class="bookmark-title"></span>`;
                 folderItem.querySelector('.bookmark-title').textContent = titleText;
                 const newPath = parentPath ? `${parentPath} / ${titleText}` : titleText;
                 folderItem.addEventListener('click', () => pick(node.id, newPath, folderItem));

--- a/modules/searchManager.js
+++ b/modules/searchManager.js
@@ -111,12 +111,12 @@ function updateGroupVisibility(header, content, visibleTabsCount, keywords) {
     if ((hasVisibleChildren || groupTitleMatches) && keywords.length > 0) {
         // 搜尋時展開群組（需使用 inline style 以覆蓋 tabRenderer 設定的 style.display）
         content.style.display = 'block';
-        if (arrow) arrow.textContent = '▼';
+        if (arrow) arrow.classList.remove('is-collapsed');
     } else if (keywords.length === 0) {
         // 無搜尋時恢復原狀態
         const isCollapsed = header.dataset.collapsed === 'true';
         content.style.display = isCollapsed ? 'none' : 'block';
-        if (arrow) arrow.textContent = isCollapsed ? '▶' : '▼';
+        if (arrow) arrow.classList.toggle('is-collapsed', isCollapsed);
     }
 }
 
@@ -217,12 +217,12 @@ function filterOtherWindowsTabs(keywords) {
         if (windowCount > 0 && keywords.length > 0) {
             // 有搜尋結果時：展開並顯示
             content.classList.remove('collapsed');
-            if (icon) icon.textContent = '▼';
+            if (icon) icon.classList.remove('is-collapsed');
             folder.setAttribute('aria-expanded', 'true');
         } else if (keywords.length === 0) {
             // 清除搜尋時：收合
             content.classList.add('collapsed');
-            if (icon) icon.textContent = '▶';
+            if (icon) icon.classList.add('is-collapsed');
             folder.setAttribute('aria-expanded', 'false');
         }
     }

--- a/modules/spotlight/spotlightController.js
+++ b/modules/spotlight/spotlightController.js
@@ -7,6 +7,7 @@ import * as api from '../apiManager.js';
 import { searchAll } from '../commandPalette/dataProvider.js';
 import { debounce } from '../utils/functionUtils.js';
 import { isImageSrc } from '../utils/iconUtils.js';
+import { renderIcon, renderIconEl, hasIcon } from '../icons.js';
 
 let inputEl, resultsEl;
 /** @type {Array<{item: object, row: HTMLElement}>} */
@@ -93,13 +94,17 @@ function buildRow(item, index) {
     // (http/https/chrome/chrome-extension/data/blob/file)都以圖片渲染;其餘才當文字。
     // 漏掉 data: 等 scheme 會讓 data URI favicon(分頁常見)被當成 textContent,在固定寬度的
     // 圖示框內水平溢出而與相鄰列文字重疊。
+    // dispatch 順序固定:① favicon URL/URI → <img>(real favicon 優先,且避免 data: URI 被
+    // 當文字溢出);② 已註冊的 Material Symbols icon-id → 內嵌 SVG;③ 其餘 → 文字(emoji/glyph)。
     const iconStr = typeof item.icon === 'string' ? item.icon : '';
     if (isImageSrc(iconStr)) {
         const img = document.createElement('img');
         img.src = iconStr;
         img.alt = '';
-        img.onerror = () => { img.replaceWith(document.createTextNode('🌐')); };
+        img.onerror = () => { img.replaceWith(renderIconEl('language', { size: 16 })); };
         icon.appendChild(img);
+    } else if (hasIcon(iconStr)) {
+        icon.innerHTML = renderIcon(iconStr, { size: 16 });
     } else {
         icon.textContent = iconStr || '•';
     }

--- a/modules/ui/aiGrouperUI.js
+++ b/modules/ui/aiGrouperUI.js
@@ -40,15 +40,19 @@ async function handleGroupAction() {
     const fillEl = progressEl?.querySelector('.ai-progress__fill');
     if (!aiGroupBtn || aiGroupBtn.classList.contains('loading')) return;
 
+    // #ai-group-btn 由 sidepanel.html 結構化為 .btn-icon + .btn-label;更新 label 文字而非
+    // 整顆按鈕 textContent,以免洗掉圖示。
+    const aiGroupLabel = aiGroupBtn.querySelector('.btn-label');
+    const setLabel = (t) => { if (aiGroupLabel) aiGroupLabel.textContent = t; else aiGroupBtn.textContent = t; };
     /** Hides and resets the progress bar, restores button text */
-    const originalBtnText = aiGroupBtn.textContent;
+    const originalBtnText = aiGroupLabel ? aiGroupLabel.textContent : aiGroupBtn.textContent;
     function resetProgress() {
         if (progressEl) {
             progressEl.hidden = true;
             progressEl.classList.remove('shimmer');
             if (fillEl) fillEl.style.width = '0%';
         }
-        aiGroupBtn.textContent = originalBtnText;
+        setLabel(originalBtnText);
     }
 
     try {
@@ -80,7 +84,7 @@ async function handleGroupAction() {
         console.info('[AI] Needs download:', needsDownload);
         if (needsDownload) {
             // Update button text to clearly inform the user
-            aiGroupBtn.textContent = '⏳ Downloading...';
+            setLabel('Downloading...');
             if (progressEl) {
                 progressEl.hidden = false;
                 if (availability === 'downloading') {
@@ -100,10 +104,10 @@ async function handleGroupAction() {
                 console.info('[AI] Download progress:', Math.round(loaded * 100) + '%');
                 if (loaded >= 1) {
                     // Download complete — model is extracting/loading into memory
-                    aiGroupBtn.textContent = '⏳ Loading...';
+                    setLabel('Loading...');
                     if (progressEl) progressEl.classList.add('shimmer');
                 } else {
-                    aiGroupBtn.textContent = `⏳ ${Math.round(loaded * 100)}%`;
+                    setLabel(`${Math.round(loaded * 100)}%`);
                     if (progressEl) {
                         progressEl.classList.remove('shimmer');
                         if (fillEl) fillEl.style.width = `${Math.round(loaded * 100)}%`;

--- a/modules/ui/bookmarkRenderer.js
+++ b/modules/ui/bookmarkRenderer.js
@@ -791,6 +791,11 @@ export function renderBookmarks(bookmarkNodes, container, parentId, refreshBookm
             const isExpanded = currentOptions.forceExpandAll || state.isFolderExpanded(node.id);
             if (isExpanded && node.children) {
                 renderBookmarks(node.children, content, node.id, refreshBookmarksCallback, currentOptions);
+            } else if (content.children.length > 0) {
+                // 收合的資料夾若殘留先前 forceExpandAll 搜尋渲染的子節點(含 <mark> 高亮),
+                // 在此清空,讓下次展開時 lazy-load 重新渲染為無高亮列。否則清除搜尋後再展開
+                // 該資料夾會顯示舊高亮殘影/卡在過濾狀態(因 lazy-load guard 見到殘留節點而不重繪)。
+                content.replaceChildren();
             }
 
             newChildren.push(item);

--- a/modules/ui/bookmarkRenderer.js
+++ b/modules/ui/bookmarkRenderer.js
@@ -1,7 +1,7 @@
 import * as api from '../apiManager.js';
 import * as state from '../stateManager.js';
 import * as modal from '../modalManager.js';
-import { EDIT_ICON_SVG, LINKED_TAB_ICON_SVG, EMPTY_FOLDER_ICON_SVG, PLUS_ICON_SVG } from '../icons.js';
+import { EDIT_ICON_SVG, LINKED_TAB_ICON_SVG, EMPTY_FOLDER_ICON_SVG, PLUS_ICON_SVG, renderIcon } from '../icons.js';
 import { GROUP_COLORS } from './groupColors.js';
 import { highlightText } from '../utils/textUtils.js';
 import { reconcileDOM } from '../utils/domUtils.js';
@@ -353,7 +353,7 @@ function initBookmarkListeners(container) {
             const icon = folderItem.querySelector('.bookmark-icon');
             const content = folderItem.nextElementSibling; // folder-content
 
-            if (icon) icon.textContent = isNowExpanded ? '▼' : '▶';
+            if (icon) icon.classList.toggle('is-collapsed', !isNowExpanded);
             if (content) {
                 content.style.display = isNowExpanded ? 'block' : 'none';
 
@@ -634,7 +634,7 @@ function updateFolderElement(item, node, { forceExpandAll = false, highlightRege
     if (item.getAttribute('aria-expanded') !== isExpanded.toString()) {
         item.setAttribute('aria-expanded', isExpanded.toString());
         const icon = item.querySelector('.bookmark-icon');
-        if (icon) icon.textContent = isExpanded ? '▼' : '▶';
+        if (icon) icon.classList.toggle('is-collapsed', !isExpanded);
     }
 
     const titleSpan = item.querySelector('.bookmark-title');
@@ -661,8 +661,9 @@ function createFolderItem(node, options) {
     folderItem.setAttribute('role', 'button');
 
     const icon = document.createElement('span');
-    icon.className = 'bookmark-icon';
-    // Text content set in update
+    icon.className = 'bookmark-icon is-chevron';
+    icon.innerHTML = renderIcon('expand_more', { size: 16 });
+    // 收合狀態(is-collapsed)由 updateFolderElement 依 aria-expanded 設定
     folderItem.appendChild(icon);
 
     const title = document.createElement('span');

--- a/modules/ui/customThemeManager.js
+++ b/modules/ui/customThemeManager.js
@@ -13,6 +13,7 @@ import {
     meetsWcagAA
 } from '../utils/colorUtils.js';
 import { debounce } from '../utils/functionUtils.js';
+import { renderIcon } from '../icons.js';
 import { escapeHtml, sanitizeUrl } from '../utils/textUtils.js';
 
 // Storage keys
@@ -116,7 +117,7 @@ function createColorPickerPanelHtml(currentColors) {
                 <input type="color" id="color-text-primary" value="${escapeHtml(colors.primaryTextColor)}" />
             </div>
             <div id="contrast-warning" class="contrast-warning hidden">
-                ⚠️ ${api.getMessage('warningLowContrast') || 'Low contrast detected. Colors will be auto-adjusted.'}
+                ${renderIcon('warning', { size: 14 })} ${api.getMessage('warningLowContrast') || 'Low contrast detected. Colors will be auto-adjusted.'}
             </div>
             <div class="custom-theme-buttons">
                 <button id="btn-export-theme" class="modal-button">${api.getMessage('buttonExportTheme') || 'Export'}</button>

--- a/modules/ui/driveSyncBadge.js
+++ b/modules/ui/driveSyncBadge.js
@@ -12,11 +12,13 @@
  * controls live in the options page Sync section.
  */
 import * as api from '../apiManager.js';
+import { renderIcon } from '../icons.js';
+import { escapeHtml } from '../utils/textUtils.js';
 
 /**
  * Pure: map a SyncStatus object to a compact badge view-model. No DOM, no I/O.
  * @param {{state?: string, message?: string, lastSyncedAt?: number}|null|undefined} status
- * @returns {{ hidden: boolean, glyph?: string, text?: string, title?: string, stateClass?: string }}
+ * @returns {{ hidden: boolean, iconId?: string, text?: string, title?: string, stateClass?: string }}
  */
 export function resolveBadgeView(status) {
     const state = status && status.state;
@@ -29,14 +31,14 @@ export function resolveBadgeView(status) {
         case 'syncing':
             return {
                 hidden: false,
-                glyph: '↻',
+                iconId: 'sync',
                 text: api.getMessage('syncStatusSyncing') || 'Syncing…',
                 stateClass: 'is-syncing',
             };
         case 'idle':
             return {
                 hidden: false,
-                glyph: '☁︎',
+                iconId: 'cloud',
                 text: '',
                 title: api.getMessage('syncStatusIdleTitle') || api.getMessage('syncStatusIdle') || 'Synced to Google Drive',
                 stateClass: 'is-idle',
@@ -57,7 +59,7 @@ export function resolveBadgeView(status) {
             if (status && status.message) title += `: ${status.message}`;
             return {
                 hidden: false,
-                glyph: '⚠',
+                iconId: 'warning',
                 text: '',
                 title,
                 stateClass: 'is-warning',
@@ -68,7 +70,7 @@ export function resolveBadgeView(status) {
     }
 }
 
-/** Render a view-model onto the badge element (textContent only; no innerHTML). */
+/** Render a view-model onto the badge element: Material Symbols SVG + optional label. */
 function renderBadge(el, view) {
     if (!el) return;
     el.classList.remove('is-syncing', 'is-idle', 'is-warning');
@@ -80,8 +82,9 @@ function renderBadge(el, view) {
     }
     el.hidden = false;
     if (view.stateClass) el.classList.add(view.stateClass);
-    // Compose "glyph text" without innerHTML — emoji/symbol + optional label.
-    el.textContent = view.text ? `${view.glyph} ${view.text}` : view.glyph;
+    // SVG icon + optional label. text 來自 i18n(可信),仍 escapeHtml 求安全。
+    const icon = renderIcon(view.iconId, { size: 12 });
+    el.innerHTML = view.text ? `${icon} ${escapeHtml(view.text)}` : icon;
     if (view.title) el.title = view.title;
     else el.removeAttribute('title');
 }

--- a/modules/ui/hoverSummarizeManager.js
+++ b/modules/ui/hoverSummarizeManager.js
@@ -279,5 +279,5 @@ function getDomain(url) {
 function buildFallbackText(tab) {
     const domain = getDomain(tab.url);
     const title = tab.title || '';
-    return `🌐 ${domain}\n${title}`;
+    return `${domain}\n${title}`;
 }

--- a/modules/ui/otherWindowRenderer.js
+++ b/modules/ui/otherWindowRenderer.js
@@ -4,7 +4,7 @@
  */
 import * as api from '../apiManager.js';
 import * as state from '../stateManager.js';
-import { EDIT_ICON_SVG } from '../icons.js';
+import { EDIT_ICON_SVG, renderIcon } from '../icons.js';
 import { otherWindowsList } from './elements.js';
 import { GROUP_COLORS, hexToRgba } from './groupColors.js';
 
@@ -197,8 +197,8 @@ export function renderOtherWindowsSection(otherWindows, currentWindowId, allGrou
         folderItem.title = `Window ${index + 1}`;
 
         const icon = document.createElement('span');
-        icon.className = 'window-icon';
-        icon.textContent = '▶';
+        icon.className = 'window-icon is-chevron is-collapsed';
+        icon.innerHTML = renderIcon('expand_more', { size: 16 });
 
         const customName = state.getWindowName(window.id);
         const titleText = customName || `Window ${index + 1} (${window.tabs.length})`;
@@ -284,8 +284,9 @@ export function renderOtherWindowsSection(otherWindows, currentWindowId, allGrou
                 groupHeader.title = group.title;
 
                 const arrow = document.createElement('span');
-                arrow.className = 'tab-group-arrow';
-                arrow.textContent = group.collapsed ? '▶' : '▼';
+                arrow.className = 'tab-group-arrow is-chevron';
+                arrow.innerHTML = renderIcon('expand_more', { size: 16 });
+                arrow.classList.toggle('is-collapsed', group.collapsed);
 
                 const colorDot = document.createElement('div');
                 colorDot.className = 'tab-group-color-dot';
@@ -331,7 +332,7 @@ export function renderOtherWindowsSection(otherWindows, currentWindowId, allGrou
                     e.stopPropagation();
                     const isCollapsed = groupContent.style.display === 'none';
                     groupContent.style.display = isCollapsed ? 'block' : 'none';
-                    arrow.textContent = isCollapsed ? '▼' : '▶';
+                    arrow.classList.toggle('is-collapsed', !isCollapsed);
                     groupHeader.setAttribute('aria-expanded', isCollapsed.toString());
                 });
 
@@ -355,7 +356,7 @@ export function renderOtherWindowsSection(otherWindows, currentWindowId, allGrou
         const toggleCollapse = () => {
             const isExpanded = folderContent.style.display !== 'none';
             folderContent.style.display = isExpanded ? 'none' : 'block';
-            icon.textContent = isExpanded ? '▶' : '▼';
+            icon.classList.toggle('is-collapsed', isExpanded);
             folderItem.setAttribute('aria-expanded', !isExpanded);
         };
 

--- a/modules/ui/otherWindowRenderer.js
+++ b/modules/ui/otherWindowRenderer.js
@@ -153,8 +153,9 @@ function createOtherWindowTabElement(tab) {
 export function renderOtherWindowsSection(otherWindows, currentWindowId, allGroups = []) {
     if (!otherWindowsList) return;
 
-    // Filter out current window and windows with no tabs
-    const windowsToShow = otherWindows.filter(w => w.id !== currentWindowId && w.tabs && w.tabs.length > 0);
+    // Filter out: current window, non-normal windows (popup/devtools/app — e.g. the
+    // Spotlight popup should not appear here), and windows with no tabs.
+    const windowsToShow = otherWindows.filter(w => w.id !== currentWindowId && w.type === 'normal' && w.tabs && w.tabs.length > 0);
 
     otherWindowsList.innerHTML = '';
 

--- a/modules/ui/settingManager.js
+++ b/modules/ui/settingManager.js
@@ -17,6 +17,19 @@ export function applyTheme(themeName) {
     }
 }
 
+/** 有效的列間距密度;cozy 為預設(等同改版前的間距)。 */
+export const VALID_DENSITIES = ['compact', 'cozy', 'comfortable'];
+
+/**
+ * 套用列間距密度到 body(data-density)。cozy 不設 attr,讓 :root 預設值生效。
+ * @param {string} value - 'compact' | 'cozy' | 'comfortable'
+ */
+export function applyDensity(value) {
+    const v = VALID_DENSITIES.includes(value) ? value : 'cozy';
+    if (v === 'cozy') delete document.body.dataset.density;
+    else document.body.dataset.density = v;
+}
+
 /**
  * 初始化主題切換器。
  * - 從存儲中加載並應用保存的主題。
@@ -49,4 +62,9 @@ export function initThemeSwitcher() {
 
     // Load and apply background image (runs in parallel with theme)
     bgImage.loadAndApplyBackgroundImage().catch(console.error);
+
+    // Load and apply list-row density (runs in parallel with theme)
+    api.getStorage('sync', { listDensity: 'cozy' })
+        .then((d) => applyDensity(d.listDensity))
+        .catch(console.error);
 }

--- a/modules/ui/settingsBridge.js
+++ b/modules/ui/settingsBridge.js
@@ -5,7 +5,7 @@
  * sidepanel reacts to storage.onChanged. resolveSettingChangeActions maps a
  * change set to a list of UI actions; applySettingChanges executes them.
  */
-import { applyTheme } from './settingManager.js';
+import { applyTheme, applyDensity } from './settingManager.js';
 import * as customTheme from './customThemeManager.js';
 import * as bgImage from './backgroundImageManager.js';
 import * as state from '../stateManager.js';
@@ -20,6 +20,7 @@ export function resolveSettingChangeActions(changes, areaName) {
     const actions = [];
     if (areaName === 'sync') {
         if (changes.theme) actions.push({ type: 'applyTheme', value: changes.theme.newValue });
+        if (changes.listDensity) actions.push({ type: 'applyDensity', value: changes.listDensity.newValue });
         if (changes.customTheme) actions.push({ type: 'applyCustomTheme' });
         if (changes.backgroundImageConfig) actions.push({ type: 'applyBackground' });
         if (changes.uiLanguage) actions.push({ type: 'reload' });
@@ -58,6 +59,8 @@ export async function applySettingChanges(actions) {
             if (a.type === 'applyTheme') {
                 if (a.value === 'custom') await customTheme.loadAndApplyCustomTheme();
                 else applyTheme(a.value);
+            } else if (a.type === 'applyDensity') {
+                applyDensity(a.value);
             } else if (a.type === 'applyCustomTheme') {
                 await customTheme.loadAndApplyCustomTheme();
             } else if (a.type === 'applyBackground') {

--- a/modules/ui/tab/tabListeners.js
+++ b/modules/ui/tab/tabListeners.js
@@ -79,7 +79,7 @@ export function initTabListeners(container, deps) {
 
             const newCollapsedState = !groupData.collapsed;
             content.style.display = newCollapsedState ? 'none' : 'block';
-            arrow.textContent = newCollapsedState ? '▶' : '▼';
+            if (arrow) arrow.classList.toggle('is-collapsed', newCollapsedState);
             header.setAttribute('aria-expanded', (!newCollapsedState).toString());
             header.dataset.collapsed = newCollapsedState ? 'true' : 'false';
 

--- a/modules/ui/tabRenderer.js
+++ b/modules/ui/tabRenderer.js
@@ -1,5 +1,5 @@
 import * as api from '../apiManager.js';
-import { ADD_TO_GROUP_ICON_SVG, BOOKMARK_ICON_SVG } from '../icons.js';
+import { ADD_TO_GROUP_ICON_SVG, BOOKMARK_ICON_SVG, renderIcon } from '../icons.js';
 import { tabListContainer } from './elements.js';
 import { GROUP_COLORS, hexToRgba } from './groupColors.js';
 import { reconcileDOM } from '../utils/domUtils.js';
@@ -117,7 +117,7 @@ function updateGroupHeaderElement(header, group) {
         header.setAttribute('aria-expanded', (!isCollapsed).toString());
         header.dataset.collapsed = isCollapsed ? 'true' : 'false';
         const arrow = header.querySelector('.tab-group-arrow');
-        if (arrow) arrow.textContent = isCollapsed ? '▶' : '▼';
+        if (arrow) arrow.classList.toggle('is-collapsed', isCollapsed);
     }
 
     if (header.title !== group.title) header.title = group.title;
@@ -298,7 +298,8 @@ export function renderTabsAndGroups(tabs, groups, { onAddToGroupClick }) {
                 groupHeader.setAttribute('role', 'button');
 
                 const arrow = document.createElement('span');
-                arrow.className = 'tab-group-arrow';
+                arrow.className = 'tab-group-arrow is-chevron';
+                arrow.innerHTML = renderIcon('expand_more', { size: 16 });
 
                 const colorDot = document.createElement('div');
                 colorDot.className = 'tab-group-color-dot';

--- a/modules/workspace/workspaceManager.js
+++ b/modules/workspace/workspaceManager.js
@@ -45,6 +45,8 @@
  * @property {string} [groupColor]
  */
 import { getStorage, setStorage, setStorageStrict, addTabToNewGroup } from '../apiManager.js';
+import { renderIcon, hasIcon } from '../icons.js';
+import { escapeHtml } from '../utils/textUtils.js';
 
 const LEGACY_WORKSPACES_KEY = 'workspaces';            // pre-Phase-9 unified key
 const WORKSPACE_METADATA_KEY = 'workspaceMetadata';     // sync
@@ -52,7 +54,33 @@ const WORKSPACE_SNAPSHOTS_KEY = 'workspaceSnapshots';   // local
 const WINDOW_WORKSPACE_MAP_KEY = 'windowWorkspaceMap';  // local (per-device)
 
 const PRESET_COLORS = ['grey', 'blue', 'red', 'yellow', 'green', 'pink', 'purple', 'cyan'];
-const PRESET_ICONS = ['💼', '📚', '🎯', '🧪', '🎨', '🚀', '🏠', '🛒'];
+// 工作區圖示改存 Material Symbols icon-id(過往裝置可能仍存 emoji 字串,由 resolveWorkspaceIcon 相容)。
+const PRESET_ICONS = ['work', 'menu_book', 'track_changes', 'science', 'palette', 'rocket_launch', 'home', 'shopping_cart'];
+const DEFAULT_WORKSPACE_ICON = 'work';
+
+/**
+ * 有效的工作區圖示:已註冊的 icon-id,或短字串(<=4,相容舊版 emoji)。
+ * 放寬自原本單純的 length<=4,使新的 icon-id(如 'shopping_cart')不被誤拒;
+ * 仍拒絕任意長遠端字串(防濫用)。
+ */
+function isValidWorkspaceIcon(x) {
+    return typeof x === 'string' && (hasIcon(x) || (x.length >= 1 && x.length <= 4));
+}
+
+/**
+ * 將儲存的工作區圖示解析為可渲染的 HTML:icon-id → Material Symbols SVG;
+ * 舊版 emoji(短字串)→ 經跳脫的文字;其餘 → 預設 work 圖示。供管理 dialog 列使用。
+ * @param {unknown} stored
+ * @param {{size?:number}} [opts]
+ * @returns {string}
+ */
+export function resolveWorkspaceIcon(stored, { size = 16 } = {}) {
+    if (typeof stored === 'string' && hasIcon(stored)) return renderIcon(stored, { size });
+    if (typeof stored === 'string' && stored.length >= 1 && stored.length <= 4) {
+        return `<span class="ws-emoji-icon" aria-hidden="true">${escapeHtml(stored)}</span>`;
+    }
+    return renderIcon(DEFAULT_WORKSPACE_ICON, { size });
+}
 
 /** @type {Object<string, Workspace>} In-memory mirror of storage. */
 let workspaces = {};
@@ -152,7 +180,7 @@ export async function createWorkspace(args) {
         id,
         name: (args.name || 'Workspace').trim().slice(0, 60),
         color: PRESET_COLORS.includes(args.color) ? args.color : 'blue',
-        icon: (args.icon && args.icon.length <= 4) ? args.icon : '💼',
+        icon: isValidWorkspaceIcon(args.icon) ? args.icon : DEFAULT_WORKSPACE_ICON,
         bookmarkFolderId: args.bookmarkFolderId || undefined,
         tabSnapshot: [],
         lastActiveAt: Date.now(),
@@ -177,7 +205,7 @@ export async function updateWorkspace(id, updates) {
     if (!ws) return null;
     if (updates.name !== undefined) ws.name = updates.name.trim().slice(0, 60);
     if (updates.color !== undefined && PRESET_COLORS.includes(updates.color)) ws.color = updates.color;
-    if (updates.icon !== undefined && updates.icon.length <= 4) ws.icon = updates.icon;
+    if (updates.icon !== undefined && isValidWorkspaceIcon(updates.icon)) ws.icon = updates.icon;
     if (updates.bookmarkFolderId !== undefined) ws.bookmarkFolderId = updates.bookmarkFolderId || undefined;
     bumpRev(ws);
     await persistWorkspaces();
@@ -249,9 +277,9 @@ export async function applyRemoteWorkspace(id, { metadata = {}, tabSnapshot = []
     if (existing) {
         if (metadata.name !== undefined) existing.name = metadata.name;
         if (metadata.color !== undefined) existing.color = metadata.color;
-        // icon 與本機 create/update 一致限為單一 emoji(length<=4):防止損毀/惡意的遠端
-        // 資料帶入超長字串,污染各處圖示渲染(workspace 標籤、Spotlight 結果列)。
-        if (metadata.icon !== undefined && metadata.icon.length <= 4) existing.icon = metadata.icon;
+        // icon 與本機 create/update 一致:僅接受已註冊 icon-id 或短 emoji(<=4),防止損毀/
+        // 惡意的遠端資料帶入超長字串,污染各處圖示渲染(workspace 標籤、Spotlight 結果列)。
+        if (metadata.icon !== undefined && isValidWorkspaceIcon(metadata.icon)) existing.icon = metadata.icon;
         // bookmarkFolderId is intentionally allowed to be cleared (undefined).
         existing.bookmarkFolderId = metadata.bookmarkFolderId || undefined;
         if (metadata.syncEnabled !== undefined) existing.syncEnabled = Boolean(metadata.syncEnabled);
@@ -263,7 +291,7 @@ export async function applyRemoteWorkspace(id, { metadata = {}, tabSnapshot = []
             id,
             name: metadata.name || 'Workspace',
             color: metadata.color || 'blue',
-            icon: (metadata.icon && metadata.icon.length <= 4) ? metadata.icon : '💼',
+            icon: isValidWorkspaceIcon(metadata.icon) ? metadata.icon : DEFAULT_WORKSPACE_ICON,
             bookmarkFolderId: metadata.bookmarkFolderId || undefined,
             tabSnapshot: Array.isArray(tabSnapshot) ? tabSnapshot : [],
             lastActiveAt: remoteUpdatedAt,

--- a/modules/workspace/workspaceUI.js
+++ b/modules/workspace/workspaceUI.js
@@ -9,6 +9,7 @@
 import * as wsManager from './workspaceManager.js';
 import * as modal from '../modalManager.js';
 import * as api from '../apiManager.js';
+import { renderIcon } from '../icons.js';
 
 let currentWindowId = null;
 
@@ -20,21 +21,16 @@ export async function initWorkspaceUI() {
         currentWindowId = chrome.windows.WINDOW_ID_CURRENT;
     }
 
-    const switcher = document.getElementById('workspace-switcher');
-    const manageBtn = document.getElementById('workspace-manage-btn');
-    if (!switcher) return;
+    const switchBtn = document.getElementById('workspace-switch-btn');
+    if (!switchBtn) return;
 
-    switcher.setAttribute('aria-label', api.getMessage('workspaceSwitcherAriaLabel') || 'Active workspace');
-    if (manageBtn) {
-        const manageLabel = api.getMessage('workspaceManageTitle') || 'Manage workspaces';
-        manageBtn.title = manageLabel;
-        manageBtn.setAttribute('aria-label', manageLabel);
-    }
+    const manageLabel = api.getMessage('workspaceManageTitle') || 'Manage workspaces';
+    switchBtn.title = manageLabel;
+    switchBtn.setAttribute('aria-label', manageLabel);
 
-    renderSwitcher();
+    renderSwitchButton();
 
-    switcher.addEventListener('change', handleSwitch);
-    manageBtn?.addEventListener('click', openManageDialog);
+    switchBtn.addEventListener('click', openManageDialog);
 
     // Re-render switcher on:
     //   - local area: workspaceSnapshots / windowWorkspaceMap (this device's edits)
@@ -54,7 +50,7 @@ export async function initWorkspaceUI() {
         clearTimeout(reloadTimer);
         reloadTimer = setTimeout(() => {
             wsManager.initWorkspaces()
-                .then(renderSwitcher)
+                .then(renderSwitchButton)
                 .catch(err => console.warn('[workspace] sync reload failed:', err));
         }, 200);
     });
@@ -122,40 +118,26 @@ function installWindowCleanup() {
     });
 }
 
-function renderSwitcher() {
-    const switcher = document.getElementById('workspace-switcher');
-    if (!switcher) return;
+function renderSwitchButton() {
+    const btn = document.getElementById('workspace-switch-btn');
+    if (!btn) return;
+    const label = btn.querySelector('.workspace-switch-label');
+    if (!label) return;
     const activeId = wsManager.getActiveWorkspaceId(currentWindowId);
-    const all = wsManager.getAllWorkspaces();
-
-    switcher.innerHTML = '';
-
-    const blank = document.createElement('option');
-    blank.value = '';
-    blank.textContent = api.getMessage('workspaceNoActive') || '— no workspace —';
-    if (!activeId) blank.selected = true;
-    switcher.appendChild(blank);
-
-    for (const ws of all) {
-        const opt = document.createElement('option');
-        opt.value = ws.id;
-        opt.textContent = `${ws.icon} ${ws.name}`;
-        if (ws.id === activeId) opt.selected = true;
-        switcher.appendChild(opt);
-    }
+    const active = activeId ? wsManager.getWorkspace(activeId) : null;
+    // 名稱置中、無前置 emoji(見 .workspace-switch-btn CSS)。
+    label.textContent = active ? active.name : (api.getMessage('workspaceNoActive') || '— no workspace —');
 }
 
-async function handleSwitch(e) {
-    const targetId = e.target.value;
-    if (!targetId) {
-        renderSwitcher();
-        return;
-    }
-    const target = wsManager.getWorkspace(targetId);
-    if (!target) {
-        renderSwitcher();
-        return;
-    }
+/**
+ * 切換到指定工作區(沿用確認流程)。回傳是否實際切換(供呼叫端決定是否關閉管理 dialog)。
+ * 不在此重繪按鈕——切換成功後 storage.onChanged 訂閱會觸發 renderSwitchButton。
+ * @param {string} targetId
+ * @returns {Promise<boolean>}
+ */
+async function performSwitch(targetId) {
+    const target = targetId ? wsManager.getWorkspace(targetId) : null;
+    if (!target) return false;
     const currentTabs = await chrome.tabs.query({ windowId: currentWindowId });
     const isUnbound = !wsManager.getActiveWorkspaceId(currentWindowId);
 
@@ -176,14 +158,10 @@ async function handleSwitch(e) {
             .replace('{n}', String(currentTabs.length)),
         confirmButtonText: api.getMessage('workspaceSwitchConfirmBtn') || 'Switch',
     });
-    if (!ok) {
-        renderSwitcher();
-        return;
-    }
+    if (!ok) return false;
     try {
         await wsManager.switchWorkspace(targetId, currentWindowId);
-        // tabs are about to be replaced; renderSwitcher will run from the
-        // storage.onChanged subscriber once setActiveWorkspace persists.
+        return true;
     } catch (err) {
         console.error('[workspace] switch failed:', err);
         // Show the failure to the user so they know the window wasn't changed.
@@ -193,7 +171,7 @@ async function handleSwitch(e) {
                 || 'Could not switch workspace. Your current tabs were not changed.',
             confirmButtonText: api.getMessage('closeButton') || 'OK',
         });
-        renderSwitcher();
+        return false;
     }
 }
 
@@ -232,7 +210,7 @@ function openManageDialog() {
             const empty = list.querySelector('.workspace-manage__empty');
             if (empty) empty.remove();
             list.appendChild(buildManageRow(ws, true, list));
-            renderSwitcher();
+            renderSwitchButton();
         }
     });
     container.appendChild(createBtn);
@@ -247,15 +225,32 @@ function buildManageRow(ws, isActive, listEl) {
     const row = document.createElement('div');
     row.className = 'workspace-manage__row';
 
+    // 主區為切換按鈕:點擊即切換工作區(沿用確認流程),成功後關閉管理 dialog。
+    // rename/delete 為同層獨立按鈕(非巢狀),點擊不會冒泡到切換按鈕。
+    const switchEl = document.createElement('button');
+    switchEl.className = 'workspace-manage__switch';
+    if (isActive) switchEl.classList.add('active');
+    switchEl.title = api.getMessage('workspaceSwitchConfirmBtn') || 'Switch';
+
+    const iconEl = document.createElement('span');
+    iconEl.className = 'workspace-manage__icon';
+    iconEl.innerHTML = wsManager.resolveWorkspaceIcon(ws.icon, { size: 18 });
+    switchEl.appendChild(iconEl);
+
     const label = document.createElement('span');
     label.className = 'workspace-manage__label';
     const updateLabel = () => {
         const tabCount = ws.tabSnapshot ? ws.tabSnapshot.length : 0;
-        label.textContent = `${ws.icon} ${ws.name} — ${tabCount} tab(s)`;
+        label.textContent = `${ws.name} — ${tabCount} tab(s)`;
     };
     updateLabel();
-    if (isActive) label.classList.add('active');
-    row.appendChild(label);
+    switchEl.appendChild(label);
+
+    switchEl.addEventListener('click', async () => {
+        const switched = await performSwitch(ws.id);
+        if (switched) document.getElementById('closeButton')?.click();
+    });
+    row.appendChild(switchEl);
 
     // Read-only Drive-sync indicator. The authoritative opt-in toggle lives in
     // the options Sync section; this is purely a visual cue that the workspace
@@ -263,7 +258,7 @@ function buildManageRow(ws, isActive, listEl) {
     if (ws.syncEnabled === true) {
         const cloud = document.createElement('span');
         cloud.className = 'workspace-manage__sync-glyph';
-        cloud.textContent = '☁️';
+        cloud.innerHTML = renderIcon('cloud', { size: 14 });
         cloud.title = api.getMessage('workspaceSyncedTitle') || 'Synced to Google Drive';
         cloud.setAttribute('aria-label', cloud.title);
         row.appendChild(cloud);
@@ -272,7 +267,8 @@ function buildManageRow(ws, isActive, listEl) {
     const renameBtn = document.createElement('button');
     renameBtn.className = 'workspace-manage__btn';
     renameBtn.title = api.getMessage('workspaceRename') || 'Rename';
-    renameBtn.textContent = '✏️';
+    renameBtn.setAttribute('aria-label', renameBtn.title);
+    renameBtn.innerHTML = renderIcon('edit', { size: 16 });
     renameBtn.addEventListener('click', async () => {
         const newName = await modal.showPrompt({
             title: api.getMessage('workspaceRename') || 'Rename workspace',
@@ -283,7 +279,7 @@ function buildManageRow(ws, isActive, listEl) {
             // Mutate the in-place snapshot used by closures and refresh just this row.
             ws.name = newName.trim();
             updateLabel();
-            renderSwitcher();
+            renderSwitchButton();
         }
     });
     row.appendChild(renameBtn);
@@ -291,7 +287,8 @@ function buildManageRow(ws, isActive, listEl) {
     const deleteBtn = document.createElement('button');
     deleteBtn.className = 'workspace-manage__btn';
     deleteBtn.title = api.getMessage('workspaceDelete') || 'Delete';
-    deleteBtn.textContent = '🗑️';
+    deleteBtn.setAttribute('aria-label', deleteBtn.title);
+    deleteBtn.innerHTML = renderIcon('delete', { size: 16 });
     deleteBtn.addEventListener('click', async () => {
         const ok = await modal.showConfirm({
             title: api.getMessage('workspaceDeleteConfirmTitle') || 'Delete workspace',
@@ -310,7 +307,7 @@ function buildManageRow(ws, isActive, listEl) {
                 empty.textContent = api.getMessage('workspaceManageEmpty') || 'No workspaces yet.';
                 listEl.appendChild(empty);
             }
-            renderSwitcher();
+            renderSwitchButton();
         }
     });
     row.appendChild(deleteBtn);
@@ -339,8 +336,5 @@ export async function createWorkspaceFromCurrent() {
 
 /** Exposed so the Command Palette can prompt switch to a workspace by id. */
 export async function requestSwitchTo(workspaceId) {
-    const switcher = document.getElementById('workspace-switcher');
-    if (!switcher) return;
-    switcher.value = workspaceId;
-    handleSwitch({ target: switcher });
+    await performSwitch(workspaceId);
 }

--- a/modules/workspace/workspaceUI.js
+++ b/modules/workspace/workspaceUI.js
@@ -186,6 +186,10 @@ function openManageDialog() {
     const container = document.createElement('div');
     container.className = 'workspace-manage';
 
+    // 本 dialog 專屬的關閉控制(於 showCustomDialog onOpen 設定):避免以 document-global
+    // 查找 #closeButton 而可能命中其他 modal(見 nlSearch.js 對同模式的警示)。
+    const dialogRef = { close: () => {} };
+
     const list = document.createElement('div');
     list.className = 'workspace-manage__list';
     if (all.length === 0) {
@@ -195,7 +199,7 @@ function openManageDialog() {
         list.appendChild(empty);
     } else {
         for (const ws of all) {
-            list.appendChild(buildManageRow(ws, ws.id === activeId, list));
+            list.appendChild(buildManageRow(ws, ws.id === activeId, list, dialogRef));
         }
     }
     container.appendChild(list);
@@ -209,7 +213,7 @@ function openManageDialog() {
             // Replace the "empty" placeholder if present, then append new row.
             const empty = list.querySelector('.workspace-manage__empty');
             if (empty) empty.remove();
-            list.appendChild(buildManageRow(ws, true, list));
+            list.appendChild(buildManageRow(ws, true, list, dialogRef));
             renderSwitchButton();
         }
     });
@@ -218,10 +222,14 @@ function openManageDialog() {
     modal.showCustomDialog({
         title: api.getMessage('workspaceManageTitle') || 'Manage workspaces',
         content: container,
+        onOpen: (modalContent) => {
+            const closeBtn = modalContent.querySelector('#closeButton');
+            if (closeBtn) dialogRef.close = () => closeBtn.click();
+        },
     });
 }
 
-function buildManageRow(ws, isActive, listEl) {
+function buildManageRow(ws, isActive, listEl, dialogRef) {
     const row = document.createElement('div');
     row.className = 'workspace-manage__row';
 
@@ -248,7 +256,7 @@ function buildManageRow(ws, isActive, listEl) {
 
     switchEl.addEventListener('click', async () => {
         const switched = await performSwitch(ws.id);
-        if (switched) document.getElementById('closeButton')?.click();
+        if (switched) dialogRef.close();
     });
     row.appendChild(switchEl);
 

--- a/options.js
+++ b/options.js
@@ -152,7 +152,7 @@ async function renderAppearance(container) {
     container.appendChild(spExplanation);
 
     const spBtn = document.createElement('button');
-    spBtn.className = 'modal-btn';
+    spBtn.className = 'modal-button';
     spBtn.textContent = api.getMessage('sidePanelPositionLinkText') || 'Open Chrome Appearance Settings';
     spBtn.addEventListener('click', () => {
         chrome.tabs.create({ url: 'chrome://settings/appearance' });
@@ -343,7 +343,7 @@ async function renderRss(container) {
 
     const addBtn = document.createElement('button');
     addBtn.id = 'rss-add-btn';
-    addBtn.className = 'modal-btn';
+    addBtn.className = 'modal-button';
     addBtn.textContent = api.getMessage('addRssSubscription') || 'Add';
     addControls.appendChild(addBtn);
 
@@ -671,7 +671,7 @@ function renderSync(container) {
             connectedLabel.className = 'opt-row__label';
             connectedLabel.textContent = api.getMessage('syncConnected') || 'Connected to Google Drive';
             const disconnectBtn = document.createElement('button');
-            disconnectBtn.className = 'modal-btn';
+            disconnectBtn.className = 'modal-button primary';
             disconnectBtn.textContent = api.getMessage('syncDisconnectButton') || 'Disconnect';
             disconnectBtn.addEventListener('click', async () => {
                 const confirmed = await modalManager.showConfirm({
@@ -692,7 +692,7 @@ function renderSync(container) {
             accountBlock.appendChild(makeRow(connectedLabel.textContent, disconnectBtn));
         } else {
             const connectBtn = document.createElement('button');
-            connectBtn.className = 'modal-btn';
+            connectBtn.className = 'modal-button primary';
             connectBtn.textContent = api.getMessage('syncConnectButton') || 'Connect Google Drive';
             const connectNote = document.createElement('div');
             connectNote.className = 'opt-row__desc sync-connect-note';
@@ -752,7 +752,7 @@ function renderSync(container) {
                     statusText = (api.getMessage('syncStatusError') || 'Error') +
                         (status.message ? `: ${status.message}` : '');
                     retryBtn = document.createElement('button');
-                    retryBtn.className = 'modal-btn';
+                    retryBtn.className = 'modal-button';
                     retryBtn.textContent = api.getMessage('syncRetryButton') || 'Retry';
                     break;
                 case 'conflict':
@@ -801,7 +801,7 @@ function renderSync(container) {
         // ===== 3. Actions =====
         actionsBlock.innerHTML = '';
         const syncNowBtn = document.createElement('button');
-        syncNowBtn.className = 'modal-btn';
+        syncNowBtn.className = 'modal-button primary';
         syncNowBtn.textContent = api.getMessage('syncNowButton') || 'Sync now';
         syncNowBtn.disabled = !connected;
         syncNowBtn.addEventListener('click', async () => {
@@ -866,7 +866,7 @@ function renderSync(container) {
             for (const entry of restorableNotLocal) {
                 const name = (entry.metadata && entry.metadata.name) || entry.name || entry.id;
                 const restoreBtn = document.createElement('button');
-                restoreBtn.className = 'modal-btn';
+                restoreBtn.className = 'modal-button';
                 restoreBtn.textContent = api.getMessage('syncRestoreButton') || 'Restore';
                 restoreBtn.addEventListener('click', async () => {
                     restoreBtn.disabled = true;
@@ -1141,7 +1141,7 @@ async function renderShortcuts(container) {
 
     // Button to open chrome://extensions/shortcuts
     const manageBtn = document.createElement('button');
-    manageBtn.className = 'modal-btn';
+    manageBtn.className = 'modal-button';
     manageBtn.textContent = api.getMessage('shortcutLinkText') || 'Manage Extension Shortcuts';
     manageBtn.addEventListener('click', () => {
         chrome.tabs.create({ url: 'chrome://extensions/shortcuts' });
@@ -1261,7 +1261,11 @@ function buildNav(navEl, contentEl) {
     activate(SECTIONS[0].id);
 }
 
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('DOMContentLoaded', async () => {
+    // 套用 uiLanguage 覆寫:必須在 buildNav(以 api.getMessage 渲染全頁)前載入自訂字典,
+    // 否則 getMessage 會退回瀏覽器語系、忽略使用者選的語言(比照 sidepanel.js / spotlight.js)。
+    const { uiLanguage } = await api.getStorage('sync', { uiLanguage: 'auto' });
+    await api.loadCustomI18n(uiLanguage);
     applyOwnTheme();
     buildNav(document.getElementById('opt-nav'), document.getElementById('opt-content'));
 });

--- a/options.js
+++ b/options.js
@@ -18,6 +18,12 @@ const THEME_OPTIONS = [
     { value: 'custom', labelKey: 'themeOptionCustom' }
 ];
 
+const DENSITY_OPTIONS = [
+    { value: 'compact', labelKey: 'densityOptionCompact' },
+    { value: 'cozy', labelKey: 'densityOptionCozy' },
+    { value: 'comfortable', labelKey: 'densityOptionComfortable' }
+];
+
 /**
  * 建立一個 .opt-row 容器：左側 label（含選用說明），右側 control。
  * @param {string} labelText
@@ -99,6 +105,26 @@ async function renderAppearance(container) {
         }
         // NOTE: no CustomEvent dispatch — sidepanel reacts via D6 storage bridge.
     });
+
+    // --- List density select ---
+    const { listDensity: storedDensity } = await api.getStorage('sync', { listDensity: 'cozy' });
+    const densitySelect = document.createElement('select');
+    densitySelect.id = 'density-select-dropdown';
+    densitySelect.className = 'modal-select';
+    for (const opt of DENSITY_OPTIONS) {
+        const o = document.createElement('option');
+        o.value = opt.value;
+        o.textContent = api.getMessage(opt.labelKey) || opt.value;
+        if (opt.value === (storedDensity || 'cozy')) o.selected = true;
+        densitySelect.appendChild(o);
+    }
+    // 只寫 storage;側邊欄透過 settingsBridge 的 storage.onChanged 即時套用密度。
+    densitySelect.addEventListener('change', async (event) => {
+        await api.setStorage('sync', { listDensity: event.target.value });
+    });
+    container.appendChild(
+        makeRow(api.getMessage('densitySectionHeader') || 'List spacing', densitySelect)
+    );
 
     // --- Background image panel (reuse backgroundImageManager) ---
     const bgConfig = await bgImage.loadBackgroundConfig();

--- a/options.js
+++ b/options.js
@@ -7,6 +7,7 @@ import { checkModelAvailability, triggerLanguageModelDownload } from './modules/
 import * as modalManager from './modules/modalManager.js';
 import * as driveAuth from './modules/sync/driveAuth.js';
 import * as workspaceManager from './modules/workspace/workspaceManager.js';
+import { renderIcon } from './modules/icons.js';
 
 const THEME_OPTIONS = [
     { value: 'geek', labelKey: 'themeOptionGeek' },
@@ -385,7 +386,7 @@ async function renderRss(container) {
             fetchBtn.className = 'rss-fetch-now-btn';
             fetchBtn.title = api.getMessage('rssFetchNowButton') || 'Fetch now';
             fetchBtn.setAttribute('aria-label', api.getMessage('rssFetchNowButton') || 'Fetch now');
-            fetchBtn.textContent = '🔄';
+            fetchBtn.innerHTML = renderIcon('refresh', { size: 16 });
             actions.appendChild(fetchBtn);
 
             const toggleBtn = document.createElement('button');
@@ -395,14 +396,14 @@ async function renderRss(container) {
                 ? (api.getMessage('rssPauseButton') || 'Pause')
                 : (api.getMessage('rssResumeButton') || 'Resume');
             toggleBtn.setAttribute('aria-label', toggleBtn.title);
-            toggleBtn.textContent = sub.enabled ? '⏸' : '▶';
+            toggleBtn.innerHTML = renderIcon(sub.enabled ? 'pause' : 'play_arrow', { size: 16 });
             actions.appendChild(toggleBtn);
 
             const deleteBtn = document.createElement('button');
             deleteBtn.className = 'rss-delete-btn';
             deleteBtn.title = api.getMessage('rssDeleteButton') || 'Delete';
             deleteBtn.setAttribute('aria-label', api.getMessage('rssDeleteButton') || 'Delete');
-            deleteBtn.textContent = '×';
+            deleteBtn.innerHTML = renderIcon('close', { size: 16 });
             actions.appendChild(deleteBtn);
 
             item.appendChild(info);
@@ -886,14 +887,14 @@ function renderSync(container) {
  * Maps an AI availability status string to a badge display object.
  * Mirrors the same helper in settingManager.js (getStatusBadge).
  * @param {string} status
- * @returns {{emoji: string, className: string}}
+ * @returns {{icon: string, label: string, className: string}}
  */
 function getStatusBadge(status) {
     switch (status) {
-        case 'available':   return { emoji: '✅ Available',   className: 'available' };
-        case 'downloading': return { emoji: '⏳ Downloading', className: 'downloading' };
-        case 'downloadable':return { emoji: '📥 Downloadable',className: 'downloadable' };
-        default:            return { emoji: '❌ Unavailable', className: 'unavailable' };
+        case 'available':   return { icon: 'check_circle',    label: 'Available',    className: 'available' };
+        case 'downloading': return { icon: 'hourglass_empty', label: 'Downloading',  className: 'downloading' };
+        case 'downloadable':return { icon: 'download',        label: 'Downloadable', className: 'downloadable' };
+        default:            return { icon: 'cancel',          label: 'Unavailable',  className: 'unavailable' };
     }
 }
 
@@ -926,7 +927,7 @@ async function renderAi(container) {
     const lmBadge = document.createElement('span');
     lmBadge.id = 'ai-lm-status-badge';
     lmBadge.className = 'ai-status-badge checking';
-    lmBadge.textContent = '⏳';
+    lmBadge.innerHTML = renderIcon('hourglass_empty', { size: 14 });
     lmRow.appendChild(lmLabel);
     lmRow.appendChild(lmBadge);
     statusSection.appendChild(lmRow);
@@ -940,7 +941,7 @@ async function renderAi(container) {
     const sumBadge = document.createElement('span');
     sumBadge.id = 'ai-sum-status-badge';
     sumBadge.className = 'ai-status-badge checking';
-    sumBadge.textContent = '⏳';
+    sumBadge.innerHTML = renderIcon('hourglass_empty', { size: 14 });
     sumRow.appendChild(sumLabel);
     sumRow.appendChild(sumBadge);
     statusSection.appendChild(sumRow);
@@ -992,7 +993,8 @@ async function renderAi(container) {
 
         const openBtn = document.createElement('button');
         openBtn.className = 'ai-setup-link-btn';
-        openBtn.textContent = (api.getMessage('aiSetupOpenLink') || 'Open') + ' ↗';
+        openBtn.textContent = (api.getMessage('aiSetupOpenLink') || 'Open') + ' ';
+        openBtn.insertAdjacentHTML('beforeend', renderIcon('open_in_new', { size: 14 }));
         openBtn.addEventListener('click', () => {
             chrome.tabs.create({ url: step.url });
         });
@@ -1003,7 +1005,8 @@ async function renderAi(container) {
 
     const restartNote = document.createElement('div');
     restartNote.className = 'ai-setup-restart-note';
-    restartNote.textContent = api.getMessage('aiSetupRestartNote') || '⚠️ Restart Chrome after changing the flags above.';
+    restartNote.textContent = api.getMessage('aiSetupRestartNote') || 'Restart Chrome after changing the flags above.';
+    restartNote.insertAdjacentHTML('afterbegin', renderIcon('warning', { size: 14 }) + ' ');
     guide.appendChild(restartNote);
 
     container.appendChild(guide);
@@ -1013,7 +1016,7 @@ async function renderAi(container) {
         // LanguageModel
         const lmStatus = await checkModelAvailability();
         const lmBadgeInfo = getStatusBadge(lmStatus);
-        lmBadge.textContent = lmBadgeInfo.emoji;
+        lmBadge.innerHTML = renderIcon(lmBadgeInfo.icon, { size: 14 }) + ' ' + lmBadgeInfo.label;
         lmBadge.className = `ai-status-badge ${lmBadgeInfo.className}`;
 
         // Summarizer — call Summarizer.availability() directly (same as settingManager)
@@ -1022,7 +1025,7 @@ async function renderAi(container) {
             try { sumStatus = await Summarizer.availability() || 'unavailable'; } catch { /* ignore */ }
         }
         const sumBadgeInfo = getStatusBadge(sumStatus);
-        sumBadge.textContent = sumBadgeInfo.emoji;
+        sumBadge.innerHTML = renderIcon(sumBadgeInfo.icon, { size: 14 }) + ' ' + sumBadgeInfo.label;
         sumBadge.className = `ai-status-badge ${sumBadgeInfo.className}`;
 
         // Trigger download + show progress if needed
@@ -1054,7 +1057,7 @@ async function renderAi(container) {
 
             const newStatus = await checkModelAvailability();
             const newBadge = getStatusBadge(newStatus);
-            lmBadge.textContent = newBadge.emoji;
+            lmBadge.innerHTML = renderIcon(newBadge.icon, { size: 14 }) + ' ' + newBadge.label;
             lmBadge.className = `ai-status-badge ${newBadge.className}`;
             progressContainer.hidden = true;
         }

--- a/sidepanel.css
+++ b/sidepanel.css
@@ -3165,20 +3165,39 @@ mark.url-match {
     border-bottom: 1px solid var(--border-color);
 }
 
-.workspace-switcher {
+/* 工作區列:單一按鈕,名稱置中、無 emoji;點擊開管理 dialog。 */
+.workspace-switch-btn {
     flex: 1;
     min-width: 0;
-    padding: 4px 6px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    padding: 6px 10px;
     font-size: 0.85em;
     background: var(--element-bg-color);
     color: var(--text-color-primary);
     border: 1px solid var(--border-color);
-    border-radius: 4px;
+    border-radius: var(--arc-radius-sm);
     cursor: pointer;
+    transition: background-color var(--arc-motion-short) var(--arc-easing-standard);
 }
 
-.workspace-switcher:focus {
-    outline: 1px solid var(--accent-color);
+.workspace-switch-btn:hover {
+    background: var(--element-bg-hover-color);
+}
+
+.workspace-switch-btn:focus-visible {
+    outline: none;
+    box-shadow: var(--arc-focus-ring);
+}
+
+.workspace-switch-label {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    text-align: center;
 }
 
 /* Drive-sync status badge: tiny, read-only indicator beside the switcher. */
@@ -3252,6 +3271,44 @@ mark.url-match {
     border-bottom: 1px solid var(--border-color);
 }
 
+/* 列主區=切換按鈕(icon + 名稱),點擊即切換。 */
+.workspace-manage__switch {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 4px 6px;
+    border: none;
+    background: transparent;
+    color: var(--text-color-primary);
+    cursor: pointer;
+    text-align: left;
+    border-radius: var(--arc-radius-sm);
+    transition: background-color var(--arc-motion-short) var(--arc-easing-standard);
+}
+
+.workspace-manage__switch:hover {
+    background: var(--element-bg-hover-color);
+}
+
+.workspace-manage__switch:focus-visible {
+    outline: none;
+    box-shadow: var(--arc-focus-ring);
+}
+
+.workspace-manage__icon {
+    flex: 0 0 auto;
+    display: inline-flex;
+    align-items: center;
+    color: var(--text-color-secondary);
+}
+
+.ws-emoji-icon {
+    font-size: 16px;
+    line-height: 1;
+}
+
 .workspace-manage__label {
     flex: 1;
     min-width: 0;
@@ -3264,13 +3321,15 @@ mark.url-match {
 
 .workspace-manage__sync-glyph {
     flex: 0 0 auto;
-    font-size: 0.85em;
+    display: inline-flex;
+    align-items: center;
     line-height: 1;
     opacity: 0.8;
     cursor: default;
+    color: var(--info-color);
 }
 
-.workspace-manage__label.active {
+.workspace-manage__switch.active .workspace-manage__label {
     font-weight: 600;
     color: var(--accent-color);
 }
@@ -3279,11 +3338,14 @@ mark.url-match {
     flex-shrink: 0;
     width: 28px;
     height: 28px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
     border: 1px solid var(--border-color);
-    border-radius: 4px;
+    border-radius: var(--arc-radius-sm);
     background: var(--element-bg-color);
+    color: var(--text-color-primary);
     cursor: pointer;
-    font-size: 14px;
 }
 
 .workspace-manage__btn:hover {

--- a/sidepanel.css
+++ b/sidepanel.css
@@ -20,6 +20,50 @@
 
     /* Hover */
     --arc-hover-shift: 3px;
+
+    /* === Material 3 token 層 (M3 UI 重構) === */
+    /* Shape scale — 適配 compact 側邊欄 (M3 4/8/12/16/full 壓縮版) */
+    --arc-radius-xs: 4px;       /* chips / 小徽章 / 文字高亮 */
+    --arc-radius-sm: 8px;       /* 按鈕 / 輸入框 / 列 / 下拉 */
+    --arc-radius-md: 12px;      /* 卡片 / context menu / 區段 */
+    --arc-radius-lg: 16px;      /* modal / dialog / spotlight 容器 */
+    --arc-radius-full: 9999px;  /* 圓點 / 圓形 icon 鈕 / pill */
+
+    /* State layer 不透明度 (M3 規格) */
+    --arc-state-hover: 0.08;
+    --arc-state-focus: 0.10;
+    --arc-state-pressed: 0.10;
+    --arc-state-drag: 0.16;
+    /* State layer 覆蓋色 — color-mix over 主題 token,使用時依當前主題解析
+       (同 settings-input 既有 color-mix 模式;主題切換於 :root 變更 token 即重算) */
+    --arc-state-layer-hover: color-mix(in srgb, var(--text-color-primary) 8%, transparent);
+    --arc-state-layer-pressed: color-mix(in srgb, var(--text-color-primary) 12%, transparent);
+    --arc-state-layer-accent: color-mix(in srgb, var(--accent-color) 14%, transparent);
+
+    /* Elevation 階 (M3-ish);1/3/5 alias 既有 shadow,不改舊名以免破壞既有引用 */
+    --arc-elevation-0: none;
+    --arc-elevation-1: var(--arc-shadow-sm);
+    --arc-elevation-2: 0 2px 6px hsl(0 0% 0% / 0.16);
+    --arc-elevation-3: var(--arc-shadow-hover);
+    --arc-elevation-4: 0 8px 24px hsl(0 0% 0% / 0.28);
+    --arc-elevation-5: var(--arc-shadow-drag);
+
+    /* 統一 focus ring */
+    --arc-focus-ring: 0 0 0 2px color-mix(in srgb, var(--accent-color) 40%, transparent);
+
+    /* Motion 語意 alias (指向既有 anim token,沿用既有曲線) */
+    --arc-motion-short: var(--arc-anim-duration-fast);
+    --arc-motion-medium: var(--arc-anim-duration-normal);
+    --arc-motion-long: var(--arc-anim-duration-slow);
+    --arc-easing-standard: var(--arc-anim-easing-out);
+    --arc-easing-emphasized: var(--arc-anim-easing-spring);
+}
+
+/* Material Symbols icon 基礎:inline 對齊、不隨 flex 壓縮。色彩由父層 color 繼承。 */
+.m3-icon {
+    display: inline-block;
+    vertical-align: middle;
+    flex-shrink: 0;
 }
 
 

--- a/sidepanel.css
+++ b/sidepanel.css
@@ -3552,8 +3552,19 @@ mark.url-match {
 
 /* 工具對話框範圍列 */
 .bm-tools__scope { display: flex; align-items: center; justify-content: space-between; gap: 8px; padding: 6px 0; }
-.bm-tools__scope-label { font-size: 0.85em; color: var(--text-color-secondary); }
-.bm-tools__scope-btn { background: none; border: 1px solid var(--border-color, #ccc); border-radius: 4px; padding: 2px 8px; cursor: pointer; }
+/* scope 列文字對齊 dialog 內其他文字(.bm-tools__intro 等用 --text-color-primary opacity 0.7),
+   按鈕補上文字色 + hover,使其隨主題變且與對話框風格一致。 */
+.bm-tools__scope-label { font-size: 0.85em; color: var(--text-color-primary); opacity: 0.7; }
+.bm-tools__scope-btn {
+    background: none;
+    border: 1px solid var(--border-color);
+    border-radius: var(--arc-radius-sm);
+    padding: 2px 8px;
+    cursor: pointer;
+    color: var(--text-color-primary);
+    transition: background-color var(--arc-motion-short) var(--arc-easing-standard);
+}
+.bm-tools__scope-btn:hover { background: var(--element-bg-hover-color); }
 
 .bm-tools__count {
     flex: 1;

--- a/sidepanel.css
+++ b/sidepanel.css
@@ -66,6 +66,20 @@
     flex-shrink: 0;
 }
 
+/* Chevron 狀態化:單一 expand_more(▼) SVG;收合時旋轉 -90deg 指向右(▶)。
+   取代原本以 textContent '▶'/'▼' 切換的做法,讓拖曳判斷與測試改用 class/aria 狀態。 */
+.is-chevron {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+.is-chevron .m3-icon {
+    transition: transform var(--arc-motion-short) var(--arc-easing-standard);
+}
+.is-chevron.is-collapsed .m3-icon {
+    transform: rotate(-90deg);
+}
+
 
 /* --- 主題定義 --- */
 

--- a/sidepanel.css
+++ b/sidepanel.css
@@ -57,6 +57,20 @@
     --arc-motion-long: var(--arc-anim-duration-slow);
     --arc-easing-standard: var(--arc-anim-easing-out);
     --arc-easing-emphasized: var(--arc-anim-easing-spring);
+
+    /* 列垂直間距(密度設定 listDensity;預設 = cozy = 現狀)。水平 padding 維持各列原值。 */
+    --list-row-py: 6px;      /* 分頁 / 閱讀清單 */
+    --bookmark-row-py: 4px;  /* 書籤 / 視窗資料夾 */
+}
+
+/* 列間距密度:body[data-density] 由 settingManager.applyDensity 設定。cozy 為預設(不需 override)。 */
+body[data-density="compact"] {
+    --list-row-py: 3px;
+    --bookmark-row-py: 2px;
+}
+body[data-density="comfortable"] {
+    --list-row-py: 10px;
+    --bookmark-row-py: 8px;
 }
 
 /* Material Symbols icon 基礎:inline 對齊、不隨 flex 壓縮。色彩由父層 color 繼承。 */
@@ -644,7 +658,7 @@ mark.url-match {
 .tab-item {
     display: flex;
     align-items: center;
-    padding: 6px 12px;
+    padding: var(--list-row-py) 12px;
     border-radius: 0;
     cursor: default;
     transition: background-color 0.15s ease-in-out,
@@ -825,7 +839,7 @@ mark.url-match {
 .window-folder {
     display: flex;
     align-items: center;
-    padding: 4px 8px;
+    padding: var(--bookmark-row-py) 8px;
     cursor: default;
     white-space: nowrap;
     overflow: hidden;
@@ -2274,7 +2288,7 @@ mark.url-match {
 .reading-list-item {
     display: flex;
     align-items: center;
-    padding: 6px 8px;
+    padding: var(--list-row-py) 8px;
     cursor: pointer;
     transition: background-color 0.15s ease-in-out;
     border-left: 3px solid transparent;
@@ -3203,7 +3217,7 @@ mark.url-match {
     justify-content: center;
     gap: 6px;
     padding: 6px 10px;
-    font-size: 0.85em;
+    font-size: 1em;
     background: var(--element-bg-color);
     color: var(--text-color-primary);
     border: 1px solid var(--border-color);
@@ -3227,6 +3241,7 @@ mark.url-match {
     text-overflow: ellipsis;
     white-space: nowrap;
     text-align: center;
+    font-weight: 500;
 }
 
 /* Drive-sync status badge: tiny, read-only indicator beside the switcher. */

--- a/sidepanel.css
+++ b/sidepanel.css
@@ -2014,6 +2014,30 @@ mark.url-match {
     cursor: pointer;
 }
 
+/* 主題化 checkbox:統一專案內各處原生 checkbox 的勾選色為 accent(隨主題變),避免預設
+   藍色與主題不符。涵蓋:編輯書籤標籤選取、書籤工具(重複/列)、AI 清理列與全選、設定頁切換。 */
+.tag-picker__row input[type="checkbox"],
+.bm-tools__dup-row input[type="checkbox"],
+.bm-tools__row input[type="checkbox"],
+.ai-cleanup-row__cb,
+.ai-cleanup-select-all input[type="checkbox"],
+.opt-row input[type="checkbox"] {
+    width: 15px;
+    height: 15px;
+    accent-color: var(--accent-color);
+    cursor: pointer;
+    flex: none;
+}
+.tag-picker__row input[type="checkbox"]:focus-visible,
+.bm-tools__dup-row input[type="checkbox"]:focus-visible,
+.bm-tools__row input[type="checkbox"]:focus-visible,
+.ai-cleanup-row__cb:focus-visible,
+.ai-cleanup-select-all input[type="checkbox"]:focus-visible,
+.opt-row input[type="checkbox"]:focus-visible {
+    outline: 2px solid var(--accent-color);
+    outline-offset: 2px;
+}
+
 .settings-toggle .toggle-label {
     font-size: 13px;
     color: var(--text-color-primary);
@@ -2162,6 +2186,20 @@ mark.url-match {
     display: flex;
     gap: 8px;
     margin-top: 10px;
+}
+
+/* RSS 新增列/錯誤訊息(原本 class 被引用但未定義,致排版/顏色退回預設)。 */
+.rss-add-controls {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    margin-top: 8px;
+}
+
+.rss-error-message {
+    color: var(--danger-color);
+    font-size: 12px;
+    margin-top: 4px;
 }
 
 .rss-add-form .settings-input {
@@ -2779,7 +2817,7 @@ mark.url-match {
 
 .ai-setup-link-btn:hover {
     background: var(--accent-color);
-    color: var(--bg-color, #fff);
+    color: var(--text-color-inverted);
 }
 
 .ai-setup-restart-note {
@@ -3018,7 +3056,7 @@ mark.url-match {
     margin-top: 2px;
 }
 
-.ai-cleanup-row__group { display: inline-flex; align-items: center; gap: 4px; margin-left: 8px; font-size: 0.8em; color: var(--secondary-text-color, #5f6368); vertical-align: middle; }
+.ai-cleanup-row__group { display: inline-flex; align-items: center; gap: 4px; margin-left: 8px; font-size: 0.8em; color: var(--text-color-secondary); vertical-align: middle; }
 .ai-cleanup-row__group-dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; flex: none; }
 .ai-cleanup-row__group-name { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 120px; }
 
@@ -3514,7 +3552,7 @@ mark.url-match {
 
 /* 工具對話框範圍列 */
 .bm-tools__scope { display: flex; align-items: center; justify-content: space-between; gap: 8px; padding: 6px 0; }
-.bm-tools__scope-label { font-size: 0.85em; color: var(--secondary-text-color, #5f6368); }
+.bm-tools__scope-label { font-size: 0.85em; color: var(--text-color-secondary); }
 .bm-tools__scope-btn { background: none; border: 1px solid var(--border-color, #ccc); border-radius: 4px; padding: 2px 8px; cursor: pointer; }
 
 .bm-tools__count {

--- a/sidepanel.css
+++ b/sidepanel.css
@@ -1082,26 +1082,24 @@ mark.url-match {
     overscroll-behavior: contain;
 }
 
-/* --- Styled Scrollbar for Modals --- */
-.modal-content::-webkit-scrollbar,
-.modal-custom-content::-webkit-scrollbar {
+/* --- 全域細捲軸:統一所有捲動區(modal、分頁/書籤/閱讀清單、Spotlight 結果、設定頁、
+   書籤工具掃描結果等)。bare ::-webkit-scrollbar 即套用至所有具捲軸的元素。
+   不混用標準 scrollbar-width/scrollbar-color,以免 Chrome 121+ 忽略此 webkit 樣式。 --- */
+::-webkit-scrollbar {
     width: 6px;
     height: 6px;
 }
 
-.modal-content::-webkit-scrollbar-track,
-.modal-custom-content::-webkit-scrollbar-track {
+::-webkit-scrollbar-track {
     background: transparent;
 }
 
-.modal-content::-webkit-scrollbar-thumb,
-.modal-custom-content::-webkit-scrollbar-thumb {
+::-webkit-scrollbar-thumb {
     background-color: var(--text-color-secondary);
     border-radius: 3px;
 }
 
-.modal-content::-webkit-scrollbar-thumb:hover,
-.modal-custom-content::-webkit-scrollbar-thumb:hover {
+::-webkit-scrollbar-thumb:hover {
     background-color: var(--text-color-primary);
 }
 
@@ -3146,26 +3144,7 @@ mark.url-match {
     padding: 4px 0;
 }
 
-/* Spotlight 結果列表捲軸:比照 .modal-content 的細捲軸樣式。
-   注意:.cmd-palette-results / .cmd-palette-icon 亦由側邊欄 Ask-AI 對話框(nlSearch.js)
-   共用,故此處與 .cmd-palette-icon 的調整會一併套用至該對話框(視覺一致、無害)。 */
-.cmd-palette-results::-webkit-scrollbar {
-    width: 6px;
-    height: 6px;
-}
-
-.cmd-palette-results::-webkit-scrollbar-track {
-    background: transparent;
-}
-
-.cmd-palette-results::-webkit-scrollbar-thumb {
-    background-color: var(--text-color-secondary);
-    border-radius: 3px;
-}
-
-.cmd-palette-results::-webkit-scrollbar-thumb:hover {
-    background-color: var(--text-color-primary);
-}
+/* Spotlight 結果列表捲軸已由全域 ::-webkit-scrollbar 統一處理(見頂部捲軸區塊)。 */
 
 .cmd-palette-group-header {
     padding: 6px 12px 2px;

--- a/sidepanel.css
+++ b/sidepanel.css
@@ -80,6 +80,27 @@
     transform: rotate(-90deg);
 }
 
+/* M3 統一 focus ring(僅 <button>):鍵盤聚焦時以 accent 環取代雜亂 outline。
+   清單列(tab/bookmark/folder)沿用既有的 inset outline(在 overflow 容器內不被裁切),
+   不納入此 outset box-shadow 環以免重疊或被裁切。:focus-visible 僅鍵盤聚焦觸發。 */
+button:focus-visible {
+    outline: none;
+    box-shadow: var(--arc-focus-ring);
+}
+
+/* M3 state layer:按下(pressed)回饋。hover 沿用各元件既有底色;此處僅 :active 疊加
+   半透明 pressed 覆蓋,提供按壓回饋(排除 .header-action-btn 等有自訂 hover 反白的元件)。 */
+.tab-item:active,
+.bookmark-item:active,
+.bookmark-folder:active,
+.cmd-palette-row:active,
+.modal-button:active,
+.context-menu-item:active,
+.workspace-switch-btn:active,
+.workspace-manage__switch:active {
+    background-color: var(--arc-state-layer-pressed);
+}
+
 
 /* --- 主題定義 --- */
 
@@ -348,6 +369,7 @@ body::before {
     box-sizing: border-box;
     background-color: var(--element-bg-color);
     border: 1px solid var(--border-color);
+    border-radius: var(--arc-radius-sm);
     color: var(--text-color-light);
     font-family: inherit;
     font-size: 14px;
@@ -356,6 +378,7 @@ body::before {
 #search-box:focus {
     outline: none;
     border-color: var(--border-color-accent);
+    box-shadow: var(--arc-focus-ring);
 }
 
 #search-box::placeholder {
@@ -459,13 +482,17 @@ body::before {
     background-color: var(--element-bg-hover-color);
 }
 
-#settings-toggle svg {
-    stroke: var(--text-color-secondary);
-    transition: stroke 0.2s ease;
+/* Material Symbols 為 fill 型,色彩經 currentColor 繼承(舊 stroke 無效)。 */
+#settings-toggle {
+    color: var(--text-color-secondary);
 }
 
-#settings-toggle:hover svg {
-    stroke: var(--text-color-primary);
+#settings-toggle svg {
+    transition: color var(--arc-motion-short) var(--arc-easing-standard);
+}
+
+#settings-toggle:hover {
+    color: var(--text-color-primary);
 }
 
 /* --- 通用隱藏 Class --- */
@@ -526,9 +553,9 @@ mark.url-match {
     background: transparent;
     border: 1px solid var(--danger-color);
     color: var(--danger-color);
-    border-radius: 3px;
+    border-radius: var(--arc-radius-sm);
     cursor: pointer;
-    transition: all 0.15s ease;
+    transition: all var(--arc-motion-short) var(--arc-easing-standard);
     white-space: nowrap;
 }
 
@@ -1006,9 +1033,10 @@ mark.url-match {
     background-color: var(--element-bg-color);
     padding: 20px;
     border: 1px solid var(--border-color);
+    border-radius: var(--arc-radius-lg);
     width: 85%;
     max-width: 400px;
-    box-shadow: 0 5px 25px var(--modal-shadow-color);
+    box-shadow: var(--arc-elevation-4);
     display: flex;
     flex-direction: column;
     gap: 15px;
@@ -1142,6 +1170,7 @@ mark.url-match {
 .modal-button {
     padding: 8px 16px;
     border: 1px solid var(--border-color);
+    border-radius: var(--arc-radius-sm);
     background-color: transparent;
     color: var(--text-color-light);
     cursor: pointer;
@@ -1367,8 +1396,8 @@ mark.url-match {
     z-index: 10000;
     background-color: var(--element-bg-color);
     border: 1px solid var(--border-color);
-    box-shadow: 0 2px 10px var(--modal-shadow-color);
-    border-radius: 4px;
+    box-shadow: var(--arc-elevation-2);
+    border-radius: var(--arc-radius-md);
     padding: 4px 0;
     min-width: 150px;
     display: flex;
@@ -1980,7 +2009,7 @@ mark.url-match {
 
 /* Design Tokens */
 :root {
-    --settings-radius: 6px;
+    --settings-radius: var(--arc-radius-sm);
     --settings-height: 32px;
     --settings-height-sm: 24px;
     --settings-transition: all 0.15s ease;
@@ -3305,7 +3334,7 @@ mark.url-match {
 }
 
 .ws-emoji-icon {
-    font-size: 16px;
+    font-size: 18px;
     line-height: 1;
 }
 

--- a/sidepanel.html
+++ b/sidepanel.html
@@ -22,16 +22,9 @@
         <div class="search-top-row">
             <div class="search-input-wrapper">
                 <input type="text" id="search-box" placeholder="">
-                <button id="clear-search-btn" class="hidden" title="Clear search" aria-label="Clear search">×</button>
+                <button id="clear-search-btn" class="hidden" title="Clear search" aria-label="Clear search" data-icon="close"></button>
             </div>
-            <button id="settings-toggle" title="Settings" aria-label="Settings">
-                <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24"
-                    fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                    <path
-                        d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 0 2l-.15.08a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.38a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1 0-2l.15.08a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z" />
-                    <circle cx="12" cy="12" r="3" />
-                </svg>
-            </button>
+            <button id="settings-toggle" title="Settings" aria-label="Settings" data-icon="settings"></button>
         </div>
         <div id="search-result-count" class="hidden" aria-live="polite"></div>
     </div>
@@ -52,12 +45,14 @@
                 <div id="ai-download-progress" class="ai-progress" hidden>
                     <div class="ai-progress__fill"></div>
                 </div>
-                <button id="ai-group-btn" class="header-action-btn" title="✨ Smart Auto-Grouping"
-                    data-i18n-title="smartGroupingBtnTitle" aria-label="Smart Auto-Grouping"
-                    data-i18n="smartGroupingBtnText">✨ 智慧整理</button>
-                <button id="ai-cleanup-btn" class="header-action-btn" title="🧹 AI Cleanup"
-                    data-i18n-title="aiCleanupBtnTitle" aria-label="AI Cleanup"
-                    data-i18n="aiCleanupBtnText">🧹 清理</button>
+                <button id="ai-group-btn" class="header-action-btn" title="Smart Auto-Grouping"
+                    data-i18n-title="smartGroupingBtnTitle" aria-label="Smart Auto-Grouping"><span
+                        class="btn-icon" data-icon="auto_awesome"></span><span class="btn-label"
+                        data-i18n="smartGroupingBtnText"></span></button>
+                <button id="ai-cleanup-btn" class="header-action-btn" title="AI Cleanup"
+                    data-i18n-title="aiCleanupBtnTitle" aria-label="AI Cleanup"><span class="btn-icon"
+                        data-icon="cleaning_services"></span><span class="btn-label"
+                        data-i18n="aiCleanupBtnText"></span></button>
             </div>
         </div>
 
@@ -65,7 +60,7 @@
         <div id="ai-cleanup-section" class="ai-cleanup-section hidden" aria-live="polite">
             <div class="ai-cleanup-header">
                 <h3 class="ai-cleanup-title" data-i18n="aiCleanupSectionHeader">AI Cleanup Suggestions</h3>
-                <button id="ai-cleanup-close" class="icon-btn" aria-label="Close">×</button>
+                <button id="ai-cleanup-close" class="icon-btn" aria-label="Close" data-icon="close"></button>
             </div>
             <div id="ai-cleanup-status" class="ai-cleanup-status"></div>
             <div id="ai-cleanup-list" class="ai-cleanup-list"></div>
@@ -113,7 +108,7 @@
             <h2 class="section-header" data-i18n="bookmarksHeader"></h2>
             <div class="header-controls-right">
                 <button id="bookmark-tools-btn" class="header-action-btn"
-                    title="" data-i18n-title="bmToolsTitle">🛠️</button>
+                    title="" data-i18n-title="bmToolsTitle" data-icon="build"></button>
             </div>
         </div>
         <div id="bookmark-list"></div>
@@ -124,7 +119,7 @@
         <span id="toast-message"></span>
         <button id="toast-undo-btn" class="hidden" title="Undo" data-i18n-title="toastUndoBtn"
             data-i18n="toastUndoBtn">復原 (Undo)</button>
-        <button id="toast-close-btn" title="Close" data-i18n-title="toastCloseBtn" aria-label="Close">×</button>
+        <button id="toast-close-btn" title="Close" data-i18n-title="toastCloseBtn" aria-label="Close" data-icon="close"></button>
     </div>
 
     <script src="lib/Sortable.min.js" defer></script>

--- a/sidepanel.html
+++ b/sidepanel.html
@@ -8,14 +8,16 @@
 </head>
 
 <body>
-    <!-- Workspace switcher: per-window active workspace + manage button.
-         Labels are resolved at runtime by workspaceUI.initWorkspaceUI(). -->
+    <!-- Workspace bar: a single button showing the active workspace name; clicking
+         opens the manage dialog (switch / rename / delete / create). Label + aria
+         resolved at runtime by workspaceUI.initWorkspaceUI(). -->
     <div id="workspace-row" class="workspace-row">
-        <select id="workspace-switcher" class="workspace-switcher"></select>
+        <button id="workspace-switch-btn" class="workspace-switch-btn">
+            <span class="workspace-switch-label"></span>
+        </button>
         <!-- Drive-sync status indicator. Hidden until a status arrives; updated
              live via the driveSyncStatusChanged event (see modules/ui/driveSyncBadge.js). -->
         <span id="drive-sync-badge" class="drive-sync-badge" hidden aria-hidden="true"></span>
-        <button id="workspace-manage-btn" class="header-action-btn">⚙️</button>
     </div>
 
     <div id="search-container">

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -15,7 +15,7 @@ import * as tagManager from './modules/bookmark/tagManager.js';
 import { openBookmarkToolsDialog } from './modules/bookmark/bookmarkToolsUI.js';
 import * as readingListSummaryStore from './modules/readingList/summaryStore.js';
 import { initSummaryRecorder } from './modules/readingList/summaryRecorder.js';
-import { SEARCH_NO_RESULTS_ICON_SVG } from './modules/icons.js';
+import { SEARCH_NO_RESULTS_ICON_SVG, renderIcon } from './modules/icons.js';
 import { debounce } from './modules/utils/functionUtils.js';
 import { initSettingsBridge } from './modules/ui/settingsBridge.js';
 import { initDriveSyncBadge } from './modules/ui/driveSyncBadge.js';
@@ -194,6 +194,13 @@ function applyStaticTranslations() {
         if (message) {
             el.textContent = message;
         }
+    });
+
+    // 注入 Material Symbols 圖示:[data-icon] 元素(icon-only 按鈕或 .btn-icon span)。
+    // 與 data-i18n 分離(label 在 .btn-label),故文字在地化不會洗掉圖示。
+    document.querySelectorAll('[data-icon]').forEach(el => {
+        const size = parseInt(el.dataset.iconSize, 10) || 16;
+        el.innerHTML = renderIcon(el.dataset.icon, { size });
     });
 }
 

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -35,7 +35,7 @@ const PANEL_ACTION_HANDLERS = {
     'smart-group': () => document.getElementById('ai-group-btn')?.click(),
     'ai-cleanup': () => document.getElementById('ai-cleanup-btn')?.click(),
     'bookmark-tools': () => document.getElementById('bookmark-tools-btn')?.click(),
-    'manage-workspaces': () => document.getElementById('workspace-manage-btn')?.click(),
+    'manage-workspaces': () => document.getElementById('workspace-switch-btn')?.click(),
     'refresh-bookmarks': () => document.dispatchEvent(new CustomEvent('refreshBookmarksRequired')),
     'ask-ai-search': async () => {
         const { openAskAiDialog } = await import('./modules/commandPalette/nlSearch.js');
@@ -286,7 +286,7 @@ async function initialize() {
         .catch(err => console.warn('[rlSummary] prune failed:', err));
     const bookmarkToolsBtn = document.getElementById('bookmark-tools-btn');
     if (bookmarkToolsBtn) {
-        // Mirror the workspace-manage-btn pattern: resolve aria-label at runtime
+        // Mirror the workspace-switch-btn pattern: resolve aria-label at runtime
         // instead of hard-coding English in the markup so it tracks UI language.
         const bmToolsLabel = api.getMessage('bmToolsTitle') || 'Bookmark Tools';
         bookmarkToolsBtn.setAttribute('aria-label', bmToolsLabel);

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -25,11 +25,6 @@ import { initDriveSyncBadge } from './modules/ui/driveSyncBadge.js';
 // 側邊欄完成初始化(按鈕等事件已綁定)前不消費轉送動作,避免點到尚未接線的按鈕。
 let panelReady = false;
 
-// pendingSearchFocus 旗標的過期窗:僅用於丟棄先前 sidePanel.open 失敗殘留的舊旗標。
-// 取較寬鬆值,確保冷啟動載入(keypress → 完整 initialize hydration,實測約數百毫秒至數秒)
-// 仍能正常聚焦;寧可偶爾尊重略舊旗標,也不要誤丟正當的聚焦請求。
-const SEARCH_FOCUS_TTL_MS = 10000;
-
 // Spotlight(獨立視窗)轉送來的 UI 類動作:在側邊欄正確情境執行。
 const PANEL_ACTION_HANDLERS = {
     'smart-group': () => document.getElementById('ai-group-btn')?.click(),
@@ -67,32 +62,9 @@ async function consumePendingPanelAction() {
     catch (err) { console.warn('[panel-action] failed:', err && err.message ? err.message : err); }
 }
 
-// 全螢幕 fallback:background 偵測來源視窗為全螢幕時不開 Spotlight popup(會跳 Space),
-// 改開側邊欄並寫此旗標 → 側邊欄聚焦搜尋框,提供等效的「快速搜尋」入口。
-async function consumePendingSearchFocus() {
-    if (!panelReady) return;
-    let pending;
-    try {
-        ({ pendingSearchFocus: pending } = await chrome.storage.session.get('pendingSearchFocus'));
-    } catch { return; }
-    if (!pending) return;
-    try { await chrome.storage.session.remove('pendingSearchFocus'); } catch { /* ignore */ }
-    // 過期保護:旗標若非近期寫入(例如先前 sidePanel.open 失敗殘留),不搶焦點,
-    // 以免下次開側邊欄時被舊旗標誤導而把游標移進搜尋框。
-    if (typeof pending.ts === 'number' && Date.now() - pending.ts > SEARCH_FOCUS_TTL_MS) return;
-    const box = document.getElementById('search-box');
-    if (box) {
-        box.focus();
-        if (typeof box.select === 'function') box.select();
-    }
-}
-
 chrome.storage.session.onChanged.addListener((changes) => {
     if (changes.pendingPanelAction && changes.pendingPanelAction.newValue) {
         consumePendingPanelAction();
-    }
-    if (changes.pendingSearchFocus && changes.pendingSearchFocus.newValue) {
-        consumePendingSearchFocus();
     }
 });
 
@@ -292,10 +264,9 @@ async function initialize() {
         bookmarkToolsBtn.setAttribute('aria-label', bmToolsLabel);
         bookmarkToolsBtn.addEventListener('click', () => openBookmarkToolsDialog('tags'));
     }
-    // 初始化完成、按鈕已接線:開放消費並處理本次開啟時已存在的轉送動作 / 搜尋聚焦請求。
+    // 初始化完成、按鈕已接線:開放消費並處理本次開啟時已存在的轉送動作。
     panelReady = true;
     consumePendingPanelAction();
-    consumePendingSearchFocus();
 
     // Keep multiple open sidepanels in sync: linkedTabs affects bookmark icons,
     // windowNames affects the "Other Windows" section labels.

--- a/usecase_tests/puppeteer_tests/empty_folder_state.test.js
+++ b/usecase_tests/puppeteer_tests/empty_folder_state.test.js
@@ -42,7 +42,7 @@ describe('Empty Folder State', () => {
         const folderElement = await page.$(folderSelector);
 
         // Check if it is collapsed (it should be initially)
-        const isCollapsed = await page.evaluate(el => el.querySelector('.bookmark-icon').textContent.includes('▶'), folderElement);
+        const isCollapsed = await page.evaluate(el => el.querySelector('.bookmark-icon').classList.contains('is-collapsed'), folderElement);
         if (isCollapsed) {
             await folderElement.click();
         }

--- a/usecase_tests/puppeteer_tests/happy_path_bookmark_folder_toggle.test.js
+++ b/usecase_tests/puppeteer_tests/happy_path_bookmark_folder_toggle.test.js
@@ -1,4 +1,4 @@
-const { setupBrowser, teardownBrowser, expandBookmarksBar, waitForTextContent } = require('./setup');
+const { setupBrowser, teardownBrowser, expandBookmarksBar, waitForChevron } = require('./setup');
 
 describe('Bookmark Folder Toggle Use Case', () => {
     let browser;
@@ -48,17 +48,17 @@ describe('Bookmark Folder Toggle Use Case', () => {
 
             const isCollapsed = await page.$eval(folderSelector, el => {
                 const icon = el.querySelector('.bookmark-icon');
-                return icon && icon.textContent.includes('▶');
+                return icon && icon.classList.contains('is-collapsed');
             });
             expect(isCollapsed).toBe(true);
 
             await page.click(folderSelector);
 
-            await waitForTextContent(page, `${folderSelector} .bookmark-icon`, '▼');
+            await waitForChevron(page, `${folderSelector} .bookmark-icon`, false);
 
             const isExpanded = await page.$eval(folderSelector, el => {
                 const icon = el.querySelector('.bookmark-icon');
-                return icon && icon.textContent.includes('▼');
+                return icon && !icon.classList.contains('is-collapsed');
             });
             expect(isExpanded).toBe(true);
 
@@ -106,21 +106,21 @@ describe('Bookmark Folder Toggle Use Case', () => {
 
             // First expand the folder
             await page.click(folderSelector);
-            await waitForTextContent(page, `${folderSelector} .bookmark-icon`, '▼');
+            await waitForChevron(page, `${folderSelector} .bookmark-icon`, false);
 
             const isExpanded = await page.$eval(folderSelector, el => {
                 const icon = el.querySelector('.bookmark-icon');
-                return icon && icon.textContent.includes('▼');
+                return icon && !icon.classList.contains('is-collapsed');
             });
             expect(isExpanded).toBe(true);
 
             // Now click to collapse
             await page.click(folderSelector);
-            await waitForTextContent(page, `${folderSelector} .bookmark-icon`, '▶');
+            await waitForChevron(page, `${folderSelector} .bookmark-icon`, true);
 
             const isCollapsed = await page.$eval(folderSelector, el => {
                 const icon = el.querySelector('.bookmark-icon');
-                return icon && icon.textContent.includes('▶');
+                return icon && icon.classList.contains('is-collapsed');
             });
             expect(isCollapsed).toBe(true);
         } finally {

--- a/usecase_tests/puppeteer_tests/perf_benchmark.test.js
+++ b/usecase_tests/puppeteer_tests/perf_benchmark.test.js
@@ -73,6 +73,7 @@ describe('Performance Benchmark', () => {
                 allGroups.push(...groups);
                 otherWindows.push({
                     id: i,
+                    type: 'normal', // chrome.windows.getAll always returns type; renderer filters type==='normal'
                     tabs: tabs,
                     focused: false
                 });

--- a/usecase_tests/puppeteer_tests/search_bookmark_clear.test.js
+++ b/usecase_tests/puppeteer_tests/search_bookmark_clear.test.js
@@ -170,4 +170,44 @@ describe('Bookmark Search Clear', () => {
         const searchValue = await page.$eval('#search-box', el => el.value);
         expect(searchValue).toBe('');
     });
+
+    it('clearing search leaves no stale highlights in a COLLAPSED folder (regression)', async () => {
+        const folderId = testBookmarkIds[0];
+        const folderSel = `.bookmark-folder[data-bookmark-id="${folderId}"]`;
+        const isCollapsed = (sel) => {
+            const f = document.querySelector(sel);
+            return f && f.getAttribute('aria-expanded') === 'false';
+        };
+
+        // Ensure the folder is COLLAPSED before searching (beforeAll expanded it).
+        await page.evaluate((sel) => {
+            const f = document.querySelector(sel);
+            if (f && f.getAttribute('aria-expanded') === 'true') f.click();
+        }, folderSel);
+        await page.waitForFunction(isCollapsed, { timeout: 5000 }, folderSel);
+
+        // Search for a bookmark INSIDE the collapsed folder: forceExpandAll renders it
+        // with <mark> highlights into the folder's (otherwise collapsed) cached content.
+        await page.type('#search-box', 'ClearTestBeta');
+        await page.waitForFunction(
+            () => document.querySelectorAll('#bookmark-list mark').length > 0,
+            { timeout: 5000 }
+        );
+
+        // Clear the search; the folder should return to its collapsed state.
+        await page.click('#clear-search-btn');
+        await page.waitForFunction(isCollapsed, { timeout: 5000 }, folderSel);
+
+        // Re-expand the folder: with the fix, stale highlighted children are purged on
+        // clear so this lazy-loads fresh, mark-free rows. Without the fix, the stale
+        // <mark> rows resurface here.
+        await page.click(folderSel);
+        await page.waitForFunction(
+            (sel) => { const f = document.querySelector(sel); return f && f.getAttribute('aria-expanded') === 'true'; },
+            { timeout: 5000 }, folderSel
+        );
+        await new Promise(r => setTimeout(r, 300));
+        const highlights = await page.evaluate(() => document.querySelectorAll('#bookmark-list mark').length);
+        expect(highlights).toBe(0);
+    });
 });

--- a/usecase_tests/puppeteer_tests/search_group_expand.test.js
+++ b/usecase_tests/puppeteer_tests/search_group_expand.test.js
@@ -197,9 +197,9 @@ describe('Search Group Auto-Expand', () => {
             });
             expect(isCollapsedAgain).toBe(true);
 
-            // Verify arrow is ▶
-            const arrow = await page.$eval(groupHeaderSelector + ' .tab-group-arrow', el => el.textContent);
-            expect(arrow).toBe('▶');
+            // Verify arrow is collapsed (chevron rotated via is-collapsed class)
+            const arrowCollapsed = await page.$eval(groupHeaderSelector + ' .tab-group-arrow', el => el.classList.contains('is-collapsed'));
+            expect(arrowCollapsed).toBe(true);
 
         } finally {
             await clearSearch();

--- a/usecase_tests/puppeteer_tests/setup.js
+++ b/usecase_tests/puppeteer_tests/setup.js
@@ -70,7 +70,7 @@ async function expandBookmarksBar(page) {
     await page.waitForSelector(bookmarksBarSelector, { timeout: 10000 });
 
     const isCollapsed = await page.$eval(bookmarksBarSelector, el =>
-        el.querySelector('.bookmark-icon').textContent.includes('▶')
+        el.querySelector('.bookmark-icon').classList.contains('is-collapsed')
     );
 
     if (isCollapsed) {
@@ -80,7 +80,10 @@ async function expandBookmarksBar(page) {
             await page.click(bookmarksBarSelector);
             try {
                 await page.waitForFunction(
-                    s => document.querySelector(s)?.querySelector('.bookmark-icon')?.textContent?.includes('▼'),
+                    s => {
+                        const ic = document.querySelector(s)?.querySelector('.bookmark-icon');
+                        return !!ic && !ic.classList.contains('is-collapsed');
+                    },
                     { timeout: 5000 },
                     bookmarksBarSelector
                 );
@@ -182,6 +185,21 @@ async function waitForTheme(page, expectedTheme, timeout = 5000) {
     );
 }
 
+/**
+ * Wait for a chevron element's collapsed state (is-collapsed class presence).
+ * @param {boolean} collapsed - true to wait until collapsed, false until expanded
+ */
+async function waitForChevron(page, selector, collapsed, timeout = 5000) {
+    await page.waitForFunction(
+        (sel, want) => {
+            const el = document.querySelector(sel);
+            return !!el && el.classList.contains('is-collapsed') === want;
+        },
+        { timeout },
+        selector, collapsed
+    );
+}
+
 module.exports = {
     setupBrowser,
     teardownBrowser,
@@ -191,5 +209,6 @@ module.exports = {
     waitForTextContent,
     waitForElementRemoved,
     waitForClass,
+    waitForChevron,
     waitForTheme
 };

--- a/usecase_tests/puppeteer_tests/tab_to_bookmark.test.js
+++ b/usecase_tests/puppeteer_tests/tab_to_bookmark.test.js
@@ -69,18 +69,18 @@ describe('Tab to Bookmark Use Case', () => {
 
         const bookmarksBarSelector = `.bookmark-folder[data-bookmark-id="1"]`;
         await page.waitForSelector(bookmarksBarSelector);
-        const isBookmarksBarCollapsed = await page.$eval(bookmarksBarSelector, el => el.querySelector('.bookmark-icon').textContent.includes('▶'));
+        const isBookmarksBarCollapsed = await page.$eval(bookmarksBarSelector, el => el.querySelector('.bookmark-icon').classList.contains('is-collapsed'));
         if (isBookmarksBarCollapsed) {
             await page.click(bookmarksBarSelector);
-            await page.waitForFunction(s => document.querySelector(s).querySelector('.bookmark-icon').textContent.includes('▼'), {}, bookmarksBarSelector);
+            await page.waitForFunction(s => !document.querySelector(s).querySelector('.bookmark-icon').classList.contains('is-collapsed'), {}, bookmarksBarSelector);
         }
 
         const targetFolderSelector = `.bookmark-folder[data-bookmark-id="${targetFolderId}"]`;
         await page.waitForSelector(targetFolderSelector);
-        const isTargetFolderCollapsed = await page.$eval(targetFolderSelector, el => el.querySelector('.bookmark-icon').textContent.includes('▶'));
+        const isTargetFolderCollapsed = await page.$eval(targetFolderSelector, el => el.querySelector('.bookmark-icon').classList.contains('is-collapsed'));
         if (isTargetFolderCollapsed) {
             await page.click(targetFolderSelector);
-            await page.waitForFunction(s => document.querySelector(s).querySelector('.bookmark-icon').textContent.includes('▼'), {}, targetFolderSelector);
+            await page.waitForFunction(s => !document.querySelector(s).querySelector('.bookmark-icon').classList.contains('is-collapsed'), {}, targetFolderSelector);
         }
 
         const dropTargetSelector = `.bookmark-folder[data-bookmark-id="${targetFolderId}"] + .folder-content`;

--- a/usecase_tests/unit_tests/driveSyncBadge.test.mjs
+++ b/usecase_tests/unit_tests/driveSyncBadge.test.mjs
@@ -3,7 +3,7 @@ import { resolveBadgeView } from '../../modules/ui/driveSyncBadge.js';
 /**
  * Unit tests for the PURE view-model resolver behind the sidepanel drive-sync
  * badge. resolveBadgeView() takes a driveSyncStatus object and returns a compact
- * descriptor { hidden, glyph?, text?, title?, stateClass? } with no DOM / I/O.
+ * descriptor { hidden, iconId?, text?, title?, stateClass? } with no DOM / I/O.
  *
  * driveSyncBadge.js imports apiManager.js, which references chrome.i18n at CALL
  * time (not module-load time). The node-side chrome stub in
@@ -40,7 +40,7 @@ describe('resolveBadgeView', () => {
     it('visible with the syncing indicator + label', () => {
       const view = resolveBadgeView({ state: 'syncing' });
       expect(view.hidden).toBe(false);
-      expect(view.glyph).toBe('↻');
+      expect(view.iconId).toBe('sync');
       expect(view.text).toBe('Syncing…');
       expect(view.stateClass).toBe('is-syncing');
     });
@@ -50,7 +50,7 @@ describe('resolveBadgeView', () => {
     it('visible with the synced (cloud) indicator + title, empty text', () => {
       const view = resolveBadgeView({ state: 'idle' });
       expect(view.hidden).toBe(false);
-      expect(view.glyph).toBe('☁︎');
+      expect(view.iconId).toBe('cloud');
       expect(view.text).toBe('');
       expect(view.title).toBe('Synced to Google Drive');
       expect(view.stateClass).toBe('is-idle');
@@ -74,7 +74,7 @@ describe('resolveBadgeView', () => {
     it.each(cases)('%s → visible warning with the base title', (state, baseTitle) => {
       const view = resolveBadgeView({ state });
       expect(view.hidden).toBe(false);
-      expect(view.glyph).toBe('⚠');
+      expect(view.iconId).toBe('warning');
       expect(view.text).toBe('');
       expect(view.title).toBe(baseTitle);
       expect(view.stateClass).toBe('is-warning');


### PR DESCRIPTION
## 摘要 (zh-TW)

依使用者回報的三類 UI 問題,進行 Material 3 視覺一致化重構。**色彩主題(5 套 + 自訂)全數保留**,僅調整結構、圖示與風格。全程遵守 MV3 最佳實作(inline SVG via innerHTML、無外部字型/CDN、CSP 不需變更)。

### 變更內容(分 6 階段,每階段獨立提交且測試綠)
- **P1 — M3 token**:`sidepanel.css :root` 新增 shape scale(`--arc-radius-*`)、state layer、elevation 階、統一 focus ring、motion 語意 alias(純加法)。
- **P2 — Icon 系統**:`modules/icons.js` 改用 **Material Symbols Outlined**(viewBox `0 -960 960 960`、fill=currentColor)。新增 `ICONS` map(~40 icon)+ `renderIcon`/`renderIconEl`/`hasIcon`;既有 12 個 `*_ICON_SVG` 沿用同名匯出、改以 Material Symbols 重繪,呼叫端不需更動。
- **P3 — emoji→SVG 全面替換**:
  - **Chevron 狀態化**:`▶/▼` textContent → 單一 `expand_more` SVG + `is-collapsed` class(CSS 旋轉);`dragDropManager` 拖曳展開改讀 `aria-expanded`;6 個 E2E + `setup.js` 同步更新。
  - **側邊欄動作鈕**:`data-icon` 注入 + 拆 `.btn-icon`/`.btn-label`(i18n 不洗掉圖示);14 locale 去 emoji。
  - **Spotlight / 命令列 / Ask AI / 設定頁**:icon-id 化、狀態徽章/RSS/警告/下載態全改 SVG。
- **P4 — 工作區列收斂**:下拉 + 齒輪 → **單一橫向按鈕(名稱置中、無 emoji)→ 開管理 dialog**;切換搬進 dialog(每列點擊即切換,沿用確認流程,成功後關閉);rename/delete/cloud 改 Material Symbols;`resolveWorkspaceIcon` 向後相容已同步的舊版 emoji 資料。
- **P5 — 套用 M3 樣式**:圓角/elevation/focus-ring/pressed state-layer 套用至 input/button/modal/menu/列/工作區鈕。

### 測試
- `test:unit` **239 綠**(含改寫的 driveSyncBadge 測試)。
- `npm test`(E2E)**serial 41 passed / 2 skipped / 0 failed(106 tests)**;`make` dev build OK;四 entrypoint + CSS esbuild 解析 OK;所有 icon-id 引用經腳本核對 **0 遺漏**。
- 每階段以多視角對抗式 review 驗證(icon 完整性/安全、工作區流程/向後相容、CSS/M3/a11y 回歸),發現的 3 個 major + 多個 minor 已全數修正。
- **需手動驗證**:逐主題(5 套 + 自訂)+ reduced-motion 視覺掃描;工作區單鈕→dialog 切換/改名/刪除;chevron 旋轉與拖曳到收合資料夾自動展開;Spotlight 真 favicon vs SVG fallback。

### 已知取捨(非阻斷)
- **AI 分頁群組「名稱」的 emoji 前綴保留**:由 `aiManager` prompt 刻意產生,Chrome 原生分頁群組標題無法用 SVG、且屬內容生成功能;如要移除需改 prompt 行為,待確認。
- `.header-action-btn` 基底為 danger-red(`#ai-cleanup-btn`/`#bookmark-tools-btn` 沿用),屬**既有**樣式;使用者要求保留色彩故未動,可選 follow-up 中性化。
- `scroll_position_on_tab_click` 在 `maxWorkers=2` 並行下偶逾時,solo/serial 皆通過——機器資源 starvation flake,非本次回歸。

---

## Summary (English)

A Material 3 visual-consistency overhaul addressing three reported UI issues. **All 5 color themes + custom theme are preserved**; only structure, icons, and styling change. Fully MV3-compliant (inline SVG via innerHTML; no external fonts/CDN; no CSP change).

- **P1** M3 tokens (shape scale, state layers, elevation, unified focus ring, motion aliases).
- **P2** `icons.js` rebuilt on **Material Symbols Outlined** + `renderIcon`/`renderIconEl`/`hasIcon` (legacy constants keep their names).
- **P3** all emoji UI icons → SVG: state-driven chevrons (class+aria, not glyph text; `dragDropManager` reads `aria-expanded`), action buttons (icon/label split so i18n won't wipe the icon), Spotlight/palette/Ask-AI/options badges. Emoji stripped from 14 locales.
- **P4** workspace bar collapsed into a single centered button → manage dialog; switching moved into clickable dialog rows; `resolveWorkspaceIcon` keeps legacy synced emoji working.
- **P5** M3 radius/elevation/focus-ring/pressed-state-layer applied to inputs/buttons/modals/menus/rows.

Tests: unit **239 green**; E2E **serial 41 passed / 2 skipped / 0 failed**; build OK; all icon-id references resolve (0 missing). Per-phase adversarial review; 3 major + several minor findings fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)