### PR TITLE
build(newswire): TG2a — teleproto migration resolves GPL blocker (BASE-018)

### DIFF
--- a/docs/specs/feature/BASE-018_newswire-telegram/SA_spec.md
+++ b/docs/specs/feature/BASE-018_newswire-telegram/SA_spec.md
@@ -4,7 +4,7 @@
 |---|---|
 | ID | BASE-018 |
 | 分級 | **T2**（Phase 2：SA） |
-| 狀態 | **v1.3 — 架構修正（見 §8/Revision History）**；Gate 2 通過、T0 spike PROCEED、TG1 已合併（PR #194）。TG2 前置：GPL 授權 blocker **解方已查證＝遷 `teleproto`**（§5） |
+| 狀態 | **v1.4 — TG2a（recipe 遷 `teleproto`，GPL blocker 已解，§5）**；Gate 2 通過、TG1 已合併（PR #194）。offscreen 整合待 TG2b、登入 UI 待 TG2c |
 | 日期 | 2026-07-23 |
 | 上游 | 同目錄 `PRD_spec.md` v1.1 |
 
@@ -56,7 +56,7 @@
 | 仿冒頻道（First Squawk 兩 handle 並存） | 策展清單醒目警示；加入前 resolve 顯示頻道名/訂閱數確認 |
 | FLOOD_WAIT／rate limit | 遵守伺服器等待秒數；加頻道操作節流 |
 | GramJS 供應鏈 | 鎖定版本＋`npm audit` 納入既有 dependabot 流程；bundle 進包＝送審內容可稽核（**註：TG1-live bundle 尚未進包，此緩解待 TG2 落地才成立**） |
-| **🟠 GPL 授權相容性（有解方，TG2 執行）** | `telegram` 的 MTProto AES-IGE **強制依賴** `@cryptography/aes@0.1.1`＝**GPL-3.0-or-later**（純 JS `dist/cjs/aes.min.js`，會被 esbuild inline 進 bundle）。MIT＋CWS 分發內嵌 GPL-3.0 ＝ 授權衝突。**✅ 解方已查證（2026-07-24）：遷 fork [`teleproto`](https://github.com/sanyok12345/teleproto)（MIT）**——依賴樹 12 packages 零 GPL、無 `@cryptography/aes`；AES-IGE 改用 Node `node:crypto` `createCipheriv(aes-256-cbc/ctr)` 手工組 IGE（瀏覽器靠 crypto-browserify＝MIT polyfill）。目錄/API 與 GramJS 對齊（`TelegramClient`／`sessions/StringSession`／`events/NewMessage` 皆在，`entry.mjs` 幾乎只需改 package 名）。**TG2 遷移待辦**：build 配方補 alias `node:crypto→crypto-browserify`（7 檔用帶前綴 import）＋重驗瀏覽器端 `createCipheriv` 正確性（IGE 依賴 CBC）＋確認 largely-compatible 的實際 API 差異。此遷移**一併解掉 `telegram` archived 風險** |
+| **✅ GPL 授權相容性（已解決，TG2a）** | 上游 `telegram`(GramJS) 強制依賴 `@cryptography/aes`＝**GPL-3.0-or-later**（AES-IGE 核心路徑、會 inline 進 bundle），與 MIT＋CWS 分發衝突。**recipe 已遷 fork `teleproto`（MIT）**（TG2a）：`package-lock` 全樹 137 packages 零 copyleft、無 `@cryptography/aes`；AES-IGE 改用 `node:crypto`（瀏覽器靠 crypto-browserify＝MIT polyfill），`npm run verify` 驗 crypto-browserify AES 與 Node 逐位元組一致＋teleproto IGE round-trip。一併解掉 `telegram` archived 風險。**遺留 tradeoff**：bundle 2.67M min / 483K gzip（telegram 1.31M/383K，browserify-zlib 較重）——offscreen＋opt-in 隔離下影響小，暫不優化（可用 pako-based zlib shim 壓回） |
 
 ## 6. Test Impact
 
@@ -84,7 +84,9 @@
 | **T0** | §7 spike（1–2 晚,scratch 不入版控） |
 | **TG1** | tgAdapter＋parseTgMessage＋feedManager 納管＋tg keys 納入既有 opt-in 同步路徑（'tg' 入 NEWSWIRE_SOURCE_IDS；含 on/off/scrub 測試）｜PR #194 已合併 |
 | **TG1-live** | **僅落地可重現 build recipe**（`tools/telegram-bundle/`：esbuild+polyfill，`npm ci && npm run build` → 1.3M bundle）。**GramJS 執行 context 定案：offscreen document**（見下方架構決策）。tgClient 維持 stub（載入待 TG2）。1.3M bundle 本身**不進 main**（無 code 引用前不入版控/打包），TG2 連同 offscreen 載入 code 一起落地 |
-| **TG2** | GramJS **offscreen 整合**（bundle 落地＋offscreen.js 加 tg handler＋SW↔offscreen message proxy＋watchdog 改監控 offscreen 存活/重建＋抽共用 `ensureOffscreenDocument`＋Makefile DEV build 補 offscreen 檔案）＋options 登入卡（頻道管理/策展清單）＋i18n＋PERMISSIONS.md |
+| **TG2a** | **recipe 遷 `teleproto`（MIT）解 GPL blocker**（`tools/telegram-bundle`：entry/build alias/lockfile＋`npm run verify` AES 自我驗證）。bundle 仍不進 `lib/`（無 code 引用，待 TG2b）｜本 PR |
+| **TG2b** | GramJS **offscreen 整合**（bundle 落地 `lib/`＋offscreen.js 加 tg handler＋SW↔offscreen message proxy＋watchdog 改監控 offscreen 存活/重建＋抽共用 `ensureOffscreenDocument`＋Makefile DEV build 補 offscreen 檔案） |
+| **TG2c** | options 登入卡（`client.start` phone→code→2FA 於 DOM context）＋頻道管理/策展清單＋session 風險告示 modal＋i18n＋PERMISSIONS.md |
 | **TG3** | 手動矩陣（真帳號登入、百頻道壓測、FLOOD_WAIT、跨端撤銷） |
 
 ### GramJS 執行 context 架構決策（TG1-live 查證定案，取代原「SW 內 dynamic import」假設）
@@ -105,3 +107,4 @@
 | v1.1 | 2026-07-23 | 依 PR #192 意見：session/api_hash 改為納入既有 key opt-in 同步（取代同步硬排除；`mergeKeys` 整包 LWW 自動涵蓋 tg，僅需 'tg' 入 NEWSWIRE_SOURCE_IDS）；連動更新 §2 Module Map、§3 storage schema、§5 安全設計、§6 測試、§8 TG1 | Tai / Claude 協作 |
 | v1.2 | 2026-07-23 | T0 spike 執行完成（SPIKE_T0.md）：GramJS 可行性 de-risk，PROCEED（有條件）；§1 依賴引入改為 vendored bundle 進 lib/（1.3M）、§7 回填四問題結論；未竟項＝使用者跑 harness 確認真登入/接收 | Tai / Claude 協作 |
 | v1.3 | 2026-07-24 | TG1-live 縮範圍：對抗式 review＋Chrome 官方文件查證確認 **MV3 SW 不支援 dynamic import()**，原「SW 內 dynamic import bundle」不可行 → §8 新增「GramJS 執行 context 架構決策」：定案 **offscreen document**（SW proxy＋watchdog 監控 offscreen），offscreen 整合併入 TG2。TG1-live 收斂為僅落地可重現 build recipe（`tools/telegram-bundle/`），1.3M bundle 不進 main（無 code 引用）。記錄上游 `telegram@2.26.22` 已 archived（fork `teleproto`），供應鏈風險待評估遷移。**PR #195 review 追加**：查證 `@cryptography/aes` = GPL-3.0-or-later（核心密碼路徑不可 stub）→ §5 新增授權 blocker、header 標示；build 輸出改 `tools/telegram-bundle/dist/`（gitignored，避免污染 `make` 打包路徑）；§1 補 forward-correction 指向 §8；header 版本 v1.2→v1.3。**GPL blocker 調研**：實測 `npm install teleproto` 掃描確認 fork `teleproto`（MIT）依賴樹零 GPL、AES-IGE 改用 `node:crypto`、API 與 GramJS 對齊 → §5 blocker 降級為「有解方（遷 teleproto）」，一併解 archived 風險 | Tai / Claude 協作 |
+| v1.4 | 2026-07-24 | **TG2a**：recipe 實際遷 `teleproto`（MIT）——`package.json`/`entry.mjs`/`build.mjs`（alias 補 `node:` 前綴雙寫＋`zlib→browserify-zlib`＋`assert`）／重生 lockfile（137 packages 零 copyleft）；新增 `verify.mjs`（`npm run verify`：crypto-browserify AES ≡ Node 逐位元組＋teleproto IGE round-trip）。§5 GPL blocker→已解決。遺留 tradeoff：bundle 2.67M/483K gzip（記於 §5/README）。§8 TG2 拆 TG2a(本 PR)/TG2b(offscreen)/TG2c(登入 UI) | Tai / Claude 協作 |

--- a/tools/telegram-bundle/README.md
+++ b/tools/telegram-bundle/README.md
@@ -1,36 +1,48 @@
 # telegram-bundle-builder
 
-GramJS vendored bundle（BASE-018 Telegram 快訊源；TG2 落地為 `lib/telegram.bundle.js`）的**可重現 build recipe**。這是 build-time 工具，**不屬於擴充功能本體**、不進 `make` 打包。build 產物輸出到 `dist/`（gitignored，**刻意不落在 `lib/`**——`make` 從檔案系統整包 cp `lib/`，輸出那裡會讓任何人跑重建就把 1.3M 打進包）。
+Telegram 快訊源（BASE-018）GramJS 客戶端的 **vendored bundle 可重現 build recipe**。底層用 **[`teleproto`](https://github.com/sanyok12345/teleproto)**（MIT，telegram/GramJS 的 fork——見下方「授權與維護」）。build-time 工具，**不屬於擴充功能本體**、不進 `make` 打包。build 產物輸出到 `dist/`（gitignored，**刻意不落在 `lib/`**——`make` 從檔案系統整包 cp `lib/`，輸出那裡會讓任何人跑重建就把 bundle 打進包）。
 
 ## 為何 vendored
 
-GramJS（`telegram`）是 CJS 套件、依賴多個 Node built-in（`crypto`/`fs`/`net`/`tls`/`stream`/`path`/`os`/`events`/`util`），**無法以原始碼直載**（`<script type=module>` 無 bundler），esbuild 也不能開箱 bundle。故預打包成單一 vendored ESM bundle。可行性見 [`docs/specs/feature/BASE-018_newswire-telegram/SPIKE_T0.md`](../../docs/specs/feature/BASE-018_newswire-telegram/SPIKE_T0.md)（crypto-browserify sha256 實測與 Node 一致、瀏覽器 WSS transport 連向 Telegram web DC）。
+teleproto 是 CJS 套件、依賴多個 Node built-in（`crypto`/`zlib`/`stream`/`path`/`os`/…），**無法以原始碼直載**（`<script type=module>` 無 bundler），esbuild 也不能開箱 bundle。故預打包成單一 vendored ESM bundle。可行性見 [`SPIKE_T0.md`](../../docs/specs/feature/BASE-018_newswire-telegram/SPIKE_T0.md)。
 
-**執行 context（SA §8 定案）**：GramJS 於 **offscreen document** 執行（`dynamic import` 此 bundle）——MV3 service worker 不支援 dynamic import()（Chrome 官方文件確認），且 GramJS 登入需 DOM context。**TG1-live 只落地此 recipe;產出的 1.3M bundle 尚無 code 引用,故不入 `lib/`/不進 main**——TG2 做 offscreen 整合時連同載入 code 一起落地（屆時比照 `lib/Sortable.min.js` 放 `lib/`）。
+**執行 context（SA §8 定案）**：GramJS 於 **offscreen document** 執行（`dynamic import` 此 bundle）——MV3 service worker 不支援 dynamic import()（Chrome 官方文件確認），且 GramJS 登入需 DOM context。bundle 於 TG2 offscreen 整合時進 `lib/telegram.bundle.js`（比照 `lib/Sortable.min.js`）；在那之前不入 `lib/`（無 code 引用）。
 
 ## 重建
 
 ```bash
 cd tools/telegram-bundle
 npm ci          # 鎖定版本安裝(package-lock.json)
-npm run build   # → dist/telegram.bundle.js (~1.3 MB min / ~383 KB gzip；gitignored)
+npm run build   # → dist/telegram.bundle.js (~2.67 MB min / ~483 KB gzip；gitignored)
+npm run verify  # AES 密碼路徑自我檢查(見下)
 ```
 
 `entry.mjs` 只匯出 `tgClient.js` 需要的 `TelegramClient` / `StringSession` / `NewMessage`。
 
 ## Polyfill 配方（`build.mjs`）
 
+teleproto 用帶 `node:` 前綴的 import，故 alias 對 bare 與 `node:` 兩種都映射。
+
 | 類別 | 對應 | 備註 |
 |---|---|---|
-| alias polyfill | `crypto→crypto-browserify`（**核心密碼路徑,不可省**）、`stream`/`path`/`events`/`util` | spike 已驗 sha256 與 Node 一致 |
-| functional shim | `os→os-shim.cjs` | 建構時讀 `os.type()` 等組 device 字串 |
-| 空存根 | `fs`/`net`/`tls`/`socks`/`node-localstorage→empty-stub.cjs` | 記憶體 StringSession,不觸檔案/原生 socket |
-| inject | `Buffer`(buffer)、`process`(process)；`global=globalThis` | GramJS 假設 Node 全域 |
+| 核心密碼 | `crypto`／`node:crypto`→crypto-browserify | teleproto IGE 底層 = aes-256-cbc；`verify.mjs` 驗與 Node 逐位元組一致 |
+| alias polyfill | `stream`／`path`／`events`／`util`／`buffer`（＋`node:` 版） | |
+| zlib | `zlib`／`node:zlib`→browserify-zlib | teleproto GZIPPacked 解壓（telegram 曾用 pako） |
+| assert | `assert`／`node:assert`→assert | browserify-zlib 依賴 |
+| functional shim | `os`→`os-shim.cjs` | 建構時讀 `os.type()` 等組 device 字串 |
+| 空存根 | `fs`／`net`／`tls`／`socks`／`node-localstorage`→`empty-stub.cjs` | 記憶體 StringSession，不觸檔案/原生 socket |
+| inject | `Buffer`(buffer)、`process`(process)；`global=globalThis` | 假設 Node 全域 |
 
-## ⚠️ 維護警示
+## crypto 自我驗證（`npm run verify`）
 
-**🟠 授權 blocker（有解方，TG2 執行）**：`telegram` 的 MTProto AES-IGE 加密**強制依賴** `@cryptography/aes@0.1.1` = **GPL-3.0-or-later**（純 JS `dist/cjs/aes.min.js`，會被 esbuild inline 進 bundle）。本專案 MIT＋CWS 分發，內嵌 GPL-3.0 = 授權衝突；它在核心密碼路徑無法 stub，WebCrypto 也無 AES-IGE（非標準模式）。
+AES-IGE 是密碼路徑，換掉 GPL 的 `@cryptography/aes` 後留一個 runnable check（`verify.mjs`）：
+1. **crypto-browserify 的 `aes-256-cbc`/`ctr` 與 Node 原生逐位元組一致**——bundle 用此 polyfill，等價成立則 bundle 環境 AES 正確。
+2. **teleproto IGE 端到端 round-trip 正確**（IGE = AES-CBC + XOR 邏輯自洽）。
 
-**✅ 解方已查證（2026-07-24）：遷 fork [`teleproto`](https://github.com/sanyok12345/teleproto)（MIT）**。實測 `npm install teleproto` 掃描：依賴樹 12 packages **零 GPL/copyleft、無 `@cryptography/aes`**；AES-IGE 改用 Node `node:crypto` 的 `createCipheriv("aes-256-cbc"/"AES-256-CTR")` 手工組（瀏覽器端靠 `crypto-browserify` = MIT polyfill）。目錄/API 與 GramJS 對齊（`TelegramClient`／`sessions/StringSession`／`events/NewMessage` 皆在），`entry.mjs` 幾乎只需把 `telegram` 換成 `teleproto`。**此遷移一併解掉 `telegram` 已 archived 的維護風險。**
+## ⚠️ 授權與維護
 
-**TG2 遷移待辦**：`entry.mjs` 改 `teleproto`；`build.mjs` alias 補 `node:crypto → crypto-browserify`（teleproto 有 7 檔用帶 `node:` 前綴的 import，現有 alias 只匹配 `crypto`）；重驗瀏覽器端 `createCipheriv` aes-256-cbc/ctr 正確性（IGE 依賴 CBC）；確認「largely compatible」的實際 API 差異。供應鏈以 `package-lock.json` 鎖版，納入既有 dependabot。
+**✅ GPL 授權已規避（改用 teleproto）**：上游 `telegram`(GramJS) 強制依賴 `@cryptography/aes` = **GPL-3.0-or-later**（AES-IGE 核心路徑、會被 inline 進 bundle），與本專案 MIT＋CWS 分發衝突。本 recipe 改用 fork **`teleproto`（MIT）**：依賴樹零 GPL/copyleft、無 `@cryptography/aes`，AES-IGE 改用 `node:crypto`（瀏覽器靠 crypto-browserify = MIT polyfill）。`npm run verify` 已驗密碼路徑正確。**一併規避 `telegram` 已 archived 的維護風險。**
+
+**⚠️ 體積 tradeoff**：teleproto bundle **2.67 MB min / 483 KB gzip**（telegram 曾為 1.31M / 383K）。min 翻倍主因 `browserify-zlib` 較重（telegram 用更輕的 pako）；gzip 僅 +100K。因 GramJS 在 offscreen＋tg opt-in（預設 disabled）僅啟用時載入，影響面小，**暫不優化**；若日後要壓，可寫僅 gunzip 的輕量 pako-based zlib shim 取代 browserify-zlib。
+
+供應鏈以 `package-lock.json` 鎖版（137 packages，零 copyleft），納入既有 dependabot。

--- a/tools/telegram-bundle/build.mjs
+++ b/tools/telegram-bundle/build.mjs
@@ -1,20 +1,42 @@
-// 可重現 build:GramJS(telegram@2.26.22)→ 單一 vendored ESM bundle。
-// 產物:../../lib/telegram.bundle.js(比照 lib/Sortable.min.js,隨 make 進包)。
+// 可重現 build:teleproto(MIT fork of GramJS)→ 單一 vendored ESM bundle。
+// 產物:dist/telegram.bundle.js(gitignored,刻意不落 lib/——見 README)。
 //
-// 為何需要:GramJS 是 CJS + 多個 Node built-in 依賴,無法以原始碼直載於 dev 模式,
-// esbuild 也不能開箱 bundle。此配方經 T0 spike 實測(crypto-browserify sha256 與
-// Node 一致、瀏覽器 WSS transport 連向 Telegram web DC),見 docs/specs/.../SPIKE_T0.md。
+// 為何 teleproto 而非 telegram:上游 telegram 強制依賴 @cryptography/aes(GPL-3.0-
+// or-later,在 AES-IGE 核心路徑會被 inline 進 bundle),與 MIT＋CWS 分發衝突。
+// teleproto 依賴樹零 GPL、AES-IGE 改用 node:crypto(瀏覽器靠 crypto-browserify
+// = MIT polyfill),API 與 GramJS 對齊。詳見 README ⚠️ 段與 SPIKE_T0.md。
 //
-// 重建:cd tools/telegram-bundle && npm ci && npm run build
+// 重建:cd tools/telegram-bundle && npm ci && npm run build && npm run verify
 import * as esbuild from 'esbuild';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
 
 const here = dirname(fileURLToPath(import.meta.url));
-// 輸出到 recipe 目錄下的 dist/（gitignored），**刻意不落在 lib/**：Makefile 從
-// 檔案系統整包 cp lib/ 進包(不依 git 追蹤),若輸出 lib/ 則任何人跑重建就會把
-// 1.3M bundle 打進擴充功能。TG2 整合時再改輸出/複製到 lib/。
 const outfile = resolve(here, 'dist/telegram.bundle.js');
+
+const cb = 'crypto-browserify', sb = 'stream-browserify', pb = 'path-browserify';
+const osShim = resolve(here, 'os-shim.cjs');
+const stub = resolve(here, 'empty-stub.cjs');
+// teleproto 用帶 `node:` 前綴的 import(node:crypto 等),故 bare 與 node: 兩種都 alias。
+const alias = {
+  // 核心密碼路徑:teleproto AES-IGE = node:crypto AES-CBC + 純 JS XOR;
+  // crypto-browserify 的 aes-256-cbc/ctr 已驗與 Node 原生逐位元組一致(verify.mjs)。
+  crypto: cb, 'node:crypto': cb,
+  stream: sb, 'node:stream': sb,
+  path: pb, 'node:path': pb,
+  events: 'events', 'node:events': 'events',
+  util: 'util', 'node:util': 'util',
+  buffer: 'buffer', 'node:buffer': 'buffer',
+  // teleproto GZIPPacked 用 node:zlib(上游 telegram 是 pako);browserify-zlib = MIT。
+  zlib: 'browserify-zlib', 'node:zlib': 'browserify-zlib',
+  assert: 'assert', 'node:assert': 'assert',
+  // functional os shim:建構時讀 os.type() 等組 device 字串。
+  os: osShim, 'node:os': osShim,
+  // 空存根:記憶體 StringSession,不觸檔案/原生 socket。
+  fs: stub, 'node:fs': stub, net: stub, 'node:net': stub,
+  tls: stub, 'node:tls': stub, socks: stub,
+  'node-localstorage': stub,
+};
 
 const r = await esbuild.build({
   entryPoints: [resolve(here, 'entry.mjs')],
@@ -22,18 +44,8 @@ const r = await esbuild.build({
   outfile, minify: true, metafile: true, logLevel: 'error',
   define: { global: 'globalThis', 'process.env.NODE_ENV': '"production"' },
   inject: [resolve(here, 'shim-inject.mjs')],
-  alias: {
-    // 核心密碼路徑,不可省(spike 已驗 sha256 與 Node 一致)。
-    crypto: 'crypto-browserify', stream: 'stream-browserify',
-    // functional os shim:GramJS 建構讀 os.type() 等組 device 字串。
-    os: resolve(here, 'os-shim.cjs'),
-    // 空存根:記憶體 StringSession,不觸檔案系統/原生 socket。
-    fs: resolve(here, 'empty-stub.cjs'), net: resolve(here, 'empty-stub.cjs'),
-    tls: resolve(here, 'empty-stub.cjs'), socks: resolve(here, 'empty-stub.cjs'),
-    'node-localstorage': resolve(here, 'empty-stub.cjs'),
-    path: 'path-browserify', events: 'events', util: 'util',
-  },
+  alias,
 }).catch((e) => { console.error('BUILD FAIL:', e.message); process.exit(2); });
 
 const bytes = Object.values(r.metafile.outputs)[0].bytes;
-console.log(`BUILD OK → tools/telegram-bundle/dist/telegram.bundle.js (${(bytes / 1024 / 1024).toFixed(2)} MB)`);
+console.log(`BUILD OK → dist/telegram.bundle.js (${(bytes / 1024 / 1024).toFixed(2)} MB)`);

--- a/tools/telegram-bundle/entry.mjs
+++ b/tools/telegram-bundle/entry.mjs
@@ -1,5 +1,5 @@
-// 生產 entry：只匯出 tgClient.js 真正需要的三個符號。GramJS 其餘 API 不進 bundle
-// 的 public surface（tree-shake 靠 esbuild），減少誤用面。
-export { TelegramClient } from 'telegram';
-export { StringSession } from 'telegram/sessions/index.js';
-export { NewMessage } from 'telegram/events/index.js';
+// 生產 entry：只匯出 tgClient.js 需要的三個符號。teleproto（MIT，telegram/GramJS
+// 的 fork）目錄/API 與上游對齊，sessions/events 子路徑相同。
+export { TelegramClient } from 'teleproto';
+export { StringSession } from 'teleproto/sessions/index.js';
+export { NewMessage } from 'teleproto/events/index.js';

--- a/tools/telegram-bundle/package-lock.json
+++ b/tools/telegram-bundle/package-lock.json
@@ -8,9 +8,11 @@
       "name": "telegram-bundle-builder",
       "version": "0.0.0",
       "dependencies": {
-        "telegram": "2.26.22"
+        "teleproto": "1.228.4"
       },
       "devDependencies": {
+        "assert": "2.1.0",
+        "browserify-zlib": "0.2.0",
         "buffer": "6.0.3",
         "crypto-browserify": "3.12.1",
         "esbuild": "0.28.1",
@@ -20,12 +22,6 @@
         "stream-browserify": "3.0.0",
         "util": "0.12.5"
       }
-    },
-    "node_modules/@cryptography/aes": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@cryptography/aes/-/aes-0.1.1.tgz",
-      "integrity": "sha512-PcYz4FDGblO6tM2kSC+VzhhK62vml6k6/YAkiWtyPvrgJVfnDRoHGDtKn5UiaRRUrvUTTocBpvc2rRgTCqxjsg==",
-      "license": "GPL-3.0-or-later"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.28.1",
@@ -488,13 +484,18 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/async-mutex": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.3.2.tgz",
-      "integrity": "sha512-HuTK7E7MT7jZEh1P9GtRW9+aTWiDWWi9InbZ5hjxrnRa39KS4BW04+xLBhYNS2aXhHUIKZSw3gj4Pn1pj+qGAA==",
+    "node_modules/assert": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-2.1.0.tgz",
+      "integrity": "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tslib": "^2.3.1"
+        "call-bind": "^1.0.2",
+        "is-nan": "^1.3.2",
+        "object-is": "^1.1.5",
+        "object.assign": "^4.1.4",
+        "util": "^0.12.5"
       }
     },
     "node_modules/available-typed-arrays": {
@@ -517,6 +518,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -632,10 +634,21 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/browserify-zlib": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pako": "~1.0.5"
+      }
+    },
     "node_modules/buffer": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
       "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -662,19 +675,6 @@
       "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/bufferutil": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.1.0.tgz",
-      "integrity": "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
-      }
     },
     "node_modules/call-bind": {
       "version": "1.0.9",
@@ -822,28 +822,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/d": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/d/-/d-1.0.2.tgz",
-      "integrity": "sha512-MOqHvMWF9/9MX6nza0KgvFH4HpMU0EF5uUDXqX/BtxtU8NfB0QzRtJ8Oe/6SuS4kbhyzVJwjd97EA4PKrzJ8bw==",
-      "license": "ISC",
-      "dependencies": {
-        "es5-ext": "^0.10.64",
-        "type": "^2.7.2"
-      },
-      "engines": {
-        "node": ">=0.12"
-      }
-    },
-    "node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
     "node_modules/define-data-property": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
@@ -854,6 +832,24 @@
         "es-define-property": "^1.0.0",
         "es-errors": "^1.3.0",
         "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -891,61 +887,6 @@
       "integrity": "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/dom-serializer": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
-      "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^2.0.1",
-        "domhandler": "^4.2.0",
-        "entities": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-      }
-    },
-    "node_modules/domelementtype": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/domhandler": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
-      "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "domelementtype": "^2.2.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domhandler?sponsor=1"
-      }
-    },
-    "node_modules/domutils": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
-      "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "dom-serializer": "^1.0.1",
-        "domelementtype": "^2.2.0",
-        "domhandler": "^4.2.0"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domutils?sponsor=1"
-      }
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -985,15 +926,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/entities": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
-      "license": "BSD-2-Clause",
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -1025,46 +957,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/es5-ext": {
-      "version": "0.10.64",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.64.tgz",
-      "integrity": "sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==",
-      "hasInstallScript": true,
-      "license": "ISC",
-      "dependencies": {
-        "es6-iterator": "^2.0.3",
-        "es6-symbol": "^3.1.3",
-        "esniff": "^2.0.1",
-        "next-tick": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "node_modules/es6-iterator": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-      "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
-      "license": "MIT",
-      "dependencies": {
-        "d": "1",
-        "es5-ext": "^0.10.35",
-        "es6-symbol": "^3.1.1"
-      }
-    },
-    "node_modules/es6-symbol": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.4.tgz",
-      "integrity": "sha512-U9bFFjX8tFiATgtkJ1zg25+KviIXpgRvRHS8sau3GfhVzThRQrOeksPeT0BWW2MNZs1OEWJ1DPXOQMn0KKRkvg==",
-      "license": "ISC",
-      "dependencies": {
-        "d": "^1.0.2",
-        "ext": "^1.7.0"
-      },
-      "engines": {
-        "node": ">=0.12"
       }
     },
     "node_modules/esbuild": {
@@ -1109,31 +1001,6 @@
         "@esbuild/win32-x64": "0.28.1"
       }
     },
-    "node_modules/esniff": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/esniff/-/esniff-2.0.1.tgz",
-      "integrity": "sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==",
-      "license": "ISC",
-      "dependencies": {
-        "d": "^1.0.1",
-        "es5-ext": "^0.10.62",
-        "event-emitter": "^0.3.5",
-        "type": "^2.7.2"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "node_modules/event-emitter": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
-      "integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
-      "license": "MIT",
-      "dependencies": {
-        "d": "1",
-        "es5-ext": "~0.10.14"
-      }
-    },
     "node_modules/events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -1153,15 +1020,6 @@
       "dependencies": {
         "md5.js": "^1.3.4",
         "safe-buffer": "^5.1.1"
-      }
-    },
-    "node_modules/ext": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
-      "integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
-      "license": "ISC",
-      "dependencies": {
-        "type": "^2.7.2"
       }
     },
     "node_modules/for-each": {
@@ -1350,29 +1208,11 @@
         "minimalistic-crypto-utils": "^1.0.1"
       }
     },
-    "node_modules/htmlparser2": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
-      "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
-      "funding": [
-        "https://github.com/fb55/htmlparser2?sponsor=1",
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^2.0.1",
-        "domhandler": "^4.0.0",
-        "domutils": "^2.5.2",
-        "entities": "^2.0.0"
-      }
-    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1464,6 +1304,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-nan": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
+      "integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -1498,12 +1355,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
-      "license": "MIT"
     },
     "node_modules/isarray": {
       "version": "1.0.0",
@@ -1581,29 +1432,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
-    },
-    "node_modules/next-tick": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
-      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
-      "license": "ISC"
-    },
-    "node_modules/node-gyp-build": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
-      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
-      "license": "MIT",
-      "bin": {
-        "node-gyp-build": "bin.js",
-        "node-gyp-build-optional": "optional.js",
-        "node-gyp-build-test": "build-test.js"
-      }
-    },
     "node_modules/node-localstorage": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/node-localstorage/-/node-localstorage-2.2.1.tgz",
@@ -1616,20 +1444,59 @@
         "node": ">=0.12"
       }
     },
+    "node_modules/object-is": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/pako": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-2.2.0.tgz",
-      "integrity": "sha512-zJq6RP/5q+TO2OpFV3FHzlPnFjmkb7Nc99a5SNjJE+uu/PkpChs+NIZSSzbBoD+6kjiISXjfYdwj1ZRQ81dz/w==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "dev": true,
       "license": "(MIT AND Zlib)"
     },
     "node_modules/parse-asn1": {
@@ -1653,6 +1520,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
       "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/pbkdf2": {
@@ -1764,12 +1632,6 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/real-cancellable-promise": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/real-cancellable-promise/-/real-cancellable-promise-1.2.3.tgz",
-      "integrity": "sha512-hBI5Gy/55VEeeMtImMgEirD7eq5UmqJf1J8dFZtbJZA/3rB0pYFZ7PayMGueb6v4UtUtpKpP+05L0VwyE1hI9Q==",
       "license": "MIT"
     },
     "node_modules/ripemd160": {
@@ -1962,31 +1824,17 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/telegram": {
-      "version": "2.26.22",
-      "resolved": "https://registry.npmjs.org/telegram/-/telegram-2.26.22.tgz",
-      "integrity": "sha512-EIj7Yrjiu0Yosa3FZ/7EyPg9s6UiTi/zDQrFmR/2Mg7pIUU+XjAit1n1u9OU9h2oRnRM5M+67/fxzQluZpaJJg==",
-      "deprecated": "This package is archived and no longer maintained. Development continues in teleproto (https://npmjs.com/package/teleproto), a largely compatible, actively maintained fork. See the migration guide at https://docs.teleproto.dev/migrating-from-gramjs",
+    "node_modules/teleproto": {
+      "version": "1.228.4",
+      "resolved": "https://registry.npmjs.org/teleproto/-/teleproto-1.228.4.tgz",
+      "integrity": "sha512-SgBC18pHbFCxAEZZZ3GZVMfZEbwd8k6yVR2a2mGPLYOIz7PVZ/vpVKeDZ0xntAtMRBUkrfJXC5IGq/PO+dU/BQ==",
       "license": "MIT",
       "dependencies": {
-        "@cryptography/aes": "^0.1.1",
-        "async-mutex": "^0.3.0",
         "big-integer": "^1.6.48",
-        "buffer": "^6.0.3",
-        "htmlparser2": "^6.1.0",
         "mime": "^3.0.0",
         "node-localstorage": "^2.2.1",
-        "pako": "^2.0.3",
-        "path-browserify": "^1.0.1",
-        "real-cancellable-promise": "^1.1.1",
         "socks": "^2.6.2",
-        "store2": "^2.13.0",
-        "ts-custom-error": "^3.2.0",
-        "websocket": "^1.0.34"
-      },
-      "optionalDependencies": {
-        "bufferutil": "^4.0.3",
-        "utf-8-validate": "^5.0.5"
+        "store2": "^2.13.0"
       }
     },
     "node_modules/to-buffer": {
@@ -2011,27 +1859,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/ts-custom-error": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/ts-custom-error/-/ts-custom-error-3.3.1.tgz",
-      "integrity": "sha512-5OX1tzOjxWEgsr/YEUWSuPrQ00deKLh6D7OTWcvNHm12/7QPyRh8SYpyWvA4IZv8H/+GQWQEh/kwo95Q9OVW1A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
-    },
-    "node_modules/type": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/type/-/type-2.7.3.tgz",
-      "integrity": "sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ==",
-      "license": "ISC"
-    },
     "node_modules/typed-array-buffer": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
@@ -2045,28 +1872,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/typedarray-to-buffer": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
-      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
-      "license": "MIT",
-      "dependencies": {
-        "is-typedarray": "^1.0.0"
-      }
-    },
-    "node_modules/utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
       }
     },
     "node_modules/util": {
@@ -2089,23 +1894,6 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/websocket": {
-      "version": "1.0.35",
-      "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.35.tgz",
-      "integrity": "sha512-/REy6amwPZl44DDzvRCkaI1q1bIiQB0mEFQLUrhz3z2EK91cp3n72rAjUlrTP0zV22HJIUOVHQGPxhFRjxjt+Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bufferutil": "^4.0.1",
-        "debug": "^2.2.0",
-        "es5-ext": "^0.10.63",
-        "typedarray-to-buffer": "^3.1.5",
-        "utf-8-validate": "^5.0.2",
-        "yaeti": "^0.0.6"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
     },
     "node_modules/which-typed-array": {
       "version": "1.1.22",
@@ -2138,16 +1926,6 @@
         "graceful-fs": "^4.1.11",
         "imurmurhash": "^0.1.4",
         "slide": "^1.1.5"
-      }
-    },
-    "node_modules/yaeti": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
-      "integrity": "sha512-MvQa//+KcZCUkBTIC9blM+CU9J2GzuTytsOUwf2lidtvkx/6gnEp1QvJv34t9vdjhFmha/mUiNDbN0D0mJWdug==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.32"
       }
     }
   }

--- a/tools/telegram-bundle/package.json
+++ b/tools/telegram-bundle/package.json
@@ -2,15 +2,18 @@
   "name": "telegram-bundle-builder",
   "private": true,
   "version": "0.0.0",
-  "description": "Reproducible build recipe for lib/telegram.bundle.js (GramJS vendored bundle, BASE-018). Not part of the extension — build-time only. See README.md.",
+  "description": "Reproducible build recipe for the GramJS vendored bundle (BASE-018). Uses teleproto (MIT fork of telegram/GramJS) to avoid telegram's GPL @cryptography/aes dependency. Build-time only — not part of the extension. See README.md.",
   "type": "module",
   "scripts": {
-    "build": "node build.mjs"
+    "build": "node build.mjs",
+    "verify": "node verify.mjs"
   },
   "dependencies": {
-    "telegram": "2.26.22"
+    "teleproto": "1.228.4"
   },
   "devDependencies": {
+    "assert": "2.1.0",
+    "browserify-zlib": "0.2.0",
     "buffer": "6.0.3",
     "crypto-browserify": "3.12.1",
     "esbuild": "0.28.1",

--- a/tools/telegram-bundle/verify.mjs
+++ b/tools/telegram-bundle/verify.mjs
@@ -1,0 +1,44 @@
+// recipe 密碼路徑自我驗證（BASE-018 TG2a）。ponytail: AES-IGE 是密碼路徑,換掉
+// GPL 的 @cryptography/aes 後必須留一個 runnable check。`npm run verify`。
+//   1. bundle 用 crypto-browserify polyfill,必須與 Node 原生 AES 逐位元組一致
+//      （teleproto IGE 底層 = aes-256-cbc；此等價成立則 bundle 環境 AES 正確）。
+//   2. teleproto IGE 端到端 round-trip 正確（IGE = AES-CBC + XOR 邏輯自洽）。
+import assert from 'node:assert/strict';
+import nodeCrypto from 'node:crypto';
+import browserCrypto from 'crypto-browserify';
+import { IGE } from 'teleproto/crypto/IGE.js';
+
+const enc = (lib, algo, key, iv, pt) => {
+    const c = lib.createCipheriv(algo, key, iv);
+    return Buffer.concat([c.update(pt), c.final()]);
+};
+const dec = (lib, algo, key, iv, ct) => {
+    const d = lib.createDecipheriv(algo, key, iv);
+    return Buffer.concat([d.update(ct), d.final()]);
+};
+
+// 1. polyfill 等價:crypto-browserify(bundle 用) vs Node 原生。
+{
+    const key = Buffer.alloc(32, 7);
+    const iv = Buffer.alloc(16, 3);
+    const pt = Buffer.from('teleproto IGE relies on the block cipher — verify it!'.padEnd(64).slice(0, 64));
+    for (const algo of ['aes-256-cbc', 'aes-256-ctr']) {
+        const nEnc = enc(nodeCrypto, algo, key, iv, pt);
+        const bEnc = enc(browserCrypto, algo, key, iv, pt);
+        assert.ok(bEnc.equals(nEnc), `${algo}: crypto-browserify 與 Node 輸出不一致`);
+        assert.ok(dec(browserCrypto, algo, key, iv, nEnc).equals(pt), `${algo}: cross round-trip 失敗`);
+    }
+}
+
+// 2. teleproto IGE 端到端 round-trip（16 倍數明文,不觸發隨機 pad）。
+{
+    const key = Buffer.alloc(32, 9);
+    const iv = Buffer.alloc(32, 5);
+    const pt = Buffer.alloc(48, 0x41);
+    const ige = new IGE(key, iv);
+    const ct = Buffer.from(ige.encryptIge(pt));
+    assert.ok(!ct.equals(pt), 'IGE 密文竟等於明文（未加密）');
+    assert.ok(Buffer.from(ige.decryptIge(ct)).equals(pt), 'teleproto IGE round-trip 失敗');
+}
+
+console.log('✅ verify OK: crypto-browserify ≡ Node (aes-256-cbc/ctr) + teleproto IGE round-trip');


### PR DESCRIPTION
## 摘要 / Summary

把 GramJS 客戶端的 build recipe 從 `telegram`（GramJS，含 GPL 依賴）遷到 fork **`teleproto`（MIT）**，解掉 PR #195 調研確認的 GPL 授權 blocker。承接已合併的 #195（TG1-live）。

> _Migrates the bundle build recipe from `telegram` (GramJS, GPL-tainted) to the MIT fork `teleproto`, resolving the GPL license blocker found in #195._

## 為什麼 / Why

上游 `telegram` 強制依賴 `@cryptography/aes` = **GPL-3.0-or-later**（MTProto AES-IGE 核心路徑、會被 esbuild inline 進 bundle），與本專案 MIT + Chrome Web Store 分發衝突。`teleproto` 依賴樹零 GPL、AES-IGE 改用 `node:crypto`（瀏覽器靠 crypto-browserify = MIT polyfill），API 與 GramJS 對齊。**一併規避 `telegram` 已 archived 的維護風險。**

## 變更 / Changes

- **`package.json`/lockfile**：`telegram`→`teleproto`；build polyfill 加 `browserify-zlib`（teleproto GZIPPacked 用 `node:zlib`）+ `assert`。lockfile 全樹 **137 packages 零 copyleft、無 `@cryptography/aes`**。
- **`entry.mjs`**：`telegram`→`teleproto`（sessions/events 子路徑相同，export 三符號齊全）。
- **`build.mjs`**：alias 對 bare 與 `node:` 前綴**雙寫**（teleproto 用帶前綴 import）。
- **`verify.mjs`（新）**：`npm run verify` — AES 密碼路徑自我檢查：① crypto-browserify 的 `aes-256-cbc`/`ctr` 與 Node 原生**逐位元組一致** ② teleproto IGE 端到端 round-trip。換掉 GPL 加密庫的正確性保證。
- 文件：SA §5 GPL blocker→已解決、§8 TG2 拆 TG2a/b/c、header v1.4、README 改寫。

## 驗證 / Verification

- `npm ci && npm run build && npm run verify` 全過；bundle 零 GPL 痕跡、export 齊全
- 全套 unit 無回歸（未動 runtime）
- ⚠️ **體積 tradeoff**：2.67 MB min / 483 KB gzip（telegram 1.31M/383K，`browserify-zlib` 較重）。offscreen + opt-in 隔離下影響小，暫不優化（可用 pako-based zlib shim 壓回）

## 注意 / Notes

bundle 仍**不進 `lib/`**（無 code 引用）；TG2b offscreen 整合連同載入 code 一起落地。

🤖 Generated with [Claude Code](https://claude.com/claude-code)