### PR TITLE
chore(release): bump version to 1.17.1

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "__MSG_extensionName__",
   "description": "__MSG_extensionDescription__",
   "default_locale": "en",
-  "version": "1.17.0",
+  "version": "1.17.1",
   "homepage_url": "https://sidebar-for-tabs-bookmarks.taislife.work/",
   "permissions": [
     "tabs",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "arc-like-chrome-extension",
-  "version": "1.17.0",
+  "version": "1.17.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "arc-like-chrome-extension",
-      "version": "1.17.0",
+      "version": "1.17.1",
       "license": "ISC",
       "devDependencies": {
         "baseline-browser-mapping": "^2.10.37",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arc-like-chrome-extension",
-  "version": "1.17.0",
+  "version": "1.17.1",
   "description": "這是一個 Chrome 擴充功能專案，旨在透過側邊欄介面，在 Chrome 瀏覽器中提供類似 Arc 瀏覽器的垂直分頁管理體驗，整合了分頁、群組與書籤的全功能管理面板。",
   "main": "background.js",
   "directories": {


### PR DESCRIPTION
## 摘要 Summary

將版本號自 1.17.0 升至 **1.17.1**(patch)。此版本內容為 #184:修復 RSS 訂閱暫停後無法恢復截取,並放寬 RSS 設定區排版。僅含錯誤修復與樣式調整,依 semver 升 patch。

## 變更 Changes
- `manifest.json`、`package.json`、`package-lock.json`:1.17.0 → 1.17.1

合併後將於 main 打 tag `v1.17.1` 並建立 GitHub Release。

🤖 Generated with [Claude Code](https://claude.com/claude-code)