### PR TITLE
fix(tags): cross-window consistency + anchored tag: parsing (#162 WP4)

### DIFF
--- a/docs/specs/fix/ISSUE-162_tags-search/SPEC.md
+++ b/docs/specs/fix/ISSUE-162_tags-search/SPEC.md
@@ -1,0 +1,47 @@
+# [Fix/T1] Tags 與搜尋修正（#162 WP4：B1~B7）
+
+## 背景與問題
+
+- **B1 [High]**：`tagManager` 把 tags/bookmarkTags 整表載入 module 狀態、每次變更整表寫回，卻是**全專案唯一沒訂 `storage.onChanged` 的可變資料集** —— 多視窗下，視窗 B 的任一 tag 操作會用陳舊的表覆寫掉視窗 A 剛建立的 tag（last-write-wins 互滅，靜默且不可復原）。
+- **B2 [Med]**：`tag:` regex 未錨定字界 —— `montag:9`、貼上含 `hashtag:` 的 URL 都被解析成 tag 查詢 → 非書籤區段全部隱藏 + 零結果，全面板空白且無解釋。
+- **B3 [Med]**：刪除 tag 只移除對話框列，沒發 `refreshBookmarksRequired`（edit 路徑有）→ 書籤列殘留死 dot，點擊進入 `tag:已刪名稱` 死路。
+- **B4 [Med]**：tag 名允許 `"` → dot-click 產生的 `tag:"..."` token 無法 round-trip。
+- **B5 [Low]**：全形冒號 `tag：` 不被解析 —— zh-TW IME 預設輸出全形標點，主場痛點。
+- **B6 [Low]**：暖啟動時 `pruneOrphanedBookmarkTags` 拿「上個 session 的 cache 快照」立即執行，與背景 rebuild 競態 —— 陳舊快照缺少仍存在的書籤時會**誤刪活的 tag 綁定**且無法復原。
+- **B7 [Low]**：8px 純色 dot 無描邊，yellow on light 1.93:1、grey on dark ~2.7:1，低於 WCAG 1.4.11 的 3:1。
+
+## 方案
+
+1. **B1**：`initTags()` 安裝一次性 `storage.onChanged` 訂閱（比照 readingList summaryStore 模式）：reload in-memory 兩表；內容真的變了才 dispatch `refreshBookmarksRequired`（JSON 比對 —— 寫入端自己的 echo 內容相同，自動跳過、不雙重 render）。
+2. **B2/B5**：regex 改 `(^|\s)tag[:：]"..."|(^|\s)tag[:：]\S+`（字界錨定 + 全形冒號）。
+3. **B3**：刪除路徑補發 `refreshBookmarksRequired`。
+4. **B4**：抽出純函式 `normalizeTagName`（trim + 40 字 + 剝 `"`），create/update 共用。
+5. **B6**：prune 一律等 cache 可信：冷啟動（已 await build）直接跑；暖啟動掛 `bookmarkCacheReady` once listener（新增 `pendingWarmCacheRebuild` 旗標判別）。rebuild 失敗 → 本 session 跳過 prune（安全方向）。
+6. **B7**：dot 9px + 1px 主題感知描邊（`color-mix` 寫在消費端規則，跟著 body 主題解析）。
+
+排除的替代方案：tags 改 per-id keys（如 workspace v2）—— tags 資料量極小（幾 KB）、寫入頻率低，onChanged reload 已消除互滅；per-id 化的 migration 成本不成比例。
+
+## 影響面
+
+- `modules/bookmark/tagManager.js`（訂閱、normalizeTagName）
+- `modules/utils/searchUtils.js`（parseSearchQuery regex）
+- `modules/bookmark/bookmarkToolsUI.js`（刪除路徑 refresh）
+- `sidepanel.js`（prune 時機 + 旗標）
+- `sidepanel.css`（dot 描邊）
+- 無 storage schema 變更（資料形狀不變）、無 manifest / i18n 變更
+
+## Test Impact
+
+- `searchUtils.test.mjs`：新增錨定（montag / hashtag-URL）、全形冒號、錨定後正常 token 案例。
+- `tagPicker.test.mjs` 不受影響；新增 `normalizeTagName` 案例（附在 searchUtils 測試檔或獨立）。
+- E2E：`happy_path_` 全套需綠（含 tag 相關 E2E）。
+
+## 驗收條件
+
+- [ ] `parseSearchQuery('montag:9')` → keywords=['montag:9']、tags=[]；URL 含 `hashtag:` 不再誤判。
+- [ ] `parseSearchQuery('tag：工作')` → tags=['工作']。
+- [ ] `normalizeTagName('say "hi"')` 無引號。
+- [ ] 刪除 tag 後書籤列 dot 即時消失（refreshBookmarksRequired 由刪除路徑發出）。
+- [ ] 他窗 tag 變更觸發本窗 reload + 重繪；本窗自己的寫入不雙重 render（JSON 相同跳過）。
+- [ ] 暖啟動 prune 不在 bookmarkCacheReady 前執行。
+- [ ] unit + happy_path E2E 全綠。

--- a/modules/bookmark/bookmarkToolsUI.js
+++ b/modules/bookmark/bookmarkToolsUI.js
@@ -173,6 +173,9 @@ function buildTagRow(tag, listEl) {
             if (listEl.querySelectorAll('.bm-tools__row').length === 0) {
                 listEl.appendChild(makeEmpty(api.getMessage('bmToolsTagsEmpty') || 'No tags yet.'));
             }
+            // 與 edit 路徑一致(ISSUE-162 B3):重繪書籤列移除殘留的 tag dot,
+            // 否則點到死 dot 會進入 tag:已刪名稱 的全面板空白死路。
+            document.dispatchEvent(new CustomEvent('refreshBookmarksRequired'));
         }
     });
     row.appendChild(deleteBtn);

--- a/modules/bookmark/tagManager.js
+++ b/modules/bookmark/tagManager.js
@@ -24,10 +24,58 @@ let tags = {};
 /** @type {Object<string, string[]>} */
 let bookmarkTags = {};
 
+/**
+ * 正規化 tag 名稱:trim、截 40 字,並剝除雙引號 —— tag 名含 `"` 會讓
+ * dot-click 產生的 `tag:"..."` token 無法 round-trip(ISSUE-162 B4)。
+ * 純函式(可單元測試)。
+ * @param {unknown} name
+ * @param {string} [fallback]
+ * @returns {string}
+ */
+export function normalizeTagName(name, fallback = 'Tag') {
+    const n = String(name ?? '').replace(/"/g, '').trim().slice(0, 40);
+    return n || fallback;
+}
+
+let storageSubscribed = false;
+
 export async function initTags() {
     const result = await getStorage('local', [TAGS_KEY, BOOKMARK_TAGS_KEY]);
     tags = result[TAGS_KEY] || {};
     bookmarkTags = result[BOOKMARK_TAGS_KEY] || {};
+
+    // 跨視窗一致性(ISSUE-162 B1):tags/bookmarkTags 是整表持久化的
+    // 可變資料集,且本擴充功能支援多個同時開啟的 sidepanel。沒有這個
+    // 訂閱,視窗 B 會拿陳舊的 in-memory 表覆寫掉視窗 A 剛建立的 tag
+    // (last-write-wins 互滅)。寫入端自己的 onChanged 會因內容相同而
+    // 跳過重繪(免雙重 render)。
+    if (!storageSubscribed && typeof chrome !== 'undefined' && chrome.storage?.onChanged) {
+        storageSubscribed = true;
+        chrome.storage.onChanged.addListener((changes, area) => {
+            if (area !== 'local') return;
+            if (!changes[TAGS_KEY] && !changes[BOOKMARK_TAGS_KEY]) return;
+            let dirty = false;
+            if (changes[TAGS_KEY]) {
+                const next = changes[TAGS_KEY].newValue || {};
+                if (JSON.stringify(next) !== JSON.stringify(tags)) {
+                    tags = next;
+                    dirty = true;
+                }
+            }
+            if (changes[BOOKMARK_TAGS_KEY]) {
+                const next = changes[BOOKMARK_TAGS_KEY].newValue || {};
+                if (JSON.stringify(next) !== JSON.stringify(bookmarkTags)) {
+                    bookmarkTags = next;
+                    dirty = true;
+                }
+            }
+            // 重繪書籤列讓 tag dots 反映他窗變更;spotlight 等無此監聽的
+            // context 只更新 in-memory 即可。
+            if (dirty && typeof document !== 'undefined') {
+                document.dispatchEvent(new CustomEvent('refreshBookmarksRequired'));
+            }
+        });
+    }
 }
 
 export function getAllTags() {
@@ -63,7 +111,7 @@ export async function createTag(args) {
     const id = 'tag_' + Date.now().toString(36) + Math.random().toString(36).slice(2, 6);
     const tag = {
         id,
-        name: (args.name || 'Tag').trim().slice(0, 40),
+        name: normalizeTagName(args.name),
         color: PRESET_COLORS.includes(args.color) ? args.color : 'blue',
         createdAt: Date.now(),
     };
@@ -75,7 +123,7 @@ export async function createTag(args) {
 export async function updateTag(id, updates) {
     const tag = tags[id];
     if (!tag) return null;
-    if (updates.name !== undefined) tag.name = updates.name.trim().slice(0, 40);
+    if (updates.name !== undefined) tag.name = normalizeTagName(updates.name, tag.name);
     if (updates.color !== undefined && PRESET_COLORS.includes(updates.color)) tag.color = updates.color;
     await persistTags();
     return tag;

--- a/modules/utils/searchUtils.js
+++ b/modules/utils/searchUtils.js
@@ -45,17 +45,25 @@ export function extractDomain(url) {
 /**
  * 將搜尋字串拆成一般關鍵字與 tag: 篩選。
  * 支援 tag:單詞 與 tag:"含空白名稱"；tag 名稱去引號、小寫化。其餘空白分隔詞為關鍵字（小寫）。
+ *
+ * Token 必須錨定在字界（字首或空白後）：未錨定的版本會把 `montag:9` 或
+ * 貼上的 URL `https://x.com/hashtag:foo` 解析成 tag 查詢，整個面板瞬間
+ * 清空且毫無解釋（ISSUE-162 B2）。同時接受全形冒號 `：` —— zh-TW 使用者
+ * IME 預設輸出全形標點（B5）。
  * @param {string} query
  * @returns {{keywords: string[], tags: string[]}}
  */
 export function parseSearchQuery(query) {
     const tags = [];
     if (typeof query !== 'string') return { keywords: [], tags };
-    const rest = query.replace(/tag:"([^"]*)"|tag:(\S+)/gi, (_, quoted, bare) => {
-        const name = (quoted !== undefined ? quoted : bare).trim().toLowerCase();
-        if (name) tags.push(name);
-        return ' ';
-    });
+    const rest = query.replace(
+        /(^|\s)tag[:：]"([^"]*)"|(^|\s)tag[:：](\S+)/gi,
+        (_, _sep1, quoted, _sep2, bare) => {
+            const name = (quoted !== undefined ? quoted : bare).trim().toLowerCase();
+            if (name) tags.push(name);
+            return ' ';
+        }
+    );
     const keywords = rest.toLowerCase().split(/\s+/).filter(k => k.length > 0);
     return { keywords, tags };
 }

--- a/sidepanel.css
+++ b/sidepanel.css
@@ -3512,7 +3512,10 @@ mark.url-match {
 
 /* 書籤列上的標籤圓點 */
 .bookmark-tags { display: inline-flex; gap: 3px; align-items: center; margin: 0 6px; }
-.bookmark-tag-dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; cursor: pointer; transition: transform 0.1s ease; }
+/* 1px 主題感知描邊(ISSUE-162 B7):純色 8px 圓點對淺色背景的 yellow(1.93:1)
+   與深色背景的 grey(~2.7:1)皆低於 WCAG 1.4.11 的 3:1 非文字對比;color-mix
+   寫在「消費端規則」而非 :root 自訂屬性,確保跟著當前主題解析。 */
+.bookmark-tag-dot { width: 9px; height: 9px; border-radius: 50%; display: inline-block; cursor: pointer; transition: transform 0.1s ease; box-sizing: border-box; border: 1px solid color-mix(in srgb, var(--text-color-primary) 45%, transparent); }
 .bookmark-tag-dot:hover { transform: scale(1.25); }
 .bookmark-tag-dot[data-color="grey"]   { background: #5f6368; }
 .bookmark-tag-dot[data-color="blue"]   { background: #1a73e8; }

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -198,11 +198,19 @@ async function initialize() {
     // Warm start stays non-blocking and notifies search to re-run with fresh data.
     // Check the init flag — not cache length — so users with zero bookmarks
     // don't get treated as cold-start on every launch.
+    let pendingWarmCacheRebuild = false;
     if (!state.isBookmarkCacheInitialized()) {
         await state.buildBookmarkCache();
     } else {
+        // 暖啟動:目前 cache 是上個 session 的持久化快照,真正內容要等
+        // 這個背景 rebuild 完成(bookmarkCacheReady)。tag prune 等
+        // 「不可拿陳舊快照做破壞性決策」的工作須等該事件(ISSUE-162 B6)。
+        pendingWarmCacheRebuild = true;
         state.buildBookmarkCache()
-            .then(() => document.dispatchEvent(new CustomEvent('bookmarkCacheReady')))
+            .then(() => {
+                pendingWarmCacheRebuild = false;
+                document.dispatchEvent(new CustomEvent('bookmarkCacheReady'));
+            })
             .catch(console.error);
     }
     applyStaticTranslations();
@@ -242,9 +250,20 @@ async function initialize() {
     // and listens for driveSyncStatusChanged (dispatched by initSettingsBridge).
     initDriveSyncBadge().catch(err => console.warn('[sync] badge init failed:', err));
     await tagManager.initTags(); // Load bookmark tags before command palette / tools UI
-    // Prune orphaned bookmarkTags entries (bookmarks deleted while we weren't watching).
-    tagManager.pruneOrphanedBookmarkTags(state.getBookmarkCache() || [])
-        .catch(err => console.warn('[tags] prune failed:', err));
+    // Prune orphaned bookmarkTags entries (bookmarks deleted while we weren't
+    // watching). 時機(ISSUE-162 B6):暖啟動時 cache 是上個 session 的快照、
+    // 真正的 rebuild 在背景跑 — 立刻 prune 會拿陳舊快照誤刪「仍然存在的
+    // 書籤」的 tag 綁定且無法復原。一律等 bookmarkCacheReady(暖啟動)
+    // 或冷啟動已 await 完成的 cache。
+    if (state.isBookmarkCacheInitialized() && !pendingWarmCacheRebuild) {
+        tagManager.pruneOrphanedBookmarkTags(state.getBookmarkCache() || [])
+            .catch(err => console.warn('[tags] prune failed:', err));
+    } else {
+        document.addEventListener('bookmarkCacheReady', () => {
+            tagManager.pruneOrphanedBookmarkTags(state.getBookmarkCache() || [])
+                .catch(err => console.warn('[tags] prune failed:', err));
+        }, { once: true });
+    }
     // Parallelize the two independent storage reads (sync + local) so the
     // total init time doesn't lengthen the critical path before refreshBookmarks
     // settles — CI puppeteer tests were sensitive to even small init delays.

--- a/usecase_tests/unit_tests/searchUtils.test.mjs
+++ b/usecase_tests/unit_tests/searchUtils.test.mjs
@@ -1,5 +1,6 @@
 import { matchesAnyKeyword, extractDomain } from '../../modules/utils/searchUtils.js';
 import { parseSearchQuery, bookmarkMatchesTags } from '../../modules/utils/searchUtils.js';
+import { normalizeTagName } from '../../modules/bookmark/tagManager.js';
 import { searchScope } from '../../modules/utils/searchUtils.js';
 
 describe('searchManager.matchesAnyKeyword', () => {
@@ -109,6 +110,42 @@ describe('bookmarkMatchesTags', () => {
   it('bookmarkTagNames 為空/缺 → 只有 required 也空才 true', () => {
     expect(bookmarkMatchesTags(undefined, ['work'])).toBe(false);
     expect(bookmarkMatchesTags(undefined, [])).toBe(true);
+  });
+});
+
+describe('parseSearchQuery — 字界錨定與全形冒號 (ISSUE-162 B2/B5)', () => {
+  it('montag:9 不是 tag 查詢(token 須錨定字首/空白後)', () => {
+    expect(parseSearchQuery('montag:9')).toEqual({ keywords: ['montag:9'], tags: [] });
+  });
+  it('貼上含 hashtag: 的 URL 不觸發 tag 模式', () => {
+    expect(parseSearchQuery('https://x.com/hashtag:foo')).toEqual({
+      keywords: ['https://x.com/hashtag:foo'], tags: [],
+    });
+  });
+  it('字首與空白後的 tag: 正常解析', () => {
+    expect(parseSearchQuery('tag:work')).toEqual({ keywords: [], tags: ['work'] });
+    expect(parseSearchQuery('react tag:work')).toEqual({ keywords: ['react'], tags: ['work'] });
+  });
+  it('全形冒號 tag：也解析(zh-TW IME)', () => {
+    expect(parseSearchQuery('tag：工作')).toEqual({ keywords: [], tags: ['工作'] });
+    expect(parseSearchQuery('react tag：工作')).toEqual({ keywords: ['react'], tags: ['工作'] });
+  });
+  it('引號形式仍支援錨定', () => {
+    expect(parseSearchQuery('tag:"my work"')).toEqual({ keywords: [], tags: ['my work'] });
+    expect(parseSearchQuery('x tag:"my work" y')).toEqual({ keywords: ['x', 'y'], tags: ['my work'] });
+  });
+});
+
+describe('normalizeTagName (ISSUE-162 B4)', () => {
+  it('剝除雙引號(dot-click token round-trip)', () => {
+    expect(normalizeTagName('say "hi"')).toBe('say hi');
+    expect(normalizeTagName('"quoted"')).toBe('quoted');
+  });
+  it('trim + 截 40 字 + 空值 fallback', () => {
+    expect(normalizeTagName('  work  ')).toBe('work');
+    expect(normalizeTagName('x'.repeat(50))).toHaveLength(40);
+    expect(normalizeTagName('')).toBe('Tag');
+    expect(normalizeTagName('""', 'fallback')).toBe('fallback');
   });
 });
 


### PR DESCRIPTION
Part of #162 (WP4, T1 — spec: `docs/specs/fix/ISSUE-162_tags-search/SPEC.md`).

## 摘要 (Summary)

修復 Tags 與搜尋七缺陷，核心是 **B1 跨視窗互滅**：`tagManager` 是全專案唯一沒訂 `storage.onChanged` 的可變資料集，多視窗下任一 tag 操作會用陳舊整表覆寫他窗剛建立的 tag。

## 📝 變更內容 (Changes)

- **B1**：`initTags` 安裝 onChanged 訂閱 —— reload + JSON 比對（變更才重繪、寫入端自身 echo 不雙重 render）
- **B2/B5**：`tag:` regex 字界錨定 + 全形冒號 `tag：` —— `montag:9`／貼上含 `hashtag:` 的 URL 不再把面板清空；zh-TW IME 全形標點可用
- **B3**：刪除 tag 補發 `refreshBookmarksRequired`，殘留死 dot 消失
- **B4**：`normalizeTagName` 純函式（剝 `"`），dot-click token round-trip 修復
- **B6**：prune 等 `bookmarkCacheReady`，不再拿上個 session 陳舊快照誤刪活的 tag 綁定
- **B7**：dot 9px + 1px 主題感知描邊（WCAG 1.4.11 3:1）

## 🧪 測試 (Testing)

- [x] searchUtils 新增 7 案例（錨定／全形冒號／normalizeTagName）
- [x] unit 260 passed；happy_path E2E 21 suites / 53 tests passed

## 🌐 English Version

Fixes seven tag/search defects. Core: `tagManager` was the only mutable dataset without a `storage.onChanged` subscription — with multiple sidepanels open, any tag operation in one window clobbered tags just created in another (silent last-write-wins data loss); it now reloads on change with JSON-diff gating (no double-render for the writer). The `tag:` token is now word-boundary-anchored and accepts the full-width colon (`tag：`) typed by CJK IMEs, so pasted URLs containing `hashtag:` no longer blank the whole panel. Tag deletion now refreshes bookmark rows (no dead dots); tag names strip double quotes so dot-click tokens round-trip; orphan pruning waits for a trustworthy bookmark cache (`bookmarkCacheReady`) instead of racing the warm-start rebuild; tag dots get a theme-aware 1px border to meet WCAG 1.4.11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)