### PR TITLE
fix(ui): theme-following M3 tokens + a11y state fixes (#162 WP5)

### DIFF
--- a/docs/specs/fix/ISSUE-162_m3-theme-a11y/SPEC.md
+++ b/docs/specs/fix/ISSUE-162_m3-theme-a11y/SPEC.md
@@ -1,0 +1,37 @@
+# [Fix/T1] M3 主題與無障礙修正（#162 WP5：C1~C6）
+
+## 背景與問題
+
+- **C1 [High，Puppeteer 實證]**：四個 color-mix tokens（state-layer ×3、focus-ring）宣告在 `:root`，但主題（內建 `data-theme` 與自訂變數）套在 `body`。CSS custom property 中的 `var()` 在**宣告元素**上即完成替換 → tokens 永遠以 :root 的 GEEK 預設值解析，所有非預設主題的 focus ring 都是 GEEK 綠。
+- **C2 [Med]**：pressed state layer（`:active` 設 `background-color`）被後出的同特異性 `:hover` 規則蓋掉 —— 滑鼠按下必同時 hover，pressed 回饋從未渲染。
+- **C3 [Med]**：Other-Windows 資料夾展開狀態雙機制衝突 —— renderer 用 inline `style.display`、searchManager 用 `.collapsed` class：搜尋命中時 chevron/aria 顯示展開但內容仍隱藏（class 蓋不過 inline style）。
+- **C4 [Low-Med]**：`data-i18n-title` 無任何處理迴圈，6 個元素的 tooltip 永遠空白或硬編碼英文（14 語系皆然）。
+- **C5 [Low]**：新建的「展開」group header 缺初始 `aria-expanded`/`dataset.collapsed`（update 路徑只在狀態變化時寫入）。
+- **C6 [Low]**：`renderIcon` 未知 id 靜默回空字串（`renderIconEl` 卻 fallback 'language'）—— 動態 id 呼叫端打錯字會渲染出隱形按鈕。
+
+## 方案
+
+1. **C1**：四個 color-mix tokens 移到 `body { }` 區塊宣告（主題所在元素），`:root` 留註解指路。
+2. **C2**：`:active` 改寫 `background-image: linear-gradient(token, token)` —— 與 hover 的 `background-color` 不同屬性，直接複合疊加，無特異性競賽。
+3. **C3**：searchManager 的 window-folder 分支改用 inline `style.display`（與 renderer、與 group 分支同機制）；chevron/aria 行為不變。
+4. **C4**：`applyStaticTranslations` 新增 `[data-i18n-title]` 迴圈：設 `title`，icon-only 缺 `aria-label` 時一併補。
+5. **C5**：group header 建立時即寫齊 `aria-expanded`/`dataset.collapsed`/chevron class。
+6. **C6**：`renderIcon` 未知 id → `console.warn` + fallback `'language'`（與 `renderIconEl` 一致）。
+
+## 影響面
+
+`sidepanel.css`（tokens 位置、pressed 疊層）、`modules/searchManager.js`、`sidepanel.js`（i18n-title 迴圈）、`modules/ui/tabRenderer.js`、`modules/icons.js`。無 storage / manifest 變更；i18n 僅「使用既有 key」，無新 key。
+
+## Test Impact
+
+- `happy_path_theme_switch.test.js` 新增 **C1 迴歸斷言**：切到 google 主題後，`getComputedStyle(body).getPropertyValue('--arc-focus-ring')` 內含 `#1a73e8`、不含 GEEK 綠 `#00ff41`。
+- 其餘為視覺/語意修正，由既有 E2E 全套守護。
+
+## 驗收條件
+
+- [ ] 非預設主題下 focus ring 跟隨主題 accent（E2E 斷言）。
+- [ ] 按下任一列/按鈕可見 pressed 疊層（與 hover 複合）。
+- [ ] 搜尋命中 Other-Windows 資料夾時內容真的展開；清除搜尋後 chevron 與內容一致。
+- [ ] 6 個 `data-i18n-title` 元素在非英文語系顯示在地化 tooltip。
+- [ ] 新建展開態 group header 即有 `aria-expanded="true"`。
+- [ ] unit + happy_path E2E 全綠。

--- a/modules/icons.js
+++ b/modules/icons.js
@@ -62,11 +62,18 @@ export function hasIcon(name) {
  * @param {string} name ICONS 的 key
  * @param {{size?:number, className?:string, label?:string}} [opts]
  *   size 寬高(px,預設 16);className(預設 'm3-icon');label 有值則設 role/aria-label,否則 aria-hidden。
- * @returns {string} SVG 字串;name 不存在時回傳空字串。
+ * @returns {string} SVG 字串;name 不存在時警告並 fallback 至 'language' 圖示。
  */
 export function renderIcon(name, { size = 16, className = 'm3-icon', label } = {}) {
-    const inner = ICONS[name];
-    if (!inner) return '';
+    let inner = ICONS[name];
+    if (!inner) {
+        // 與 renderIconEl 一致的 fallback(ISSUE-162 C6):回空字串會讓動態
+        // id 呼叫端(data-icon、driveSyncBadge)在 id 打錯時靜默渲染出
+        // 看不見的按鈕;改 fallback 至 'language' 並警告。
+        console.warn('[icons] unknown icon id:', name, '— falling back to "language"');
+        inner = ICONS.language;
+        if (!inner) return '';
+    }
     // label 跳脫,使函式對未來傳入動態/不可信 label 的呼叫端也安全(現無此用法)。
     const safeLabel = label != null ? String(label).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;') : '';
     const a11y = label ? `role="img" aria-label="${safeLabel}"` : 'aria-hidden="true"';

--- a/modules/searchManager.js
+++ b/modules/searchManager.js
@@ -212,16 +212,19 @@ function filterOtherWindowsTabs(keywords) {
         folder.classList.toggle('hidden', !visible);
         content.classList.toggle('hidden', !visible);
 
-        // 展開/收合（統一使用 CSS class 控制，避免 inline style 衝突）
+        // 展開/收合：必須用 inline style —— otherWindowRenderer 以
+        // style.display 控制這個節點(初始 'none'、點擊 toggle),class 機制
+        // 蓋不過 inline style:搜尋命中時 chevron/aria 顯示展開、內容卻仍
+        // 隱藏;清除搜尋時又反過來(ISSUE-162 C3,同 group 分支的既有做法)。
         const icon = folder.querySelector('.window-icon');
         if (windowCount > 0 && keywords.length > 0) {
             // 有搜尋結果時：展開並顯示
-            content.classList.remove('collapsed');
+            content.style.display = 'block';
             if (icon) icon.classList.remove('is-collapsed');
             folder.setAttribute('aria-expanded', 'true');
         } else if (keywords.length === 0) {
             // 清除搜尋時：收合
-            content.classList.add('collapsed');
+            content.style.display = 'none';
             if (icon) icon.classList.add('is-collapsed');
             folder.setAttribute('aria-expanded', 'false');
         }

--- a/modules/ui/tabRenderer.js
+++ b/modules/ui/tabRenderer.js
@@ -296,9 +296,14 @@ export function renderTabsAndGroups(tabs, groups, { onAddToGroupClick }) {
                 groupHeader.className = 'tab-group-header';
                 groupHeader.tabIndex = 0;
                 groupHeader.setAttribute('role', 'button');
+                // 初始狀態必須在建立時就寫齊(ISSUE-162 C5):updateGroupHeaderElement
+                // 只在 isCollapsed 變化時更新,新建的「展開」header 會卡在
+                // 無 aria-expanded 的狀態(role=button 卻沒有開合語意)。
+                groupHeader.setAttribute('aria-expanded', (!group.collapsed).toString());
+                groupHeader.dataset.collapsed = group.collapsed ? 'true' : 'false';
 
                 const arrow = document.createElement('span');
-                arrow.className = 'tab-group-arrow is-chevron';
+                arrow.className = 'tab-group-arrow is-chevron' + (group.collapsed ? ' is-collapsed' : '');
                 arrow.innerHTML = renderIcon('expand_more', { size: 16 });
 
                 const colorDot = document.createElement('div');

--- a/sidepanel.css
+++ b/sidepanel.css
@@ -36,9 +36,9 @@
     --arc-state-drag: 0.16;
     /* State layer 覆蓋色 — color-mix over 主題 token,使用時依當前主題解析
        (同 settings-input 既有 color-mix 模式;主題切換於 :root 變更 token 即重算) */
-    --arc-state-layer-hover: color-mix(in srgb, var(--text-color-primary) 8%, transparent);
-    --arc-state-layer-pressed: color-mix(in srgb, var(--text-color-primary) 12%, transparent);
-    --arc-state-layer-accent: color-mix(in srgb, var(--accent-color) 14%, transparent);
+    /* (state-layer 與 focus-ring 的 color-mix tokens 移至下方 body 區塊 —
+       它們引用主題變數,而主題套在 body 而非 :root;宣告在 :root 會在
+       :root 的預設值上提早解析,凍結成 GEEK 配色。ISSUE-162 C1) */
 
     /* Elevation 階 (M3-ish);1/3/5 alias 既有 shadow,不改舊名以免破壞既有引用 */
     --arc-elevation-0: none;
@@ -48,8 +48,7 @@
     --arc-elevation-4: 0 8px 24px hsl(0 0% 0% / 0.28);
     --arc-elevation-5: var(--arc-shadow-drag);
 
-    /* 統一 focus ring */
-    --arc-focus-ring: 0 0 0 2px color-mix(in srgb, var(--accent-color) 40%, transparent);
+    /* (--arc-focus-ring 同上,見 body 區塊) */
 
     /* Motion 語意 alias (指向既有 anim token,沿用既有曲線) */
     --arc-motion-short: var(--arc-anim-duration-fast);
@@ -61,6 +60,17 @@
     /* 列垂直間距(密度設定 listDensity;預設 = cozy = 現狀)。水平 padding 維持各列原值。 */
     --list-row-py: 6px;      /* 分頁 / 閱讀清單 */
     --bookmark-row-py: 4px;  /* 書籤 / 視窗資料夾 */
+}
+
+/* 主題相依的 color-mix tokens(ISSUE-162 C1):必須宣告在 body —— 主題(內建
+   data-theme 與自訂 CSS 變數)都套在 body 上;custom property 中的 var() 在
+   「宣告元素」上即完成替換,若宣告在 :root 會永遠拿 :root 的 GEEK 預設值,
+   所有非預設主題的 focus ring / state layer 因此凍結成 GEEK 綠。 */
+body {
+    --arc-state-layer-hover: color-mix(in srgb, var(--text-color-primary) 8%, transparent);
+    --arc-state-layer-pressed: color-mix(in srgb, var(--text-color-primary) 12%, transparent);
+    --arc-state-layer-accent: color-mix(in srgb, var(--accent-color) 14%, transparent);
+    --arc-focus-ring: 0 0 0 2px color-mix(in srgb, var(--accent-color) 40%, transparent);
 }
 
 /* 列間距密度:body[data-density] 由 settingManager.applyDensity 設定。cozy 為預設(不需 override)。 */
@@ -112,7 +122,11 @@ button:focus-visible {
 .context-menu-item:active,
 .workspace-switch-btn:active,
 .workspace-manage__switch:active {
-    background-color: var(--arc-state-layer-pressed);
+    /* 疊層而非取代(ISSUE-162 C2):原本寫 background-color 會被後出的
+       :hover 同特異性規則蓋掉(滑鼠按下時必同時 hover),pressed 回饋從未
+       渲染過。改用 background-image 與 hover 的 background-color 不同屬性,
+       直接複合疊加。 */
+    background-image: linear-gradient(var(--arc-state-layer-pressed), var(--arc-state-layer-pressed));
 }
 
 

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -168,6 +168,19 @@ function applyStaticTranslations() {
         }
     });
 
+    // data-i18n-title:tooltip 在地化(ISSUE-162 C4)。先前無任何處理迴圈,
+    // 6 個元素的 title 永遠是空字串或硬編碼英文(14 語系皆然)。icon-only
+    // 按鈕缺 aria-label 時一併補上。
+    document.querySelectorAll('[data-i18n-title]').forEach(el => {
+        const msg = api.getMessage(el.getAttribute('data-i18n-title'));
+        if (msg) {
+            el.title = msg;
+            if (!el.hasAttribute('aria-label') || !el.getAttribute('aria-label')) {
+                el.setAttribute('aria-label', msg);
+            }
+        }
+    });
+
     // 注入 Material Symbols 圖示:[data-icon] 元素(icon-only 按鈕或 .btn-icon span)。
     // 與 data-i18n 分離(label 在 .btn-label),故文字在地化不會洗掉圖示。
     document.querySelectorAll('[data-icon]').forEach(el => {

--- a/usecase_tests/puppeteer_tests/happy_path_theme_switch.test.js
+++ b/usecase_tests/puppeteer_tests/happy_path_theme_switch.test.js
@@ -57,6 +57,27 @@ describe('Theme Switch Use Case (via options page)', () => {
         await waitForTheme(page, originalTheme);
     }, 120000);
 
+    test('M3 focus-ring token follows the active theme accent (ISSUE-162 C1)', async () => {
+        const originalTheme = await page.evaluate(() => document.body.dataset.theme || 'geek');
+
+        await optionsPage.select('#theme-select-dropdown', 'google');
+        await waitForTheme(page, 'google');
+
+        // color-mix tokens 必須宣告在 body(主題所在元素)而非 :root,
+        // 否則 var() 在 :root 提早解析、永遠凍結成 GEEK 綠 #00ff41。
+        // computed custom property 已完成 var() 替換 — 直接斷言其內含
+        // google accent(#1a73e8),且不含 GEEK 綠。
+        const ring = await page.evaluate(() =>
+            getComputedStyle(document.body).getPropertyValue('--arc-focus-ring'));
+        const normalized = ring.toLowerCase();
+        expect(normalized).toContain('#1a73e8');
+        expect(normalized).not.toContain('#00ff41');
+
+        // Restore.
+        await optionsPage.select('#theme-select-dropdown', originalTheme);
+        await waitForTheme(page, originalTheme);
+    }, 120000);
+
     test('the theme dropdown exposes all expected options', async () => {
         const themeOptions = await optionsPage.$$eval(
             '#theme-select-dropdown option',


### PR DESCRIPTION
Part of #162 (WP5, T1 — spec: `docs/specs/fix/ISSUE-162_m3-theme-a11y/SPEC.md`).

## 摘要 (Summary)

修復 M3 改版遺留的六項主題／無障礙缺陷。核心是 **C1（Puppeteer 實證）**：color-mix tokens 宣告在 `:root` 而主題套在 `body` —— `var()` 在宣告元素上提早解析，所有非預設主題的 focus ring 凍結成 GEEK 綠。

## 📝 變更內容 (Changes)

| 缺陷 | 修法 |
|---|---|
| **C1** focus ring 凍結 GEEK 綠 | 四個 color-mix tokens 移到 `body` 區塊（主題所在元素） |
| **C2** pressed 回饋從未渲染 | `:active` 改 `background-image` 疊層，與 hover 的 `background-color` 複合而非互蓋 |
| **C3** Other-Windows 搜尋展開脫鉤 | searchManager 改 inline `style.display`，與 renderer 同機制 |
| **C4** tooltip 永遠空白/英文 | 新增 `[data-i18n-title]` 處理迴圈（6 元素 ×14 語系），icon-only 補 aria-label |
| **C5** 新建 group header 缺 aria | 建立時即寫齊 `aria-expanded`/`dataset.collapsed`/chevron |
| **C6** renderIcon 靜默空字串 | warn + fallback `'language'`（與 renderIconEl 一致） |

## 🧪 測試 (Testing)

- [x] `happy_path_theme_switch` 新增 **C1 迴歸斷言**：google 主題下 `--arc-focus-ring` 計算值含 `#1a73e8`、不含 `#00ff41`
- [x] unit 253 passed；happy_path E2E 21 suites / **54** tests passed

## 🌐 English Version

Fixes six theme/a11y defects left over from the M3 overhaul. Core (empirically verified with Puppeteer): the color-mix tokens (state layers + focus ring) were declared on `:root` while themes apply to `body` — `var()` inside a custom property substitutes on the declaring element, freezing every non-default theme's focus ring to the GEEK green. Tokens now live on `body`. The pressed state layer becomes a `background-image` overlay (the old `background-color` rule was always beaten by later hover rules); the Other-Windows folder expand state uses one mechanism (inline display) instead of two conflicting ones; `data-i18n-title` finally gets a processing loop (6 elements × 14 locales); group headers get their initial `aria-expanded`; `renderIcon` falls back to 'language' with a warning instead of silently rendering nothing. A regression E2E asserts the focus-ring token follows the active theme accent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)