### PR TITLE
fix(workspace): rebind on window reopen + stable switcher order (#162 WP2)

### DIFF
--- a/docs/specs/fix/ISSUE-162_rebind-coverage/SPEC.md
+++ b/docs/specs/fix/ISSUE-162_rebind-coverage/SPEC.md
@@ -1,0 +1,32 @@
+# [Fix/T1] Rebind 涵蓋面補強（#162 WP2：F6 + lastActiveAt）
+
+## 背景與問題
+
+- **F6 [Med]**：工作區自動重綁只掛在 `runtime.onStartup`。macOS 上 Chrome 在最後一扇視窗關閉後仍常駐 —— 從 Dock／⇧⌘T 重開視窗**不是** browser startup，`rebindAfterStartup` 永不執行，視窗回來全是「無工作區」（關窗時 `windows.onRemoved` 已按設計清掉綁定）。這是本專案開發平台（macOS）的主要使用路徑。
+- **lastActiveAt scramble [Low]**：rebind 逐筆呼叫 `setActiveWorkspace` 會 bump `lastActiveAt`，每次重啟都打亂切換器的 recency 排序。
+
+## 方案
+
+1. **F6**：`windows.onCreated`（僅 normal 視窗）→ 單一共用 4s debounce → `rebindOnce()`。
+   - Cmd+N 空白新窗：`rebindOnce` 內部過濾（無 http 分頁→無候選）→ 廉價 no-op。
+   - 瀏覽器啟動時的 onCreated 風暴：debounce 收斂成一次額外 no-op pass（與 onStartup 路徑並存無害）。
+   - 回復視窗的分頁即使未載入也立即帶 url，4s 足夠 settle。
+2. **lastActiveAt**：rebind 的綁定改傳 `{ touch: false }`（WP1 schema v2 新增的參數；在 v2 合併前是被忽略的多餘參數 —— 行為照舊，v2 合併後自動生效，**與 WP1 PR 無檔案交集、無合併順序要求**）。
+
+排除的替代方案：`windows.onRestored` 不存在於 extension API；`sessions.onChanged` 噪音大且不保證涵蓋 Dock 重開。
+
+## 影響面
+
+僅 `modules/workspace/workspaceLifecycle.js`（新 listener + debounce 常數 + touch 參數）。無 storage / manifest / i18n 變更。
+
+## Test Impact
+
+- 匹配邏輯本身由 `workspaceMatching.test.mjs` 守護（含 WP1 margin 案例）；本 WP 是事件接線。
+- E2E `happy_path_` 全套需綠（rebindOnce 在測試環境為 no-op：測試視窗無對應快照）。
+
+## 驗收條件
+
+- [ ] macOS「關最後一扇窗 → Dock 重開」路徑：視窗重綁回原工作區（手動驗證步驟：綁定工作區 → 關窗 → Dock 開新窗 → ⇧⌘T 回復 → ≤5s 內 sidepanel 顯示原工作區）。
+- [ ] Cmd+N 純新窗不觸發任何綁定。
+- [ ] 重啟/重綁後切換器排序不變（touch:false，於 WP1 合併後生效）。
+- [ ] unit + happy_path E2E 全綠。

--- a/modules/workspace/workspaceLifecycle.js
+++ b/modules/workspace/workspaceLifecycle.js
@@ -48,8 +48,16 @@ const STARTUP_RETRY_MS = 8000;
  *  pass runs, while refusing coincidental overlaps. */
 const REBIND_THRESHOLD = 0.6;
 
+/** Debounce for the windows.onCreated re-bind path (ISSUE-162 F6): long
+ *  enough for ⇧⌘T / Dock-reopen to materialize its tabs (restored-but-unloaded
+ *  tabs carry their url immediately), short enough to feel automatic. */
+const REOPEN_REBIND_DEBOUNCE_MS = 4000;
+
 /** @type {Map<number, ReturnType<typeof setTimeout>>} windowId → pending snapshot timer */
 const pendingSnapshots = new Map();
+
+/** @type {ReturnType<typeof setTimeout>|undefined} single shared reopen-rebind timer */
+let reopenRebindTimer;
 
 /**
  * Registers all listeners. MUST be called synchronously from the service
@@ -94,6 +102,22 @@ export function initWorkspaceLifecycle() {
     chrome.runtime.onStartup.addListener(() => {
         rebindAfterStartup().catch(err =>
             console.warn('[workspace-lifecycle] startup rebind failed:', err));
+    });
+
+    // --- reopen re-binding (ISSUE-162 F6) ----------------------------------------
+    // macOS keeps Chrome alive after the last window closes; reopening from the
+    // Dock / ⇧⌘T is NOT a browser startup, so onStartup never fires and restored
+    // windows would come back unbound forever. A debounced rebind on
+    // windows.onCreated covers that path. Plain new windows (Cmd+N) are a cheap
+    // no-op inside rebindOnce (no http tabs → no match candidates); the startup
+    // burst of onCreated events collapses into one extra no-op pass.
+    chrome.windows.onCreated.addListener(win => {
+        if (win && win.type && win.type !== 'normal') return;
+        clearTimeout(reopenRebindTimer);
+        reopenRebindTimer = setTimeout(() => {
+            rebindOnce().catch(err =>
+                console.warn('[workspace-lifecycle] reopen rebind failed:', err));
+        }, REOPEN_REBIND_DEBOUNCE_MS);
     });
 }
 
@@ -170,7 +194,10 @@ async function rebindOnce() {
         windowEntries, candidates, { threshold: REBIND_THRESHOLD });
 
     for (const m of matches) {
-        await workspaceManager.setActiveWorkspace(m.windowId, m.workspaceId);
+        // touch:false(ISSUE-162 WP2):自動重綁不是使用者活動,不可 bump
+        // lastActiveAt — 否則每次重啟都打亂切換器的 recency 排序。
+        // (在 schema v2 之前的 setActiveWorkspace 簽名上是無害的多餘參數。)
+        await workspaceManager.setActiveWorkspace(m.windowId, m.workspaceId, { touch: false });
         console.info(`[workspace-lifecycle] rebound window ${m.windowId} → workspace ${m.workspaceId} (score ${m.score.toFixed(2)})`);
     }
     return { matched: matches.length, unboundLeft: windowEntries.length - matches.length };


### PR DESCRIPTION
Part of #162 (WP2, T1 — spec: `docs/specs/fix/ISSUE-162_rebind-coverage/SPEC.md`).

## 摘要 (Summary)

**F6**：自動重綁只掛在 `runtime.onStartup` —— macOS 關最後一扇窗後 Chrome 常駐，Dock／⇧⌘T 重開不是 startup，視窗回來永遠是「無工作區」。本 PR 補上 `windows.onCreated` 重綁路徑，並讓自動重綁不再打亂切換器排序。

## 📝 變更內容 (Changes)

- `windows.onCreated`（僅 normal 視窗）→ 單一 4s debounce → `rebindOnce()`；Cmd+N 空白窗為廉價 no-op，啟動風暴收斂為一次無害 pass
- rebind 綁定改傳 `{ touch: false }`，不 bump `lastActiveAt`（參數由 #163 引入；合併前為被忽略的多餘參數，**兩 PR 無檔案交集、無合併順序要求**）

## 🧪 測試 (Testing)

- [x] unit 253 passed；happy_path E2E 21 suites / 53 tests passed
- [ ] 手動驗證（macOS）：綁定工作區 → 關窗 → Dock 重開 → ⇧⌘T 回復 → ≤5s 內 sidepanel 顯示原工作區

## 🌐 English Version

Re-binding only ran on `runtime.onStartup`, but on macOS Chrome stays alive after the last window closes — reopening from the Dock / ⇧⌘T is not a startup, so restored windows came back unbound forever (F6). A debounced (4s) `rebindOnce()` on `windows.onCreated` (normal windows only) covers that path; plain new windows are a cheap no-op. Rebinding now passes `{ touch: false }` so automatic binding no longer scrambles the switcher's recency order (the option ships in #163; before that merge it is an ignored extra argument — the two PRs share no files and merge in any order).

🤖 Generated with [Claude Code](https://claude.com/claude-code)