### PR TITLE
feat(ux): unify Spotlight/tags/workspace interactions (#162 WP6)

### DIFF
--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -909,6 +909,12 @@
   "cmdPaletteGroupWorkspaces": {
     "message": "Workspaces"
   },
+  "cmdPaletteWorkspaceTabs": {
+    "message": "$count$ Tab(s)",
+    "placeholders": {
+      "count": { "content": "$1" }
+    }
+  },
   "cmdPaletteHintClose": {
     "message": "schließen"
   },

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -801,6 +801,12 @@
   "cmdPaletteGroupWorkspaces": {
     "message": "Workspaces"
   },
+  "cmdPaletteWorkspaceTabs": {
+    "message": "$count$ tab(s)",
+    "placeholders": {
+      "count": { "content": "$1" }
+    }
+  },
   "cmdPaletteActionCreateWorkspace": {
     "message": "Create workspace from current tabs"
   },

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -909,6 +909,12 @@
   "cmdPaletteGroupWorkspaces": {
     "message": "Workspaces"
   },
+  "cmdPaletteWorkspaceTabs": {
+    "message": "$count$ pestaña(s)",
+    "placeholders": {
+      "count": { "content": "$1" }
+    }
+  },
   "cmdPaletteHintClose": {
     "message": "cerrar"
   },

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -909,6 +909,12 @@
   "cmdPaletteGroupWorkspaces": {
     "message": "Workspaces"
   },
+  "cmdPaletteWorkspaceTabs": {
+    "message": "$count$ onglet(s)",
+    "placeholders": {
+      "count": { "content": "$1" }
+    }
+  },
   "cmdPaletteHintClose": {
     "message": "fermer"
   },

--- a/_locales/hi/messages.json
+++ b/_locales/hi/messages.json
@@ -909,6 +909,12 @@
   "cmdPaletteGroupWorkspaces": {
     "message": "Workspaces"
   },
+  "cmdPaletteWorkspaceTabs": {
+    "message": "$count$ टैब",
+    "placeholders": {
+      "count": { "content": "$1" }
+    }
+  },
   "cmdPaletteHintClose": {
     "message": "बंद करें"
   },

--- a/_locales/id/messages.json
+++ b/_locales/id/messages.json
@@ -909,6 +909,12 @@
   "cmdPaletteGroupWorkspaces": {
     "message": "Workspaces"
   },
+  "cmdPaletteWorkspaceTabs": {
+    "message": "$count$ tab",
+    "placeholders": {
+      "count": { "content": "$1" }
+    }
+  },
   "cmdPaletteHintClose": {
     "message": "tutup"
   },

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -909,6 +909,12 @@
   "cmdPaletteGroupWorkspaces": {
     "message": "Workspaces"
   },
+  "cmdPaletteWorkspaceTabs": {
+    "message": "タブ $count$ 件",
+    "placeholders": {
+      "count": { "content": "$1" }
+    }
+  },
   "cmdPaletteHintClose": {
     "message": "閉じる"
   },

--- a/_locales/ko/messages.json
+++ b/_locales/ko/messages.json
@@ -909,6 +909,12 @@
   "cmdPaletteGroupWorkspaces": {
     "message": "Workspaces"
   },
+  "cmdPaletteWorkspaceTabs": {
+    "message": "탭 $count$개",
+    "placeholders": {
+      "count": { "content": "$1" }
+    }
+  },
   "cmdPaletteHintClose": {
     "message": "닫기"
   },

--- a/_locales/pt_BR/messages.json
+++ b/_locales/pt_BR/messages.json
@@ -909,6 +909,12 @@
   "cmdPaletteGroupWorkspaces": {
     "message": "Workspaces"
   },
+  "cmdPaletteWorkspaceTabs": {
+    "message": "$count$ aba(s)",
+    "placeholders": {
+      "count": { "content": "$1" }
+    }
+  },
   "cmdPaletteHintClose": {
     "message": "fechar"
   },

--- a/_locales/ru/messages.json
+++ b/_locales/ru/messages.json
@@ -909,6 +909,12 @@
   "cmdPaletteGroupWorkspaces": {
     "message": "Workspaces"
   },
+  "cmdPaletteWorkspaceTabs": {
+    "message": "Вкладок: $count$",
+    "placeholders": {
+      "count": { "content": "$1" }
+    }
+  },
   "cmdPaletteHintClose": {
     "message": "закрыть"
   },

--- a/_locales/th/messages.json
+++ b/_locales/th/messages.json
@@ -909,6 +909,12 @@
   "cmdPaletteGroupWorkspaces": {
     "message": "Workspaces"
   },
+  "cmdPaletteWorkspaceTabs": {
+    "message": "$count$ แท็บ",
+    "placeholders": {
+      "count": { "content": "$1" }
+    }
+  },
   "cmdPaletteHintClose": {
     "message": "ปิด"
   },

--- a/_locales/vi/messages.json
+++ b/_locales/vi/messages.json
@@ -909,6 +909,12 @@
   "cmdPaletteGroupWorkspaces": {
     "message": "Workspaces"
   },
+  "cmdPaletteWorkspaceTabs": {
+    "message": "$count$ thẻ",
+    "placeholders": {
+      "count": { "content": "$1" }
+    }
+  },
   "cmdPaletteHintClose": {
     "message": "đóng"
   },

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -798,6 +798,12 @@
   "cmdPaletteGroupWorkspaces": {
     "message": "工作区"
   },
+  "cmdPaletteWorkspaceTabs": {
+    "message": "$count$ 个标签页",
+    "placeholders": {
+      "count": { "content": "$1" }
+    }
+  },
   "cmdPaletteActionCreateWorkspace": {
     "message": "从当前标签页创建工作区"
   },

--- a/_locales/zh_TW/messages.json
+++ b/_locales/zh_TW/messages.json
@@ -798,6 +798,12 @@
   "cmdPaletteGroupWorkspaces": {
     "message": "工作區"
   },
+  "cmdPaletteWorkspaceTabs": {
+    "message": "$count$ 個分頁",
+    "placeholders": {
+      "count": { "content": "$1" }
+    }
+  },
   "cmdPaletteActionCreateWorkspace": {
     "message": "從當前分頁建立工作區"
   },

--- a/docs/specs/feature/ISSUE-162_ux-integration/SPEC.md
+++ b/docs/specs/feature/ISSUE-162_ux-integration/SPEC.md
@@ -1,0 +1,34 @@
+# [Feature/T1] UX 整合包（#162 WP6）
+
+## 背景與問題
+
+四路審查的 [UX] 觀察：Spotlight 與 sidepanel 是兩套割裂的體驗 —— 切工作區繞道 sidepanel（A 窗彈 panel、焦點卻跳去 B 窗）、兩個搜尋面是兩套查詢語言（Spotlight 不認 `tag:`）；dot-click 只能單 tag（引擎卻支援 AND）；workspace 按鈕無「可開管理」暗示；tag 建立兩個入口行為不一致（tagPicker 永遠藍色、無唯一性檢查）；palette 工作區列硬編英文 `N tab(s)`；density/radius 收斂半途而廢。
+
+## 方案（逐項小步、互不依賴）
+
+1. **Spotlight 直切工作區**：palette workspace handler 直呼 `switchWorkspace(id, originWindowId)`（非破壞性 focus-or-open；spotlight 已 init workspaceManager）。不再 `requestPanelAction` 繞道。
+2. **Spotlight 支援 `tag:`**：`searchAll` 開頭以 `parseSearchQuery`（重用純函式）解析；命中 tag 時僅書籤參與（= sidepanel 隱藏非書籤區段的對等行為），AND 語意與 sidepanel 一致；spotlight init 補 `tagManager.initTags()`。
+3. **Dot-click 組合**：append token（去重）而非取代 —— 解鎖引擎本就支援的多 tag AND。
+4. **Workspace 按鈕 affordance**：trailing `expand_more` chevron（aria-hidden，label 已有 a11y）。
+5. **Tag 入口一致化**：tagPicker「+ New tag」改用 `showTagDialog` 色彩對話框；新增 `findTagByName`（不分大小寫）—— 兩個建立入口同名沿用既有 tag（tagPicker 直接勾選），杜絕 Work/work 並存。
+6. **palette 工作區列 i18n**：新 key `cmdPaletteWorkspaceTabs`（帶 `$count$` placeholder）×14 語系。
+7. **Density/radius 收斂**：`.tab-group-header` padding 改 `var(--list-row-py)`、radius 2px→`--arc-radius-sm`；`.workspace-manage__create`/`.drive-sync-badge`/`.custom-theme-panel` 4px→`--arc-radius-xs`。
+
+## 影響面
+
+`dataProvider.js`、`spotlight.js`、`bookmarkRenderer.js`、`tagPicker.js`、`bookmarkToolsUI.js`、`tagManager.js`（新純函式）、`sidepanel.html`、`sidepanel.css`、`_locales/*/messages.json` ×14。無 storage schema / manifest 變更。
+
+## Test Impact
+
+- 純函式重用（parseSearchQuery/bookmarkMatchesTags）已有測試；`findTagByName` 行為簡單（大小寫不敏感查找）。
+- E2E `happy_path_` 全套需綠（含 spotlight 搜尋）。
+- i18n：14 檔 JSON 插入後逐一 `json.load` 驗證。
+
+## 驗收條件
+
+- [ ] Spotlight 選工作區 → 直接聚焦/開啟工作區視窗，不彈 sidepanel。
+- [ ] Spotlight 輸入 `tag:work` → 僅書籤群組、結果與 sidepanel 同。
+- [ ] 連點兩顆 dot → search box 為 `tag:a tag:b`（AND）。
+- [ ] 兩個建立入口：同名（含大小寫差異）不再產生第二顆 tag。
+- [ ] palette 工作區列 subtitle 隨 UI 語言在地化。
+- [ ] unit + happy_path E2E 全綠。

--- a/modules/bookmark/bookmarkToolsUI.js
+++ b/modules/bookmark/bookmarkToolsUI.js
@@ -118,6 +118,8 @@ function renderTagsView(root) {
             title: api.getMessage('bmToolsCreateTagPrompt') || 'New tag',
         });
         if (!res || !res.name) return;
+        // 名稱唯一性(ISSUE-162 WP6):同名 tag 已在列表,不重複建立。
+        if (tagManager.findTagByName(res.name)) return;
         const tag = await tagManager.createTag({ name: res.name, color: res.color });
         const empty = list.querySelector('.bm-tools__empty');
         if (empty) empty.remove();

--- a/modules/bookmark/tagManager.js
+++ b/modules/bookmark/tagManager.js
@@ -56,6 +56,18 @@ export function getPresetColors() {
 }
 
 /**
+ * 以名稱(不分大小寫)尋找既有 tag。建立入口用來防重複(ISSUE-162 WP6):
+ * tag: 查詢按小寫名稱比對,Work/work 並存時查詢無法區分、dots 卻兩顆。
+ * @param {string} name
+ * @returns {object|null}
+ */
+export function findTagByName(name) {
+    const n = String(name || '').trim().toLowerCase();
+    if (!n) return null;
+    return Object.values(tags).find(t => t.name.toLowerCase() === n) || null;
+}
+
+/**
  * @param {{name: string, color?: string}} args
  * @returns {Promise<object>}
  */

--- a/modules/bookmark/tagPicker.js
+++ b/modules/bookmark/tagPicker.js
@@ -66,12 +66,20 @@ export function createTagPicker(initialTagIds = []) {
     createBtn.className = 'tag-picker__create';
     createBtn.textContent = api.getMessage('bmToolsCreateTag') || '+ New tag';
     createBtn.addEventListener('click', async () => {
-        const name = await modal.showPrompt({
-            title: api.getMessage('bmToolsCreateTagPrompt') || 'New tag name',
-            defaultValue: '',
+        // 與 bm-tools 同一個色彩對話框(ISSUE-162 WP6):原本走 showPrompt,
+        // 從這裡建立的 tag 永遠是預設藍,兩個入口行為不一致。
+        const res = await modal.showTagDialog({
+            title: api.getMessage('bmToolsCreateTagPrompt') || 'New tag',
         });
-        if (!name || !name.trim()) return;
-        const tag = await tagManager.createTag({ name: name.trim() });
+        if (!res || !res.name) return;
+        // 名稱唯一性:同名(不分大小寫)沿用既有 tag 並直接勾選。
+        const existing = tagManager.findTagByName(res.name);
+        if (existing) {
+            const cb = list.querySelector(`input[value="${existing.id}"]`);
+            if (cb && !cb.checked) cb.click();
+            return;
+        }
+        const tag = await tagManager.createTag({ name: res.name, color: res.color });
         selected.add(tag.id);
         addRow(tag);
         root.dispatchEvent(new CustomEvent('tagselectionchange', {

--- a/modules/commandPalette/dataProvider.js
+++ b/modules/commandPalette/dataProvider.js
@@ -9,8 +9,11 @@ import * as state from '../stateManager.js';
 import * as api from '../apiManager.js';
 import * as readingListManager from '../readingListManager.js';
 import * as wsManager from '../workspace/workspaceManager.js';
+import * as tagManager from '../bookmark/tagManager.js';
+import { parseSearchQuery, bookmarkMatchesTags } from '../utils/searchUtils.js';
 import { buildActions } from './actions.js';
-import { requestPanelAction, openUrlInOrigin } from './panelBridge.js';
+import { openUrlInOrigin } from './panelBridge.js';
+import { getOriginWindowId } from './searchContext.js';
 
 const MAX_RESULTS_PER_GROUP = 8;
 
@@ -33,7 +36,20 @@ const MAX_RESULTS_PER_GROUP = 8;
  * @returns {Promise<Array<{type: string, titleKey: string, items: PaletteItem[]}>>}
  */
 export async function searchAll(query) {
-    const q = (query || '').trim().toLowerCase();
+    const raw = (query || '').trim();
+
+    // tag: 查詢(ISSUE-162 WP6):與 sidepanel 搜尋同一查詢語言 — 解析
+    // 重用 parseSearchQuery 純函式;命中時僅書籤參與(sidepanel 的對等
+    // 行為是隱藏非書籤區段),其他來源讓位。
+    const parsed = parseSearchQuery(raw);
+    if (parsed.tags.length > 0) {
+        const items = getTaggedBookmarkResults(parsed.keywords, parsed.tags);
+        return items.length > 0
+            ? [{ type: 'bookmark', titleKey: 'cmdPaletteGroupBookmarks', items }]
+            : [];
+    }
+
+    const q = raw.toLowerCase();
 
     const [tabs, readingList] = await Promise.all([
         getTabResults(q),
@@ -59,9 +75,33 @@ function getWorkspaceResults(q) {
         type: 'workspace',
         icon: w.icon,
         title: w.name,
-        subtitle: `${(w.tabSnapshot || []).length} tab(s)`,
-        handler: () => requestPanelAction('switch-workspace', { workspaceId: w.id }),
+        subtitle: api.getMessage('cmdPaletteWorkspaceTabs', [String((w.tabSnapshot || []).length)])
+            || `${(w.tabSnapshot || []).length} tab(s)`,
+        // 直接切換(ISSUE-162 WP6):switchWorkspace 是非破壞性 focus-or-open,
+        // spotlight context 已 init workspaceManager — 不再繞道 sidepanel
+        // (舊路徑會在來源視窗彈出 panel、焦點卻跳去工作區視窗,觀感破碎)。
+        handler: () => wsManager.switchWorkspace(w.id, getOriginWindowId()),
     }));
+}
+
+/** tag: 查詢的書籤結果(AND 語意:全部 tag 命中 + 全部關鍵字命中)。 */
+function getTaggedBookmarkResults(keywords, tags) {
+    const cache = state.getBookmarkCache() || [];
+    return cache
+        .filter(b => b.type === 'bookmark')
+        .filter(b => bookmarkMatchesTags(
+            tagManager.getTagsForBookmark(b.id).map(t => t.name), tags))
+        .filter(b => keywords.every(k =>
+            ((b.title || '') + ' ' + (b.url || '')).toLowerCase().includes(k)))
+        .slice(0, MAX_RESULTS_PER_GROUP)
+        .map(b => ({
+            id: 'bookmark-' + b.id,
+            type: 'bookmark',
+            icon: 'bookmark',
+            title: b.title || '(untitled)',
+            subtitle: b.url,
+            handler: () => openUrlInOrigin(b.url),
+        }));
 }
 
 async function getTabResults(q) {

--- a/modules/ui/bookmarkRenderer.js
+++ b/modules/ui/bookmarkRenderer.js
@@ -190,7 +190,12 @@ function initBookmarkListeners(container) {
                 const token = /\s/.test(name) ? `tag:"${name}"` : `tag:${name}`;
                 const box = document.getElementById('search-box');
                 if (box) {
-                    box.value = token;
+                    // 組合而非取代(ISSUE-162 WP6):引擎本就支援多 tag AND 與
+                    // 關鍵字並用;再點同一顆 dot 不重複附加。
+                    const cur = box.value.trim();
+                    if (!cur.includes(token)) {
+                        box.value = cur ? `${cur} ${token}` : token;
+                    }
                     box.dispatchEvent(new Event('input', { bubbles: true }));
                     box.focus();
                 }

--- a/sidepanel.css
+++ b/sidepanel.css
@@ -798,9 +798,11 @@ mark.url-match {
 .tab-group-header {
     display: flex;
     align-items: center;
-    padding: 4px 8px;
+    /* 跟隨 density 設定(ISSUE-162 WP6):固定 padding 會讓 compact/comfortable
+       下的列表節奏混雜;radius 一併收斂到 shape token(原 2px 自成一格)。 */
+    padding: var(--list-row-py, 4px) 8px;
     cursor: default;
-    border-radius: 2px;
+    border-radius: var(--arc-radius-sm);
     margin-top: 6px;
     background-color: var(--group-bg-color);
     transition: background-color 0.2s ease;
@@ -1600,7 +1602,7 @@ mark.url-match {
     padding: 12px;
     background-color: var(--main-bg-color);
     border: 1px solid var(--border-color);
-    border-radius: 4px;
+    border-radius: var(--arc-radius-xs);
 }
 
 .color-picker-row {
@@ -3252,6 +3254,12 @@ mark.url-match {
     box-shadow: var(--arc-focus-ring);
 }
 
+.workspace-switch-chevron {
+    flex: 0 0 auto;
+    display: inline-flex;
+    opacity: 0.55;
+}
+
 .workspace-switch-label {
     min-width: 0;
     overflow: hidden;
@@ -3270,7 +3278,7 @@ mark.url-match {
     font-size: 0.72em;
     line-height: 1;
     padding: 2px 5px;
-    border-radius: 4px;
+    border-radius: var(--arc-radius-xs);
     white-space: nowrap;
     user-select: none;
     color: var(--text-color-primary);
@@ -3417,7 +3425,7 @@ mark.url-match {
     width: 100%;
     padding: 8px;
     border: 1px dashed var(--border-color);
-    border-radius: 4px;
+    border-radius: var(--arc-radius-xs);
     background: transparent;
     color: var(--text-color-primary);
     font-size: 0.9em;

--- a/sidepanel.html
+++ b/sidepanel.html
@@ -14,6 +14,8 @@
     <div id="workspace-row" class="workspace-row">
         <button id="workspace-switch-btn" class="workspace-switch-btn">
             <span class="workspace-switch-label"></span>
+            <!-- 開啟管理 dialog 的視覺暗示(ISSUE-162 WP6):純名稱按鈕看不出可點開 -->
+            <span class="workspace-switch-chevron" data-icon="expand_more" data-icon-size="16" aria-hidden="true"></span>
         </button>
         <!-- Drive-sync status indicator. Hidden until a status arrives; updated
              live via the driveSyncStatusChanged event (see modules/ui/driveSyncBadge.js). -->

--- a/spotlight.js
+++ b/spotlight.js
@@ -3,6 +3,7 @@ import { applyTheme } from './modules/ui/settingManager.js';
 import * as customTheme from './modules/ui/customThemeManager.js';
 import * as state from './modules/stateManager.js';
 import * as workspaceManager from './modules/workspace/workspaceManager.js';
+import * as tagManager from './modules/bookmark/tagManager.js';
 import { setOriginWindowId } from './modules/commandPalette/searchContext.js';
 import { initSpotlight } from './modules/spotlight/spotlightController.js';
 
@@ -42,6 +43,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         state.initAiGroupingVisibility(),
         state.initAiCleanupVisibility(),
         workspaceManager.initWorkspaces(),
+        tagManager.initTags(), // tag: 查詢需要(ISSUE-162 WP6)
     ]);
 
     initSpotlight();


### PR DESCRIPTION
Part of #162 (WP6, T1 — spec: `docs/specs/feature/ISSUE-162_ux-integration/SPEC.md`). Closes #162（六個工作包全數出 PR）。

## 摘要 (Summary)

UX 整合包：把四路審查指出的「割裂體驗」縫起來 —— Spotlight 直切工作區、`tag:` 查詢語言統一、dot-click 多 tag AND、tag 建立入口一致化、workspace 按鈕 affordance、palette i18n、density/radius 收斂。

## 📝 變更內容 (Changes)

- **Spotlight 直切工作區**：handler 直呼 `switchWorkspace`（focus-or-open），不再繞道 sidepanel（舊路徑：A 窗彈 panel、焦點跳去 B 窗）
- **Spotlight 支援 `tag:`**：重用 `parseSearchQuery`；tag 查詢僅書籤參與，與 sidepanel 同語意；spotlight init 補 `initTags()`
- **Dot-click 組合**：append + 去重 → 多 tag AND（引擎本就支援，UI 終於用得到）
- **Tag 入口一致化**：tagPicker 改色彩對話框；`findTagByName` 唯一性 —— 同名沿用既有 tag，杜絕 Work/work 並存
- **Workspace 按鈕**：trailing `expand_more` chevron
- **i18n**：`cmdPaletteWorkspaceTabs`（`$count$`）×14 語系，palette 工作區列不再硬編英文
- **Density/radius**：group header 跟隨 `--list-row-py`；三處硬編 radius 收斂到 shape tokens

## 🧪 測試 (Testing)

- [x] unit 253 passed；happy_path E2E 21 suites / 53 tests passed
- [x] 14 locale JSON 逐一 `json.load` 驗證
- [ ] 手動：Spotlight 選工作區直接聚焦；`tag:work` 僅書籤群組；連點兩 dot 得 `tag:a tag:b`

## 🌐 English Version

UX integration pass: Spotlight workspace rows now call the non-destructive `switchWorkspace` directly (no more side-panel detour that popped a panel in window A while focus jumped to window B); Spotlight speaks the same `tag:` query language as the sidepanel (reusing the pure `parseSearchQuery`/`bookmarkMatchesTags` helpers, bookmark-only scope); clicking tag dots now composes multi-tag AND filters instead of replacing the query; both tag-creation entry points share the color dialog and enforce case-insensitive name uniqueness via the new `findTagByName`; the workspace switcher button gets a trailing chevron affordance; the palette's workspace subtitle is localized across all 14 locales (`cmdPaletteWorkspaceTabs` with a `$count$` placeholder); group headers follow the density setting and three hardcoded radii converge on the M3 shape tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)