### PR TITLE
chore(release): bump version to 1.16.0

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "__MSG_extensionName__",
   "description": "__MSG_extensionDescription__",
   "default_locale": "en",
-  "version": "1.15.2",
+  "version": "1.16.0",
   "homepage_url": "https://sidebar-for-tabs-bookmarks.taislife.work/",
   "permissions": [
     "tabs",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "arc-like-chrome-extension",
-  "version": "1.15.2",
+  "version": "1.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "arc-like-chrome-extension",
-      "version": "1.15.2",
+      "version": "1.16.0",
       "license": "ISC",
       "devDependencies": {
         "baseline-browser-mapping": "^2.10.37",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arc-like-chrome-extension",
-  "version": "1.15.2",
+  "version": "1.16.0",
   "description": "這是一個 Chrome 擴充功能專案，旨在透過側邊欄介面，在 Chrome 瀏覽器中提供類似 Arc 瀏覽器的垂直分頁管理體驗，整合了分頁、群組與書籤的全功能管理面板。",
   "main": "background.js",
   "directories": {


### PR DESCRIPTION
## 摘要 / Summary

PR#177 已合併進 `main`，本 PR 將版本號更新至 **v1.16.0**，作為後續打 tag 與 GitHub Release 的基準。

Bumps the extension version to **v1.16.0** following the merge of PR#177, as the baseline for the upcoming git tag and GitHub Release.

## 變更 / Changes

- `manifest.json`：`1.15.2` → `1.16.0`
- `package.json`：`1.15.2` → `1.16.0`
- `package-lock.json`：`1.15.2` → `1.16.0`（root 兩處）

## 驗證 / Verification

純版本號變更，無程式邏輯異動。

🤖 Generated with [Claude Code](https://claude.com/claude-code)