### PR TITLE
fix(rss): URL validation follow-ups + tg lazy-load

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -53,7 +53,7 @@ key_files:
   - file_path: modules/utils/colorUtils.js
     description: "[工具] 顏色工具函式庫。提供 HSL/HEX 轉換、WCAG 對比度計算以及衍生色演算法。"
   - file_path: modules/utils/urlSafety.js
-    description: "[工具] RSS feed URL SSRF 驗證（PR #193）。validateFeedUrl 純函式：僅允許 http/https；黑名單擋 localhost／私網 IPv4（127/8、10/8、192.168/16、172.16/12、169.254/16、0.0.0.0）與 IPv6 保留段（^:: 前綴涵蓋 ::、::1、::ffff:v4、v4-compatible ::/96；fc00::/7、fe80）；IPv6 判斷只對含冒號的 literal 套用，避免誤擋 fc2.com 類網域。decimal/hex/octal IP 編碼靠 new URL() 正規化後被攔。兩個 fetch 入口（rssManager 直抓、offscreen fetchAndParseRssFeed）都先驗來源 URL，redirect 跟隨後再驗 response.url（擋 302 轉私網後讀取回應）。已知限制：字串比對無法防 DNS rebinding（見檔頭註解）。零 chrome/DOM 依賴可跑 unit test。"
+    description: "[工具] RSS feed URL SSRF 驗證（PR #193）。validateFeedUrl 純函式：僅允許 http/https；黑名單擋 localhost／私網 IPv4（127/8、10/8、192.168/16、172.16/12、169.254/16、100.64/10 CGNAT、0.0.0.0）與 IPv6 保留段（^:: 前綴涵蓋 ::、::1、::ffff:v4、v4-compatible ::/96；fc00::/7、fe80）；IPv6 判斷只對含冒號的 literal 套用，避免誤擋 fc2.com 類網域。decimal/hex/octal IP 編碼靠 new URL() 正規化後被攔。兩個 fetch 入口（rssManager 直抓、offscreen fetchAndParseRssFeed）都先驗來源 URL，redirect 跟隨後再驗 response.url（擋 302 轉私網後讀取回應）。已知限制：字串比對無法防 DNS rebinding（見檔頭註解）。零 chrome/DOM 依賴可跑 unit test。"
   - file_path: modules/utils/sectionOrder.js
     description: "[工具] 側邊欄區塊排序純函式（BASE-015）。DEFAULT_SECTION_ORDER 常數與 mergeSectionOrder(stored, actual)：以 storage 偏好為序、過濾本機不存在的 id（容忍他裝置/未來區塊）、缺漏者依 canonical 序附尾；讀取端不回寫。零 chrome/DOM 依賴可跑 unit test。"
   - file_path: modules/ui/sectionOrderUI.js

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -52,6 +52,8 @@ key_files:
     description: "[工具] 文字工具函式庫。提供安全處理 HTML 的工具函式，如 `escapeHtml` 以防止 XSS 攻擊。"
   - file_path: modules/utils/colorUtils.js
     description: "[工具] 顏色工具函式庫。提供 HSL/HEX 轉換、WCAG 對比度計算以及衍生色演算法。"
+  - file_path: modules/utils/urlSafety.js
+    description: "[工具] RSS feed URL SSRF 驗證（PR #193）。validateFeedUrl 純函式：僅允許 http/https；黑名單擋 localhost／私網 IPv4（127/8、10/8、192.168/16、172.16/12、169.254/16、0.0.0.0）與 IPv6 保留段（^:: 前綴涵蓋 ::、::1、::ffff:v4、v4-compatible ::/96；fc00::/7、fe80）；IPv6 判斷只對含冒號的 literal 套用，避免誤擋 fc2.com 類網域。decimal/hex/octal IP 編碼靠 new URL() 正規化後被攔。兩個 fetch 入口（rssManager 直抓、offscreen fetchAndParseRssFeed）都先驗來源 URL，redirect 跟隨後再驗 response.url（擋 302 轉私網後讀取回應）。已知限制：字串比對無法防 DNS rebinding（見檔頭註解）。零 chrome/DOM 依賴可跑 unit test。"
   - file_path: modules/utils/sectionOrder.js
     description: "[工具] 側邊欄區塊排序純函式（BASE-015）。DEFAULT_SECTION_ORDER 常數與 mergeSectionOrder(stored, actual)：以 storage 偏好為序、過濾本機不存在的 id（容忍他裝置/未來區塊）、缺漏者依 canonical 序附尾；讀取端不回寫。零 chrome/DOM 依賴可跑 unit test。"
   - file_path: modules/ui/sectionOrderUI.js
@@ -105,7 +107,7 @@ key_files:
   - file_path: modules/readingListManager.js
     description: "[功能] 閱讀清單業務邏輯。管理閱讀清單 CRUD 操作、自動分組開啟的分頁、刪除時標記 hash 防止 RSS 重複加入、清除所有已讀功能。"
   - file_path: modules/rssManager.js
-    description: "[功能] RSS 訂閱管理。訂閱清單存 chrome.storage.local（自 sync 遷入，rssMigratedFromSync 旗標；updatedAt 為跨裝置合併鍵）、chrome.alarms 排程抓取、hash 去重、自動加入閱讀清單、手動立即抓取。hash/lastFetched 寫入改序列化 read-union-write（hashWriteChain / persistLastFetched，修陳舊快照全表覆寫的去重失效 bug）；storage.onChanged 刷新跨 context in-memory 快取；removeSubscription 寫 rssTombstones；exportLocalRssState/importMergedRssState 為 Drive 同步橋接（rssManager 對 Drive 無知，由 background 驅動）。SW context 的 fetch+parse 委派改用共用 modules/offscreenManager.js 的 ensureOffscreenDocument（與 tg 共用單一 offscreen document,TG2b）。"
+    description: "[功能] RSS 訂閱管理。訂閱清單存 chrome.storage.local（自 sync 遷入，rssMigratedFromSync 旗標；updatedAt 為跨裝置合併鍵）、chrome.alarms 排程抓取、hash 去重、自動加入閱讀清單、手動立即抓取。hash/lastFetched 寫入改序列化 read-union-write（hashWriteChain / persistLastFetched，修陳舊快照全表覆寫的去重失效 bug）；storage.onChanged 刷新跨 context in-memory 快取；removeSubscription 寫 rssTombstones；exportLocalRssState/importMergedRssState 為 Drive 同步橋接（rssManager 對 Drive 無知，由 background 驅動）。SW context 的 fetch+parse 委派改用共用 modules/offscreenManager.js 的 ensureOffscreenDocument（與 tg 共用單一 offscreen document,TG2b）。fetchRssFeed 進入點先經 modules/utils/urlSafety.js 驗證 feed URL,redirect 跟隨後再驗 response.url（PR #193）。"
   - file_path: modules/rss/rssSyncLogic.js
     description: "[功能][純函式] RSS 狀態跨裝置合併邏輯（set-union / id-merge，非 workspace 的 rev 模型）。mergeRssState（hashes union+cap、subs 依 id 合併 updatedAt-LWW + lastFetched-max、tombstone deletedAt≥updatedAt 排除 + union + GC 180d）對固定 now 交換律+冪等（no-op write guard 收斂前提）；mergeHashesForWrite、capHashes、nextTimestamp(Lamport-lite)、canonicalizeRssState/rssStateEqual。MAX_STORED_HASHES=5000。"
   - file_path: modules/ui/readingListRenderer.js

--- a/modules/newswire/tgClient.js
+++ b/modules/newswire/tgClient.js
@@ -10,8 +10,10 @@
 let _modPromise = null;
 function loadGramJS() {
     // import() reject 時清快取,讓 tgAdapter 的重連能重試(否則永遠拿到同一顆 rejected)。
+    // getURL 而非字面相對路徑:esbuild(make release)會把字面 import() 的 2.7M bundle
+    // inline 進 offscreen.js(iife 無 code-splitting),破壞「不啟用 tg 零成本」的 lazy load。
     if (!_modPromise) {
-        _modPromise = import('../../lib/telegram.bundle.js').catch((e) => { _modPromise = null; throw e; });
+        _modPromise = import(chrome.runtime.getURL('lib/telegram.bundle.js')).catch((e) => { _modPromise = null; throw e; });
     }
     return _modPromise;
 }

--- a/modules/newswire/tgLoginController.js
+++ b/modules/newswire/tgLoginController.js
@@ -9,7 +9,8 @@
 // 不經此模組儲存。session ≈ 完整帳號存取權,由 caller 負責風險告示與 storage。
 
 export function createTgLoginController(deps = {}) {
-    const loadGramJS = deps.loadGramJS || (() => import('../../lib/telegram.bundle.js'));
+    // getURL 而非字面相對路徑:esbuild(make release)會把字面 import() 的 2.7M bundle inline 進 options.js。
+    const loadGramJS = deps.loadGramJS || (() => import(chrome.runtime.getURL('lib/telegram.bundle.js')));
 
     // 建一個短命 client 執行一次性操作後必 disconnect。
     async function withClient(session, apiId, apiHash, fn) {

--- a/modules/rssManager.js
+++ b/modules/rssManager.js
@@ -610,11 +610,14 @@ async function fetchRssFeed(feedUrl) {
             const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
 
             try {
-                const response = await fetch(feedUrl, { signal: controller.signal, redirect: 'manual' });
+                const response = await fetch(feedUrl, { signal: controller.signal });
                 clearTimeout(timeoutId);
 
-                if (response.type === 'opaqueredirect') {
-                    throw new Error('Feed URL redirects are not allowed');
+                // Redirects are followed, then the FINAL url is re-validated so a
+                // public feed can't 302 into a private address (same as offscreen.js).
+                const redirectError = checkUrlSafety(response.url);
+                if (redirectError) {
+                    throw new Error(redirectError);
                 }
                 if (!response.ok) {
                     throw new Error(`HTTP ${response.status}`);

--- a/modules/utils/urlSafety.js
+++ b/modules/utils/urlSafety.js
@@ -18,7 +18,9 @@ export function validateFeedUrl(feedUrl) {
         /^10\./.test(hostname) ||
         /^192\.168\./.test(hostname) ||
         /^172\.(1[6-9]|2[0-9]|3[01])\./.test(hostname) ||
-        /^169\.254\./.test(hostname)
+        /^169\.254\./.test(hostname) ||
+        // 100.64.0.0/10 CGNAT (RFC 6598) — incl. Alibaba Cloud metadata 100.100.100.200
+        /^100\.(6[4-9]|[7-9][0-9]|1[01][0-9]|12[0-7])\./.test(hostname)
     ) {
         return 'Feed URL points to private network';
     }

--- a/modules/utils/urlSafety.js
+++ b/modules/utils/urlSafety.js
@@ -27,12 +27,15 @@ export function validateFeedUrl(feedUrl) {
     // Regular DNS hostnames never contain colons, so this avoids false-positives
     // on domains like fc.example.com, fdroid-mirror.org, fe80something.dev.
     if (hostname.includes(':')) {
+        // /^::/ covers the whole reserved low block in canonical form:
+        // :: (unspecified), ::1 (loopback), ::ffff:a.b.c.d (IPv4-mapped),
+        // and deprecated IPv4-compatible ::/96 forms like ::7f00:1.
+        // No public IPv6 address serializes with a leading "::".
         if (
-            hostname === '::1' ||
+            /^::/.test(hostname) ||
             /^fc/i.test(hostname) ||
             /^fd/i.test(hostname) ||
-            /^fe80/i.test(hostname) ||
-            /^::ffff:/i.test(hostname)
+            /^fe80/i.test(hostname)
         ) {
             return 'Feed URL points to private network';
         }

--- a/offscreen.js
+++ b/offscreen.js
@@ -150,11 +150,15 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
                 const controller = new AbortController();
                 const timeoutId = setTimeout(() => controller.abort(), message.timeoutMs || 10000);
 
-                const response = await fetch(message.feedUrl, { signal: controller.signal, redirect: 'manual' });
+                const response = await fetch(message.feedUrl, { signal: controller.signal });
                 clearTimeout(timeoutId);
 
-                if (response.type === 'opaqueredirect') {
-                    sendResponse({ success: false, error: 'Feed URL redirects are not allowed' });
+                // Redirects are followed (http→https, FeedBurner-style feeds are
+                // common), then the FINAL url is re-validated so a public feed
+                // can't 302 into a private address and have its response read.
+                const redirectError = validateFeedUrl(response.url);
+                if (redirectError) {
+                    sendResponse({ success: false, error: redirectError });
                     return;
                 }
                 if (!response.ok) {

--- a/usecase_tests/unit_tests/urlSafety.test.mjs
+++ b/usecase_tests/unit_tests/urlSafety.test.mjs
@@ -1,0 +1,77 @@
+import { validateFeedUrl } from '../../modules/utils/urlSafety.js';
+
+const PRIVATE = 'Feed URL points to private network';
+
+describe('urlSafety.validateFeedUrl', () => {
+    describe('accepts normal public feeds', () => {
+        it.each([
+            'https://example.com/feed.xml',
+            'http://feeds.bbci.co.uk/news/rss.xml',
+            'https://fc2.com/rss',                  // fc-prefixed domain ≠ IPv6 ULA
+            'https://fdroid-mirror.org/feed',       // fd-prefixed domain
+            'https://fe80something.dev/feed',       // fe80-prefixed domain
+            'http://172.32.0.1/feed',               // just outside 172.16.0.0/12
+            'https://[2606:4700::6810:85e5]/feed',  // public IPv6 literal
+        ])('%s', (url) => {
+            expect(validateFeedUrl(url)).toBeNull();
+        });
+    });
+
+    describe('rejects unparseable input', () => {
+        it.each(['', 'not a url', 'http://'])('%j', (url) => {
+            expect(validateFeedUrl(url)).toBe('Invalid feed URL');
+        });
+    });
+
+    describe('rejects non-http(s) protocols', () => {
+        it.each([
+            'ftp://example.com/feed',
+            'file:///etc/passwd',
+            'chrome-extension://abcdef/x.xml',
+            'javascript:alert(1)',
+        ])('%s', (url) => {
+            expect(validateFeedUrl(url)).toBe('Invalid feed URL protocol');
+        });
+    });
+
+    describe('rejects localhost and private/reserved IPv4', () => {
+        it.each([
+            'http://localhost/feed',
+            'http://0.0.0.0/feed',
+            'http://127.0.0.1/feed',
+            'http://127.8.9.10/feed',                    // full 127.0.0.0/8, not just .0.0.1
+            'http://10.1.2.3/feed',
+            'http://192.168.1.1/feed',
+            'http://172.16.0.1/feed',
+            'http://172.31.255.254/feed',
+            'http://169.254.169.254/latest/meta-data/',  // cloud metadata endpoint
+        ])('%s', (url) => {
+            expect(validateFeedUrl(url)).toBe(PRIVATE);
+        });
+    });
+
+    describe('rejects alternate IPv4 encodings (normalized by new URL())', () => {
+        it.each([
+            'http://2130706433/feed',  // decimal → 127.0.0.1
+            'http://0x7f000001/feed',  // hex     → 127.0.0.1
+            'http://0177.0.0.1/feed',  // octal   → 127.0.0.1
+            'http://127.1/feed',       // short   → 127.0.0.1
+        ])('%s', (url) => {
+            expect(validateFeedUrl(url)).toBe(PRIVATE);
+        });
+    });
+
+    describe('rejects private/reserved IPv6 literals', () => {
+        it.each([
+            'http://[::1]/feed',              // loopback
+            'http://[::]/feed',               // unspecified
+            'http://[::ffff:127.0.0.1]/feed', // IPv4-mapped
+            'http://[::127.0.0.1]/feed',      // deprecated IPv4-compatible → ::7f00:1
+            'http://[fc00::1]/feed',          // ULA fc00::/7
+            'http://[fd12:3456::1]/feed',     // ULA fd00::/8
+            'http://[fe80::1]/feed',          // link-local
+        ])('%s', (url) => {
+            expect(validateFeedUrl(url)).toBe(PRIVATE);
+        });
+    });
+});

--- a/usecase_tests/unit_tests/urlSafety.test.mjs
+++ b/usecase_tests/unit_tests/urlSafety.test.mjs
@@ -11,6 +11,8 @@ describe('urlSafety.validateFeedUrl', () => {
             'https://fdroid-mirror.org/feed',       // fd-prefixed domain
             'https://fe80something.dev/feed',       // fe80-prefixed domain
             'http://172.32.0.1/feed',               // just outside 172.16.0.0/12
+            'http://100.63.255.254/feed',           // just below 100.64.0.0/10
+            'http://100.128.0.1/feed',              // just above 100.64.0.0/10
             'https://[2606:4700::6810:85e5]/feed',  // public IPv6 literal
         ])('%s', (url) => {
             expect(validateFeedUrl(url)).toBeNull();
@@ -45,6 +47,9 @@ describe('urlSafety.validateFeedUrl', () => {
             'http://172.16.0.1/feed',
             'http://172.31.255.254/feed',
             'http://169.254.169.254/latest/meta-data/',  // cloud metadata endpoint
+            'http://100.100.100.200/latest/meta-data/',  // Alibaba Cloud metadata (CGNAT range)
+            'http://100.64.0.1/feed',                    // 100.64.0.0/10 lower bound
+            'http://100.127.255.254/feed',               // 100.64.0.0/10 upper bound
         ])('%s', (url) => {
             expect(validateFeedUrl(url)).toBe(PRIVATE);
         });


### PR DESCRIPTION
## 摘要 (Summary)

複查 [PR #193](https://github.com/Tai-ch0802/arc-like-chrome-extension/pull/193)（社群提交的 offscreen.js feed URL SSRF 驗證）merge 後的殘留事項：補上六輪 review 中「已提出但未落地」的三個缺口，並修復一個 review 沒抓到的新問題（esbuild inline 破壞 GramJS lazy-load）。

### 相關 Issue / PR

- Refs #193（follow-up）
- Refs BASE-018（GramJS lazy-load 設計）

---

## 📝 變更內容 (Changes)

### 修復 (Fixed)

- **IPv6 保留段缺口**（`modules/utils/urlSafety.js`）：改用 `/^::/` 前綴判斷，補上最後一輪 review 記錄的 `::`（unspecified）與已棄用 IPv4-compatible `::/96`（如 `::7f00:1`）兩個缺口，同時涵蓋原本的 `::1` 與 `::ffff:` 規則。
- **合法轉址 feed 的功能 regression**（`offscreen.js`、`modules/rssManager.js`）：redirect 政策從「一律拒絕」改為「跟隨後對 `response.url` 重跑同一套驗證」。一律拒絕會讓 http→https、FeedBurner 類合法 feed 全數失效；extension 特有的 SSRF primitive 是 host permission 繞 CORS **讀取回應**（blind GET 任何網頁 `<img>` 都做得到），跟隨後再驗最終 URL 可在恢復功能的同時維持等效防護——302 轉私網時回應不讀即棄。
- **GramJS lazy-load 在 prod 被破壞**（`modules/newswire/tgClient.js`、`tgLoginController.js`）：esbuild iife 無 code-splitting，字面路徑 `import('../../lib/telegram.bundle.js')` 被整顆 inline——offscreen.js 2.76MB（PR #193 改 esbuild bundle 後）、options.js 2.87MB（TG2c 起即存在）。改為 `import(chrome.runtime.getURL('lib/telegram.bundle.js'))` 讓 esbuild 無法靜態分析、保留 runtime 動態載入。結果：**offscreen.js 2.76MB→6.7KB、options.js 2.87MB→113KB**。

### 新增 (Added)

- `usecase_tests/unit_tests/urlSafety.test.mjs`：review 第五輪要求過的 unit test（33 cases：公網通過含 `fc2.com` 類前綴網域不誤擋、私網／loopback／cloud metadata、decimal/hex/octal IP 編碼、IPv6 保留段）。

### 文件 (Docs)

- `GEMINI.md` key_files：新增 `urlSafety.js` 條目、`rssManager.js` 描述補驗證流程。

---

## 🧪 測試 (Testing)

### 自動化測試

- [x] `npm run test:unit`：46 suites / 592 tests 全數通過（含新增 33 cases）
- [x] `.agent/skills/code-review/scripts/lint-check.sh`：乾淨
- [x] `make release`：端到端成功；zip 內確認 offscreen.js 6.7KB、options.js 113KB、`lib/telegram.bundle.js` 僅一份

### 手動驗證

1. 訂閱一個會轉址的 feed（如 http→https 301）：應可正常抓取，不再回報「Feed URL redirects are not allowed」。
2. 新增 `http://169.254.169.254/`、`http://[::1]/` 等私網 URL：應被拒絕。

---

## ✅ 檢查清單 (Checklist)

- [x] 程式碼遵循專案 coding style
- [x] 已執行 lint 檢查
- [x] 測試已通過
- [x] 文件已更新（GEMINI.md key_files）
- [x] PR 描述包含英文版本

---

## 🌐 English Version

### Summary

Post-merge follow-up for [PR #193](https://github.com/Tai-ch0802/arc-like-chrome-extension/pull/193) (community-contributed feed URL SSRF validation): closes three gaps that were raised during its six review rounds but never landed, and fixes a newly discovered issue the reviews missed (esbuild inlining defeating the GramJS lazy-load design).

### Changes

#### Fixed

- **IPv6 reserved-range gaps** (`modules/utils/urlSafety.js`): switched to a `/^::/` prefix check, covering the recorded gaps (`::` unspecified and the deprecated IPv4-compatible `::/96` forms like `::7f00:1`) while subsuming the previous `::1` / `::ffff:` rules.
- **Functional regression for legitimately redirecting feeds** (`offscreen.js`, `modules/rssManager.js`): redirect policy changed from "reject all redirects" to "follow, then re-validate the final `response.url`". Blanket rejection broke http→https and FeedBurner-style feeds; the extension-specific SSRF primitive is *reading* cross-origin responses via host permissions (a blind GET is already possible from any web page via `<img>`), so validating the post-redirect URL restores functionality with equivalent protection — a 302 into a private address gets its response discarded unread.
- **GramJS lazy-load defeated in prod builds** (`modules/newswire/tgClient.js`, `tgLoginController.js`): esbuild's iife output has no code-splitting, so literal-path `import('../../lib/telegram.bundle.js')` was inlined wholesale — offscreen.js ballooned to 2.76MB (since PR #193 switched it to esbuild bundling) and options.js to 2.87MB (pre-existing since TG2c). Switched to `import(chrome.runtime.getURL('lib/telegram.bundle.js'))`, which esbuild cannot statically analyze, preserving the runtime dynamic import. Result: **offscreen.js 2.76MB→6.7KB, options.js 2.87MB→113KB**.

#### Added

- `usecase_tests/unit_tests/urlSafety.test.mjs`: the unit tests requested in review round 5 (33 cases: public hosts pass incl. `fc2.com`-style prefix domains, private/loopback/cloud-metadata blocked, decimal/hex/octal IP encodings, IPv6 reserved ranges).

#### Docs

- `GEMINI.md` key_files: added the `urlSafety.js` entry; appended the validation flow to the `rssManager.js` description.

### Testing

- `npm run test:unit`: 46 suites / 592 tests pass (incl. the 33 new cases)
- lint-check.sh clean; `make release` succeeds end-to-end with the expected bundle sizes and a single copy of `lib/telegram.bundle.js` in the zip
- Manual: a redirecting feed (http→https) now subscribes successfully; private-network URLs (`http://169.254.169.254/`, `http://[::1]/`) are rejected

### Related Issues

- Refs #193, BASE-018

🤖 Generated with [Claude Code](https://claude.com/claude-code)
