### PR TITLE
chore(release): bump version to 1.17.0

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "__MSG_extensionName__",
   "description": "__MSG_extensionDescription__",
   "default_locale": "en",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "homepage_url": "https://sidebar-for-tabs-bookmarks.taislife.work/",
   "permissions": [
     "tabs",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "arc-like-chrome-extension",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "arc-like-chrome-extension",
-      "version": "1.16.0",
+      "version": "1.17.0",
       "license": "ISC",
       "devDependencies": {
         "baseline-browser-mapping": "^2.10.37",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arc-like-chrome-extension",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "description": "這是一個 Chrome 擴充功能專案，旨在透過側邊欄介面，在 Chrome 瀏覽器中提供類似 Arc 瀏覽器的垂直分頁管理體驗，整合了分頁、群組與書籤的全功能管理面板。",
   "main": "background.js",
   "directories": {


### PR DESCRIPTION
發佈 **v1.17.0**：修復閱讀清單 RSS 項目重複出現的 bug，並新增 RSS 訂閱與去重紀錄透過 Google Drive appdata 的跨裝置同步（#181，BASE-014）。含新功能，依 semver 升 minor。

僅版本號變更：`manifest.json` / `package.json` / `package-lock.json` 1.16.0 → 1.17.0。取代已關閉的 #182（原為 1.16.1）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)