### PR TITLE
fix(rss): restore resume toggle and loosen list layout

### DIFF
--- a/options.js
+++ b/options.js
@@ -495,10 +495,14 @@ async function renderRss(container) {
         });
 
         listContainer.querySelectorAll('.rss-toggle-btn').forEach(btn => {
-            btn.addEventListener('click', async (e) => {
-                const item = e.target.closest('.rss-subscription-item');
+            btn.addEventListener('click', async () => {
+                // Read state off `btn` (the listener's element), NOT e.target: the
+                // button's innerHTML is an inline SVG, so a click lands on the <path>
+                // child, whose dataset.action is undefined — which silently coerced
+                // every toggle to enabled:false and made "resume" impossible.
+                const item = btn.closest('.rss-subscription-item');
                 const id = item.dataset.id;
-                const action = e.target.dataset.action;
+                const action = btn.dataset.action;
                 await rss.updateSubscription(id, { enabled: action === 'resume' });
                 await renderList();
             });

--- a/sidepanel.css
+++ b/sidepanel.css
@@ -2226,10 +2226,11 @@ mark.url-match {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    padding: 8px 10px;
+    gap: 12px;
+    padding: 12px 14px;
     background: var(--element-bg-color);
     border-radius: var(--settings-radius);
-    margin-bottom: 6px;
+    margin-bottom: 10px;
     transition: var(--settings-transition);
 }
 
@@ -2240,7 +2241,7 @@ mark.url-match {
 .rss-subscription-info {
     display: flex;
     flex-direction: column;
-    gap: 4px;
+    gap: 6px;
     overflow: hidden;
     flex: 1;
     min-width: 0;
@@ -2256,8 +2257,9 @@ mark.url-match {
 
 .rss-subscription-actions {
     display: flex;
-    gap: 4px;
+    gap: 6px;
     align-items: center;
+    flex-shrink: 0;
 }
 
 /* Reuse icon button styles */
@@ -2289,7 +2291,12 @@ mark.url-match {
 }
 
 .rss-interval-select {
+    /* Override .modal-select's width:100% so the select sizes to its short
+       value ("24h") instead of stretching the full row and crowding the item. */
+    align-self: flex-start;
+    width: 72px;
     height: var(--settings-height-sm);
+    margin-top: 2px;
     padding: 0 6px;
     border: 1px solid var(--border-color);
     border-radius: var(--settings-radius);

--- a/usecase_tests/puppeteer_tests/regression_rss_toggle_resume.test.js
+++ b/usecase_tests/puppeteer_tests/regression_rss_toggle_resume.test.js
@@ -1,0 +1,82 @@
+const { setupBrowser, teardownBrowser } = require('./setup');
+
+/**
+ * Regression: RSS subscription "resume" was impossible after pausing.
+ *
+ * Root cause: the toggle-button click handler read `e.target.dataset.action`,
+ * but the button's innerHTML is an inline SVG icon, so a real click lands on
+ * the <path> child (dataset.action === undefined). `undefined === 'resume'` is
+ * false, so every toggle coerced to { enabled: false } — pause worked by
+ * coincidence, resume could never set enabled back to true.
+ *
+ * This seeds one PAUSED subscription (enabled=0) directly into storage.local
+ * (pipe-delimited: id|url|title|interval|enabled|lastFetched|updatedAt),
+ * opens the RSS section, clicks the resume button (the click lands on the SVG
+ * path, reproducing the bug), and asserts the subscription flips to enabled=1.
+ */
+describe('RSS toggle resume regression', () => {
+    let browser;
+    let page;
+    let extensionId;
+
+    const SUB_ID = 'rss_regtoggle';
+    const SEEDED = `${SUB_ID}|https://example.com/regfeed|RegToggle Feed|24h|0|0|0`;
+
+    beforeAll(async () => {
+        const setup = await setupBrowser();
+        browser = setup.browser;
+        page = setup.page;
+        extensionId = setup.extensionId;
+
+        const optionsUrl = `chrome-extension://${extensionId}/options.html`;
+        await page.goto(optionsUrl, { waitUntil: 'domcontentloaded' });
+        await page.waitForSelector('.opt-nav__item', { timeout: 15000 });
+
+        // Seed a paused subscription, then reload so renderRss()/initRssManager()
+        // reads it fresh from storage on the next page build.
+        await page.evaluate((rec) => new Promise(resolve => {
+            chrome.storage.local.set({ rssSubscriptions: [rec] }, resolve);
+        }), SEEDED);
+        await page.goto(optionsUrl, { waitUntil: 'domcontentloaded' });
+        await page.waitForSelector('.opt-nav__item', { timeout: 15000 });
+    }, 120000);
+
+    afterAll(async () => {
+        if (page) {
+            await page.evaluate(() => new Promise(resolve => {
+                chrome.storage.local.remove(['rssSubscriptions'], resolve);
+            }));
+        }
+        await teardownBrowser(browser);
+    });
+
+    test('clicking resume (on the SVG icon) re-enables a paused subscription', async () => {
+        await page.click('.opt-nav__item[data-section="rss"]');
+
+        const toggleSel = '#rss-subscriptions-list .rss-toggle-btn';
+        await page.waitForSelector(toggleSel, { timeout: 10000 });
+
+        // Paused subscription renders a resume affordance.
+        const action = await page.$eval(toggleSel, el => el.dataset.action);
+        expect(action).toBe('resume');
+
+        // Center-of-button click lands on the play_arrow <path>, reproducing the
+        // original e.target-vs-button bug.
+        await page.click(toggleSel);
+
+        // The subscription must now be enabled (field index 4 === '1').
+        await page.waitForFunction(() => new Promise(resolve => {
+            chrome.storage.local.get(['rssSubscriptions'], (res) => {
+                const rec = (res.rssSubscriptions || [])[0] || '';
+                resolve(rec.split('|')[4] === '1');
+            });
+        }), { timeout: 10000 });
+
+        // And the button flips back to a pause affordance.
+        await page.waitForFunction(
+            (sel) => document.querySelector(sel)?.dataset.action === 'pause',
+            { timeout: 10000 },
+            toggleSel
+        );
+    }, 60000);
+});


### PR DESCRIPTION
## 摘要 Summary

修復 RSS 訂閱項目「暫停後無法恢復截取」的問題,並順道放寬 RSS 設定區過於擁擠的排版。兩者都集中在 RSS 設定區,同一功能面。

## 變更內容 Changes

### 🐛 `fix(rss)`:恢復暫停狀態無法恢復的問題
- **根因**:toggle 按鈕的點擊 handler 讀 `e.target.dataset.action`,但按鈕的 `innerHTML` 是 inline SVG 圖示,且 `.m3-icon` 未設 `pointer-events: none`,實際點擊會落在 `<path>` 子元素上。`e.target` 因而是那個 `<path>`(沒有 `dataset.action` → `undefined`),`undefined === 'resume'` 恆為 `false`,導致每次切換都被強制寫成 `{ enabled: false }`——暫停剛好符合預期,恢復則永遠設不回 `true`。
- **修法**:改讀監聽器綁定的閉包變數 `btn`(保證是 button 本身)而非 `e.target`。同容器的 fetch / delete 按鈕原本就用閉包 `btn` + `closest()`,所以沒有此問題,屬單點根因修正。

### 💅 `style(rss)`:放寬訂閱清單排版
- item 內距 `8px 10px → 12px 14px`、item 間距 `6px → 10px`、資訊欄與動作區 `gap 4px → 6px`。
- interval 下拉選單原本同時掛 `.modal-select`(`width: 100%`)被拉滿整行、視覺沉重;改為靠左、固定 `72px` 的小 pill(以顯式 `width` 覆蓋 `.modal-select` 的 `100%`)。純樣式調整,不影響邏輯。

## 測試 Testing

- **新增 regression E2E** `regression_rss_toggle_resume.test.js`:seed 一筆暫停中的訂閱 → 點恢復(點擊刻意落在 SVG `<path>` 上以重現 bug)→ 驗證 storage 的 `enabled` 翻回 `1`、按鈕翻回暫停。**已做紅綠雙向確認**:還原成舊 code 時該測試如預期 timeout 失敗,套回修復後綠燈。
- `npm run test:ci`(happy-path 21 suites / 54 tests)全過。
- RSS unit `rssSyncLogic.test.mjs`(21 tests)全過。
- CSS 改動以 puppeteer 截圖目視確認(暫停中顯示 ▶、啟用中顯示 ⏸,版面明顯鬆開)。

---

## English Version

**Summary** — Fixes RSS subscriptions being unable to *resume* capture after being paused, and loosens the cramped RSS settings layout. Both changes are confined to the RSS settings section.

**Changes**
- `fix(rss)`: The toggle-button click handler read `e.target.dataset.action`, but the button's `innerHTML` is an inline SVG icon (and `.m3-icon` has no `pointer-events: none`), so a real click lands on the `<path>` child. `e.target` is that `<path>` — no `dataset.action` → `undefined`, and `undefined === 'resume'` is always `false`, coercing every toggle to `{ enabled: false }`. Pause worked by coincidence; resume could never set `enabled` back to `true`. Fix: read state off the listener's `btn` (the button element) instead of `e.target`. The sibling fetch/delete buttons already used the closure `btn` + `closest()`, so this is a single root-cause fix.
- `style(rss)`: Wider item padding/margins and gaps; the interval `<select>` (which also carried `.modal-select`'s `width: 100%` and stretched the whole row) is now a left-aligned fixed 72px pill.

**Testing** — New regression E2E (verified red against the old code, green after the fix); `test:ci` happy-path (54) and RSS unit (21) all pass; CSS verified via puppeteer screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
