### PR TITLE
chore(deps): patch js-yaml, ws, brace-expansion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1285,9 +1285,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2677,9 +2677,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4435,10 +4435,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -5906,9 +5916,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## 摘要 (Summary)

修補 GitHub Dependabot 回報預設分支的 2 個 moderate 弱點（[dependabot alerts](https://github.com/Tai-ch0802/arc-like-chrome-extension/security/dependabot)），並順手處理本機 `npm audit` 揪出的 2 個 high。全部為 **devDependencies 傳遞依賴的 lockfile-only 升級**，`package.json` 不變。

### 弱點與修補對照

| 套件 | 版本 | 弱點 | 嚴重度 | 來源鏈 |
|---|---|---|---|---|
| js-yaml | 3.14.2 → 3.15.0 | GHSA-h67p-54hq-rp68（merge key 二次方 DoS） | moderate | `@istanbuljs/load-nyc-config`（Jest coverage） |
| js-yaml | 4.1.1 → 4.3.0 | GHSA-h67p-54hq-rp68（同上） | moderate | `cosmiconfig` |
| ws | 8.19.0 → 8.21.1 | GHSA-58qx-3vcg-4xpx、GHSA-96hv-2xvq-fx4p | high（GitHub 端 auto-dismissed） | `jsdom` / `puppeteer-core` |
| brace-expansion | 5.0.6 → 5.0.7 | GHSA-3jxr-9vmj-r5cp（指數時間展開 DoS） | high（GitHub 尚未開 alert） | `minimatch` |

### 影響面評估

- 四者皆僅在**本機／CI 測試工具鏈**中使用（Jest、jsdom、puppeteer），不進 `make` 打包產物，終端使用者零暴露。
- 升級皆落在父層 semver range 內（如 puppeteer-core `ws@^8.19.0` 可容納 8.21.1），**puppeteer 本體維持 24.42.0** —— 25+ 改 ESM 發佈會打掛 CJS 的 setup.js require，升級需另案遷移。
- 修補後 `npm audit` 歸零。

---

## 🧪 測試 (Testing)

- [x] `npm run test:unit`：26 suites / 396 tests 全數通過
- [x] `npm run test:ci`（happy-path E2E）：21 suites / 54 tests 全數通過（實際驅動 puppeteer，驗證 ws 8.21.1 相容）

---

## 🌐 English Version

### Summary

Patches the 2 moderate Dependabot alerts on the default branch (GHSA-h67p-54hq-rp68, js-yaml quadratic-complexity DoS in merge key handling) plus 2 high-severity findings from local `npm audit` (ws GHSA-58qx-3vcg-4xpx / GHSA-96hv-2xvq-fx4p, brace-expansion GHSA-3jxr-9vmj-r5cp). All four are transitive devDependencies bumped within their parents' semver ranges — lockfile-only, `package.json` untouched.

### Impact

- Dev/CI tooling only (Jest, jsdom, puppeteer); nothing ships in the packaged extension.
- puppeteer itself stays at 24.42.0 (25+ moved to ESM-only publishing, which breaks the CJS `require` in test setup; that migration is tracked separately).
- `npm audit` reports 0 vulnerabilities after this change.

### Testing

- `npm run test:unit`: 26 suites / 396 tests passed
- `npm run test:ci` (happy-path E2E): 21 suites / 54 tests passed (exercises puppeteer against ws 8.21.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)