### PR TITLE
fix(spotlight): addressed panel actions + SW-restart-safe popup lifecycle (#162 WP3)

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -94,7 +94,7 @@ key_files:
   - file_path: modules/commandPalette/searchContext.js
     description: "[功能] Spotlight 來源視窗上下文。儲存 Spotlight 啟動時的「來源 normal 視窗 id」（setOriginWindowId / getOriginWindowId）；因 Spotlight 為獨立 popup 視窗，item handler 須作用於使用者的瀏覽器視窗而非 popup，故由此提供作用目標視窗。"
   - file_path: modules/commandPalette/panelBridge.js
-    description: "[通訊] Spotlight → sidepanel 橋接器（非 runtime messaging）。requestPanelAction 將 UI 類動作以 chrome.storage.session 旗標 pendingPanelAction 寫入並 sidePanel.open(來源視窗)，交由 sidepanel.js 的 consumePendingPanelAction 在正確 context 執行；openUrlInOrigin / resolveTargetWindowId 負責在來源 normal 視窗開分頁。"
+    description: "[通訊] Spotlight → sidepanel 橋接器（非 runtime messaging）。requestPanelAction 將 UI 類動作以 chrome.storage.session 旗標 pendingPanelAction 寫入並 sidePanel.open(來源視窗)，交由 sidepanel.js 的 consumePendingPanelAction 在正確 context 執行；openUrlInOrigin / resolveTargetWindowId 負責在來源 normal 視窗開分頁。ISSUE-162 WP3:旗標帶定址 windowId + ts,純函式 classifyPendingAction(execute/ignore/expired)守門——非目標視窗的 panel 不消費(防錯窗執行/雙重執行),TTL 15s 過期丟棄,sidePanel.open 失敗主動清旗標。"
   - file_path: modules/commandPalette/dataProvider.js
     description: "[功能] Command Palette / Spotlight 資料源。Phase 5 新增；聚合多個 source 的搜尋結果與分組顯示邏輯；index.js 已移除，資料/動作層（dataProvider/actions/nlSearch）現直接供獨立 Spotlight 彈窗（Cmd+Shift+K）使用。"
   - file_path: modules/commandPalette/actions.js

--- a/background.js
+++ b/background.js
@@ -376,6 +376,19 @@ async function findExistingSpotlight() {
     return null;
 }
 
+/**
+ * 記住 Spotlight 視窗 id:模組快取 + chrome.storage.session 雙寫。
+ * SW idle 回收會清空模組狀態(ISSUE-162 A2)— session 副本讓 onFocusChanged
+ * 在 SW 重生後仍能 lazy 補位,失焦自動關閉不再失效。
+ */
+async function setSpotlightWindowId(id) {
+    spotlightWindowId = id;
+    try {
+        if (id == null) await chrome.storage.session.remove('spotlightWindowId');
+        else await chrome.storage.session.set({ spotlightWindowId: id });
+    } catch { /* session unavailable → degrade to module cache only */ }
+}
+
 // 快捷鍵入口:一律開置中 popup(不論是否全螢幕)。每次行為一致、ESC 關閉後可靠重開。
 // (注:macOS 原生全螢幕下 popup 可能被系統移到別的 Space,屬使用者選擇接受的取捨。)
 async function openSpotlight() {
@@ -384,14 +397,18 @@ async function openSpotlight() {
     try {
         const origin = await chrome.windows.getLastFocused({ windowTypes: ['normal'] }).catch(() => null);
 
-        if (spotlightWindowId == null) spotlightWindowId = await findExistingSpotlight();
-        if (spotlightWindowId != null) {
-            try { await chrome.windows.update(spotlightWindowId, { focused: true }); return; }
-            catch { spotlightWindowId = null; }
-        }
+        // Origin 必須在 focus-existing 分支「之前」更新(ISSUE-162 A2):
+        // 從另一個視窗再按 Cmd+Shift+K 聚焦既有 Spotlight 時,動作要路由到
+        // 新的來源視窗。spotlight 頁有 session onChanged 監聽會即時接手。
         await chrome.storage.session.set({
             spotlightOriginWindowId: origin && typeof origin.id === 'number' ? origin.id : null
         });
+
+        if (spotlightWindowId == null) spotlightWindowId = await findExistingSpotlight();
+        if (spotlightWindowId != null) {
+            try { await chrome.windows.update(spotlightWindowId, { focused: true }); return; }
+            catch { await setSpotlightWindowId(null); }
+        }
         const opts = { url: SPOTLIGHT_URL, type: 'popup', focused: true, width: SPOTLIGHT_W, height: SPOTLIGHT_H };
         if (origin && typeof origin.left === 'number' && typeof origin.width === 'number') {
             // 以 origin 視窗的左上為下限(非 0),避免左側副螢幕(origin.left 為負)時被推回主螢幕。
@@ -399,7 +416,7 @@ async function openSpotlight() {
             opts.top = Math.max(origin.top, origin.top + Math.round((origin.height - SPOTLIGHT_H) / 3));
         }
         const win = await chrome.windows.create(opts);
-        spotlightWindowId = win && typeof win.id === 'number' ? win.id : null;
+        await setSpotlightWindowId(win && typeof win.id === 'number' ? win.id : null);
     } catch (err) {
         console.warn('[spotlight] open failed:', err && err.message ? err.message : err);
     } finally {
@@ -407,14 +424,28 @@ async function openSpotlight() {
     }
 }
 
-// 失焦自動關閉(排除短暫無焦點 WINDOW_ID_NONE)
+// 失焦自動關閉(排除短暫無焦點 WINDOW_ID_NONE)。
+// SW 重生後模組快取為 null → 先從 session lazy 補位再判斷(ISSUE-162 A2)。
 chrome.windows.onFocusChanged.addListener((winId) => {
-    if (spotlightWindowId != null && winId !== spotlightWindowId && winId !== chrome.windows.WINDOW_ID_NONE) {
-        chrome.windows.remove(spotlightWindowId).catch(() => {});
-    }
+    if (winId === chrome.windows.WINDOW_ID_NONE) return;
+    (async () => {
+        if (spotlightWindowId == null) {
+            try {
+                const { spotlightWindowId: stored } = await chrome.storage.session.get('spotlightWindowId');
+                if (typeof stored === 'number') spotlightWindowId = stored;
+            } catch { /* ignore */ }
+        }
+        if (spotlightWindowId != null && winId !== spotlightWindowId) {
+            // remove 後一律清掉記錄:成功=已關閉;失敗=id 已死(SW 重啟前殘留)。
+            // 兩種情況都不該讓 stale id 在 session 裡無限期重試。
+            chrome.windows.remove(spotlightWindowId)
+                .catch(() => {})
+                .finally(() => setSpotlightWindowId(null));
+        }
+    })();
 });
 chrome.windows.onRemoved.addListener((winId) => {
-    if (winId === spotlightWindowId) spotlightWindowId = null;
+    if (winId === spotlightWindowId) setSpotlightWindowId(null);
 });
 
 // 監聽快捷鍵指令

--- a/docs/specs/fix/ISSUE-162_spotlight-routing/SPEC.md
+++ b/docs/specs/fix/ISSUE-162_spotlight-routing/SPEC.md
@@ -1,0 +1,41 @@
+# [Fix/T1] Spotlight 動作路由修正（#162 WP3：A1/A2/A3/A4）
+
+## 背景與問題
+
+- **A1 [High]**：`pendingPanelAction` 是全域 session 旗標，**每個**開著的 sidepanel 都會收到 `storage.session.onChanged` 並以「get → remove」非原子順序消費 —— 多視窗下：(1) 已開著 panel 的視窗 C 會搶在目標視窗 A 之前執行（smart-group 動到錯誤視窗的分頁）；(2) 兩個 panel 可在 remove 前都讀到值 → 雙重執行（switch-workspace 開出兩個重複視窗）。
+- **A2 [Med]**：`spotlightWindowId` 是 SW 模組狀態；SW idle 回收後 `onFocusChanged` 守門永遠 false → 失焦自動關閉失效（孤兒 popup）。且 `openSpotlight` 的 focus-existing 路徑不更新 `spotlightOriginWindowId`，spotlight 頁又只在 DOMContentLoaded 讀一次 → 動作路由到舊 origin 視窗。
+- **A3 [Med]**：`pendingPanelAction` 無 TTL；`sidePanel.open` 失敗時旗標殘留整個 session，下次手動開任何 panel 時突發執行陳年動作。
+- **A4 [Low]**：palette 的 tab 結果含 Spotlight 自身分頁（選中即自我關閉的無效項）。
+
+## 方案
+
+1. **定址 + 認領消費（A1）**：`requestPanelAction` 先解析目標視窗，payload 帶 `windowId`；各 panel 啟動時記住自己的 windowId，**只消費寄給自己的動作**（mismatch 一律不動、留給目標 panel）。同視窗僅一個 panel → 認領競態消失。`classifyPendingAction` 抽成純函式（execute / ignore / expired）供單元測試。
+2. **TTL + 失敗清理（A3）**：消費時丟棄 >15s 的動作並清旗標；`requestPanelAction` 的 `sidePanel.open` 失敗路徑主動 remove 旗標。
+3. **Spotlight id 進 session（A2）**：`spotlightWindowId` 同步寫入 `chrome.storage.session`；`onFocusChanged` 在模組快取為 null 時 lazy 從 session 補位後再判斷。`openSpotlight` 把 origin 寫入移到 focus-existing 分支**之前**（兩條路徑都更新）；spotlight 頁加 `storage.session.onChanged` 監聽，origin 變更即 `setOriginWindowId`。
+4. **過濾自身（A4）**：`getTabResults` 排除 `spotlight.html` 自身分頁。
+
+排除的替代方案：改用 `chrome.tabs.sendMessage`/port 點對點路由 —— 需要 panel 註冊 port 生命週期管理，比定址旗標複雜且 sidePanel.open 後的時序更難保證；定址 + TTL 已消除全部已知失效模式。
+
+## 影響面
+
+- `modules/commandPalette/panelBridge.js`（定址、TTL 清理、純函式）
+- `sidepanel.js`（消費守門：windowId + TTL）
+- `background.js`（Spotlight 區段：session 持久化 id、lazy 補位、origin 重寫時機）
+- `spotlight.js`（origin 變更監聽）
+- `modules/commandPalette/dataProvider.js`（自身分頁過濾）
+- 無 storage schema / manifest / i18n 變更
+
+## Test Impact
+
+- 新增 `unit_tests/panelBridge.test.mjs`：`classifyPendingAction` 的 execute / ignore（錯視窗）/ expired（TTL）/ 缺欄位案例。
+- 既有 `happy_path_spotlight_search.test.js` 等 spotlight E2E 必須全綠。
+- 驗證指令：`npm run test:unit`、`npm run test:ci`。
+
+## 驗收條件
+
+- [ ] 多視窗情境：動作只在目標視窗執行（由 classify 純函式單元測試保證 ignore 行為）。
+- [ ] 過期動作（>15s）被丟棄且旗標清除。
+- [ ] `sidePanel.open` 失敗不留殘旗標。
+- [ ] SW 重啟後（模組快取歸零）失焦仍能關閉既有 Spotlight；focus-existing 路徑後動作路由到新 origin。
+- [ ] palette 不再列出 Spotlight 自身分頁。
+- [ ] unit + happy_path E2E 全綠。

--- a/modules/commandPalette/dataProvider.js
+++ b/modules/commandPalette/dataProvider.js
@@ -65,7 +65,11 @@ function getWorkspaceResults(q) {
 }
 
 async function getTabResults(q) {
-    const tabs = await chrome.tabs.query({}).catch(() => []);
+    const allTabs = await chrome.tabs.query({}).catch(() => []);
+    // 排除 Spotlight 自身分頁(ISSUE-162 A4):列出自己只會成為「選中即
+    // 自我關閉」的無效項,還污染空查詢的 top 結果。
+    const selfUrl = chrome.runtime.getURL('spotlight.html');
+    const tabs = allTabs.filter(t => !(t.url || '').startsWith(selfUrl));
     return scoreFilter(tabs, q, t => (t.title || '') + ' ' + (t.url || ''))
         .map(t => ({
             id: 'tab-' + t.id,

--- a/modules/commandPalette/panelBridge.js
+++ b/modules/commandPalette/panelBridge.js
@@ -1,5 +1,8 @@
 import { getOriginWindowId } from './searchContext.js';
 
+/** pendingPanelAction 的有效期:超過即視為陳年動作丟棄(A3)。 */
+export const PANEL_ACTION_TTL_MS = 15000;
+
 /** 解析作用目標 normal 視窗 id:優先用啟動來源,否則退回最後聚焦的 normal 視窗。 */
 export async function resolveTargetWindowId() {
     const fromCtx = getOriginWindowId();
@@ -9,17 +12,53 @@ export async function resolveTargetWindowId() {
 }
 
 /**
+ * 判定一個 pendingPanelAction 對「我這個 panel」該怎麼處理。純函式(可單元測試)。
+ *
+ * 定址語意(ISSUE-162 A1):動作寄給特定視窗;非目標視窗的 panel 必須
+ * 'ignore' 且**不可清旗標**(目標視窗的 panel 可能還在初始化,清了就漏)。
+ * 過期(A3)則由任何 panel 'expired' 清掉,避免 sidePanel.open 失敗後
+ * 旗標殘留整個 session、之後突發執行。
+ *
+ * @param {{id?:string, windowId?:number, ts?:number}|null|undefined} pending
+ * @param {number} myWindowId
+ * @param {number} now
+ * @param {number} [ttlMs]
+ * @returns {'execute'|'ignore'|'expired'}
+ */
+export function classifyPendingAction(pending, myWindowId, now, ttlMs = PANEL_ACTION_TTL_MS) {
+    if (!pending || !pending.id) return 'ignore';
+    if (typeof pending.ts === 'number' && now - pending.ts > ttlMs) return 'expired';
+    // 缺 windowId(理論上不發生)→ 視為廣播,維持可用性。
+    if (typeof pending.windowId === 'number' && pending.windowId !== myWindowId) return 'ignore';
+    return 'execute';
+}
+
+/**
  * 從 Spotlight(獨立視窗)請求側邊欄執行 UI 類動作:
- * 寫 session 旗標 → 在來源視窗開側邊欄 → 關閉 Spotlight。
- * 旗標 pendingPanelAction 由側邊欄的 storage.session onChanged 監聽消費(見 sidepanel.js consumePendingPanelAction)。
+ * 解析目標視窗 → 寫入「定址」session 旗標 → 在目標視窗開側邊欄 → 關閉 Spotlight。
+ * 旗標 pendingPanelAction 由側邊欄的 storage.session onChanged 監聽消費
+ * (見 sidepanel.js consumePendingPanelAction;只有 windowId 相符的 panel 會執行)。
  * @param {string} id
  * @param {object} [extra]
  */
 export async function requestPanelAction(id, extra = {}) {
     try {
-        await chrome.storage.session.set({ pendingPanelAction: { id, ...extra, ts: Date.now() } });
+        // 先解析目標視窗再寫旗標:payload 必須帶定址,否則其他視窗的
+        // panel 會搶答(在錯誤視窗執行動作)或雙重執行(ISSUE-162 A1)。
         const winId = await resolveTargetWindowId();
-        if (typeof winId === 'number') await chrome.sidePanel.open({ windowId: winId });
+        await chrome.storage.session.set({
+            pendingPanelAction: { id, ...extra, windowId: winId, ts: Date.now() },
+        });
+        if (typeof winId === 'number') {
+            try {
+                await chrome.sidePanel.open({ windowId: winId });
+            } catch (openErr) {
+                // 開 panel 失敗(gesture 過期/視窗剛關)→ 不留殘旗標,
+                // 否則下次手動開 panel 會突發執行陳年動作(A3)。
+                await chrome.storage.session.remove('pendingPanelAction').catch(() => {});
+                throw openErr;
+            }
+        }
     } catch (err) {
         console.warn('[spotlight] requestPanelAction failed:', err && err.message ? err.message : err);
     } finally {

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -46,6 +46,17 @@ const PANEL_ACTION_HANDLERS = {
     },
 };
 
+// 本 panel 所屬視窗 id:消費轉送動作前必須先知道「我是誰」(定址守門用)。
+let myWindowIdPromise = null;
+function getMyWindowId() {
+    if (!myWindowIdPromise) {
+        myWindowIdPromise = chrome.windows.getCurrent()
+            .then(w => w.id)
+            .catch(() => null);
+    }
+    return myWindowIdPromise;
+}
+
 async function consumePendingPanelAction() {
     // 初始化尚未完成時不消費:旗標保留,待 initialize 末端設定 panelReady 後再讀取,
     // 避免在按鈕事件接線前觸發動作而被吞掉(亦不漏動作)。
@@ -55,7 +66,18 @@ async function consumePendingPanelAction() {
         ({ pendingPanelAction: pending } = await chrome.storage.session.get('pendingPanelAction'));
     } catch { return; }
     if (!pending || !pending.id) return;
+
+    // 定址 + TTL 守門(ISSUE-162 A1/A3):動作寄給特定視窗;非目標 panel
+    // 一律不碰(也不清旗標——目標 panel 可能還在初始化);過期動作清掉,
+    // 防 sidePanel.open 失敗後旗標殘留、之後突發執行。
+    const { classifyPendingAction } = await import('./modules/commandPalette/panelBridge.js');
+    const verdict = classifyPendingAction(pending, await getMyWindowId(), Date.now());
+    if (verdict === 'ignore') return;
     try { await chrome.storage.session.remove('pendingPanelAction'); } catch { /* ignore */ }
+    if (verdict === 'expired') {
+        console.warn('[panel-action] dropped expired action:', pending.id);
+        return;
+    }
     const fn = PANEL_ACTION_HANDLERS[pending.id];
     if (!fn) { console.warn('[panel-action] unknown id:', pending.id); return; }
     try { await fn(pending); }

--- a/spotlight.js
+++ b/spotlight.js
@@ -35,6 +35,13 @@ document.addEventListener('DOMContentLoaded', async () => {
         const { spotlightOriginWindowId } = await chrome.storage.session.get('spotlightOriginWindowId');
         setOriginWindowId(spotlightOriginWindowId);
     } catch { /* ignore */ }
+    // 從另一個視窗再按快捷鍵會「聚焦既有 Spotlight」並改寫 origin(不重載頁面),
+    // 必須跟著更新,否則動作會路由到舊的來源視窗(ISSUE-162 A2)。
+    chrome.storage.session.onChanged.addListener((changes) => {
+        if (changes.spotlightOriginWindowId) {
+            setOriginWindowId(changes.spotlightOriginWindowId.newValue);
+        }
+    });
 
     // Hydrate data provider + action 可見性判斷所讀的 state
     await Promise.all([

--- a/usecase_tests/unit_tests/panelBridge.test.mjs
+++ b/usecase_tests/unit_tests/panelBridge.test.mjs
@@ -1,0 +1,44 @@
+import { classifyPendingAction, PANEL_ACTION_TTL_MS } from '../../modules/commandPalette/panelBridge.js';
+
+describe('classifyPendingAction (ISSUE-162 A1/A3)', () => {
+  const NOW = 1_000_000;
+  const fresh = (overrides = {}) => ({ id: 'smart-group', windowId: 7, ts: NOW - 100, ...overrides });
+
+  it('寄給我的新鮮動作 → execute', () => {
+    expect(classifyPendingAction(fresh(), 7, NOW)).toBe('execute');
+  });
+
+  it('寄給別的視窗 → ignore(且呼叫端不得清旗標)', () => {
+    expect(classifyPendingAction(fresh({ windowId: 99 }), 7, NOW)).toBe('ignore');
+  });
+
+  it('過期動作 → expired(任何 panel 都該清旗標)', () => {
+    const stale = fresh({ ts: NOW - PANEL_ACTION_TTL_MS - 1 });
+    expect(classifyPendingAction(stale, 7, NOW)).toBe('expired');
+    // 即使是寄給別的視窗,過期優先 → 由看到的人清掉
+    expect(classifyPendingAction({ ...stale, windowId: 99 }, 7, NOW)).toBe('expired');
+  });
+
+  it('剛好在 TTL 邊界內 → execute', () => {
+    expect(classifyPendingAction(fresh({ ts: NOW - PANEL_ACTION_TTL_MS }), 7, NOW)).toBe('execute');
+  });
+
+  it('缺 windowId → 視為廣播,execute(向後相容防呆)', () => {
+    const p = fresh();
+    delete p.windowId;
+    expect(classifyPendingAction(p, 7, NOW)).toBe('execute');
+  });
+
+  it('null / 缺 id → ignore', () => {
+    expect(classifyPendingAction(null, 7, NOW)).toBe('ignore');
+    expect(classifyPendingAction({}, 7, NOW)).toBe('ignore');
+    expect(classifyPendingAction({ windowId: 7, ts: NOW }, 7, NOW)).toBe('ignore');
+  });
+
+  it('缺 ts → 不套 TTL,照定址判斷', () => {
+    const p = fresh();
+    delete p.ts;
+    expect(classifyPendingAction(p, 7, NOW)).toBe('execute');
+    expect(classifyPendingAction({ ...p, windowId: 99 }, 7, NOW)).toBe('ignore');
+  });
+});


### PR DESCRIPTION
Part of #162 (WP3, T1 — spec: `docs/specs/fix/ISSUE-162_spotlight-routing/SPEC.md`).

## 摘要 (Summary)

修復 Spotlight 動作路由四缺陷：**A1** 多視窗錯窗執行／雙重執行（`pendingPanelAction` 廣播 + get→remove 非原子）、**A2** SW 重啟後失焦關閉失效與 origin 路由錯舊窗、**A3** 旗標無 TTL 殘留突發執行、**A4** palette 列出 Spotlight 自身。

## 📝 變更內容 (Changes)

- **定址 + 認領（A1）**：旗標帶目標 `windowId` + `ts`；純函式 `classifyPendingAction`（execute / ignore / expired）守門 —— 非目標 panel 不消費也不清旗標，同視窗僅一 panel，雙重消費消失
- **TTL + 失敗清理（A3）**：>15s 丟棄並清旗標；`sidePanel.open` 失敗主動 remove
- **SW 重啟韌性（A2）**：`spotlightWindowId` 雙寫 `storage.session`，`onFocusChanged` lazy 補位（嘗試關閉後一律清記錄防 stale 重試）；origin 寫入提前到 focus-existing 分支之前 + spotlight 頁監聽 session 變更
- **自身過濾（A4）**：tab 結果排除 `spotlight.html`

## 🧪 測試 (Testing)

- [x] 新增 `panelBridge.test.mjs`（7 cases：定址 ignore／TTL 邊界／expired 優先／防呆）
- [x] unit 260 passed；happy_path E2E 21 suites / 53 tests passed（含既有 spotlight E2E）

## 🌐 English Version

Fixes four Spotlight action-routing defects: actions are now **addressed** to a target `windowId` with a 15s TTL and claim-based consumption via the pure `classifyPendingAction` helper (wrong-window execution and double-consumption eliminated); the popup's window id is mirrored to `storage.session` so blur-auto-close survives service-worker restarts (with stale-id cleanup); the origin window is rewritten on the focus-existing path and the popup listens for the change; the palette no longer lists the Spotlight's own tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)