### PR TITLE
chore(ci): bump checkout/setup-node to v6 for forced Node 24 migration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
     - name: Check out repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Set up Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: '20'
         cache: 'npm'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -59,7 +59,7 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
     - name: Check out repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Set up Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: '20'
         cache: 'npm'


### PR DESCRIPTION
## 摘要 (Summary)

v1.15.2 release run 的 annotation：GitHub Actions 於 **2026-06-16** 起強制以 Node.js 24 執行 JS actions（Node 20 於 2026-09-16 自 runner 移除）。本 PR 預先升級受影響的 actions，避免到期爆炸。

## 📝 變更內容 (Changes)

| Action | Before | After | 範圍 |
|---|---|---|---|
| `actions/checkout` | v4 | **v6**（Node 24 原生，`gh api` 確認最新大版） | ci / release / codeql |
| `actions/setup-node` | v4 | **v6** | ci / release |
| `github/codeql-action` | v4 | 不動（已最新大版） | — |
| `google-labs-code/jules-action` | v1.0.0 | 不動（第三方，不在棄用範圍） | — |

## 🧪 測試 (Testing)

- [x] 三個 YAML 以 js-yaml 驗證通過
- [x] **本 PR 的 CI run 即為實機驗證**：ci.yml 跑 self-hosted runner，新 actions 需要支援 Node 24 的 runner 版本 —— PR checks 綠了就代表 runner 相容
- release.yml 無法在 PR 觸發（`release: published`），但變更與 ci.yml 同質（同兩個 actions），CI 通過即可合理推定

## 🌐 English Version

The v1.15.2 release run surfaced GitHub's deprecation annotation: JavaScript actions will be forced onto Node.js 24 starting **June 16, 2026** (Node 20 removed from runners on Sept 16, 2026). This bumps `actions/checkout` and `actions/setup-node` from v4 to v6 (both Node 24-native, confirmed latest majors via `gh api`) across ci/release/codeql workflows. `codeql-action` is already on its latest major (v4) and the third-party jules-action is out of scope. Since ci.yml runs on a self-hosted runner, this PR's own CI run doubles as the live compatibility check for Node 24 support on that runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)