### PR TITLE
fix(i18n): shorten extensionDescription to <=132 chars (Chrome Web Store limit)

### DIFF
--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -4,7 +4,7 @@
     "description": "The name of the extension."
   },
   "extensionDescription": {
-    "message": "Sidebar im Arc-Stil — vereinheitlichte Tabs, Lesezeichen, Leseliste + lokale KI (Gruppen-Benennung, Cleanup, Zusammenfassung, NL-Suche), Workspaces, ⌘K-Palette. Kein API-Schlüssel.",
+    "message": "Arc-Sidebar: Tabs, Lesezeichen & Leseliste + lokale KI (Gruppieren, Cleanup, Zusammenfassung, Suche), Workspaces. Kein API-Key.",
     "description": "The description of the extension."
   },
   "searchPlaceholder": {

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -4,7 +4,7 @@
     "description": "The name of the extension."
   },
   "extensionDescription": {
-    "message": "Arc-style sidebar — unified tabs, bookmarks, reading list + local AI (group naming, cleanup, summary, NL search), Workspaces, ⌘K palette. No API key.",
+    "message": "Arc-style sidebar: tabs, bookmarks & reading list + local AI (grouping, cleanup, summary, search), Workspaces. No API key.",
     "description": "The description of the extension."
   },
   "searchPlaceholder": {

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -4,7 +4,7 @@
     "description": "The name of the extension."
   },
   "extensionDescription": {
-    "message": "Barra lateral estilo Arc — pestañas, marcadores, lista de lectura unificados + IA local (nombrado de grupos, limpieza, resumen, búsqueda NL), Workspaces, paleta ⌘K. Sin clave API.",
+    "message": "Barra lateral Arc: pestañas, marcadores, lista de lectura + IA local (grupos, limpieza, resumen, búsqueda), Workspaces. Sin API.",
     "description": "The description of the extension."
   },
   "searchPlaceholder": {

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -4,7 +4,7 @@
     "description": "The name of the extension."
   },
   "extensionDescription": {
-    "message": "Barre latérale style Arc — onglets, signets, liste de lecture unifiés + IA locale (nommage de groupes, cleanup, résumé, recherche NL), Workspaces, palette ⌘K. Sans clé API.",
+    "message": "Barre latérale Arc : onglets, signets, liste de lecture + IA locale (groupes, nettoyage, résumé), Workspaces. Sans clé API.",
     "description": "The description of the extension."
   },
   "searchPlaceholder": {

--- a/_locales/hi/messages.json
+++ b/_locales/hi/messages.json
@@ -4,7 +4,7 @@
     "description": "The name of the extension."
   },
   "extensionDescription": {
-    "message": "Arc-style sidebar — tabs, bookmarks, reading list एक साथ + local AI (group naming, cleanup, summary, NL search), Workspaces, ⌘K palette. कोई API key नहीं।",
+    "message": "Arc-style sidebar: tabs, bookmarks और reading list + local AI (grouping, cleanup, summary, search), Workspaces. कोई API key नहीं।",
     "description": "The description of the extension."
   },
   "searchPlaceholder": {

--- a/_locales/id/messages.json
+++ b/_locales/id/messages.json
@@ -4,7 +4,7 @@
     "description": "The name of the extension."
   },
   "extensionDescription": {
-    "message": "Sidebar bergaya Arc — tabs, bookmarks, reading list dalam satu panel + AI lokal (penamaan grup, cleanup, ringkasan, NL search), Workspaces, ⌘K palette. Tanpa API key.",
+    "message": "Sidebar gaya Arc: tab, bookmark & reading list + AI lokal (grup, cleanup, ringkasan, pencarian), Workspaces. Tanpa API key.",
     "description": "The description of the extension."
   },
   "searchPlaceholder": {

--- a/_locales/pt_BR/messages.json
+++ b/_locales/pt_BR/messages.json
@@ -4,7 +4,7 @@
     "description": "The name of the extension."
   },
   "extensionDescription": {
-    "message": "Barra lateral estilo Arc — abas, favoritos, lista de leitura unificados + IA local (nomeação de grupos, limpeza, resumo, busca NL), Workspaces, paleta ⌘K. Sem chave de API.",
+    "message": "Barra lateral Arc: abas, favoritos, lista de leitura + IA local (grupos, limpeza, resumo, busca), Workspaces. Sem API.",
     "description": "The description of the extension."
   },
   "searchPlaceholder": {

--- a/_locales/ru/messages.json
+++ b/_locales/ru/messages.json
@@ -4,7 +4,7 @@
     "description": "The name of the extension."
   },
   "extensionDescription": {
-    "message": "Боковая панель в стиле Arc — вкладки, закладки, список чтения в одном месте + локальный AI (именование групп, очистка, сводки, NL-поиск), Workspaces, палитра ⌘K. Без API-ключа.",
+    "message": "Боковая панель Arc: вкладки, закладки, список чтения + локальный AI (группы, очистка, сводки, поиск), Workspaces. Без API.",
     "description": "The description of the extension."
   },
   "searchPlaceholder": {

--- a/_locales/th/messages.json
+++ b/_locales/th/messages.json
@@ -4,7 +4,7 @@
     "description": "The name of the extension."
   },
   "extensionDescription": {
-    "message": "Sidebar สไตล์ Arc — tabs, bookmarks, reading list ในที่เดียว + AI ในเครื่อง (ตั้งชื่อกลุ่ม, cleanup, สรุป, NL search), Workspaces, ⌘K palette. ไม่ต้องใช้ API key",
+    "message": "Sidebar สไตล์ Arc: tabs, bookmarks, reading list + AI ในเครื่อง (จัดกลุ่ม, cleanup, สรุป, ค้นหา), Workspaces. ไม่ต้องใช้ API key",
     "description": "The description of the extension."
   },
   "searchPlaceholder": {

--- a/_locales/vi/messages.json
+++ b/_locales/vi/messages.json
@@ -4,7 +4,7 @@
     "description": "The name of the extension."
   },
   "extensionDescription": {
-    "message": "Thanh bên kiểu Arc — tabs, bookmarks, reading list trong một panel + AI cục bộ (đặt tên nhóm, cleanup, tóm tắt, NL search), Workspaces, ⌘K palette. Không cần API key.",
+    "message": "Thanh bên kiểu Arc: tabs, bookmarks & reading list + AI cục bộ (nhóm, cleanup, tóm tắt, tìm kiếm), Workspaces. Không cần API key.",
     "description": "The description of the extension."
   },
   "searchPlaceholder": {


### PR DESCRIPTION
## 摘要

上架 Chrome Web Store 時被拒：manifest 的 `description`（`__MSG_extensionDescription__` → `_locales/<lang>/messages.json` 的 `extensionDescription`）有 **11/14 語系超過 132 字元上限**（en 149、de 180、es 179、fr 172、ru 176、id/vi/pt_BR 166-172、th 161、hi 154）。

### 修正
將超標語系的 `extensionDescription` 精簡至 **≤132 字元**，保留核心賣點：Arc 風格側邊欄、分頁/書籤/閱讀清單、本機 AI（群組命名/清理/摘要/搜尋）、Workspaces、免 API key；移除較長的 NL/⌘K palette 細節。`ja/ko/zh_TW/zh_CN` 原本已合格、未更動。

### 驗證
- 全部 14 語系 `extensionDescription` ≤132、`jq` 通過。
- `make release` 產出 `arc-sidebar-v1.15.0.zip`，zip 內各語系描述皆 ≤132（en 122）。

> 此修正只動 `_locales/`（擴充功能 i18n），與 `web/locales/`（行銷網站）無關，未觸及程式碼。

🤖 Generated with [Claude Code](https://claude.com/claude-code)