### PR TITLE
fix(options): render workspace icon in the sync opt-in row (not its raw id)

### DIFF
--- a/options.css
+++ b/options.css
@@ -20,6 +20,15 @@ body {
 .opt-section h2 { margin-top: 0; font-size: 18px; color: var(--text-color-header, #fff); }
 .opt-row { display: flex; align-items: center; justify-content: space-between; gap: 16px; padding: 12px 0; border-bottom: 1px solid var(--border-color, #45475a); }
 .opt-row__label { font-size: 14px; color: var(--text-color-primary, #cdd6f4); }
+/* 工作區同步 opt-in 列的圖示(Material Symbols SVG):SVG 為 inline element,
+   直接置於文字前會沿 baseline 對齊而偏低,故以 inline-flex 置中並留間距。 */
+.sync-ws-icon {
+    display: inline-flex;
+    align-items: center;
+    vertical-align: -3px;
+    margin-right: 6px;
+    color: var(--text-color-secondary, #6c7086);
+}
 .opt-row__desc { font-size: 12px; color: var(--text-color-secondary, #6c7086); margin-top: 2px; }
 
 /* AI provider settings */

--- a/options.js
+++ b/options.js
@@ -43,7 +43,10 @@ function makeRow(labelText, control, descText) {
     const labelWrap = document.createElement('div');
     const label = document.createElement('div');
     label.className = 'opt-row__label';
-    label.textContent = labelText;
+    // 允許傳入 Node(例如「圖示 + 名稱」的組合);字串維持 textContent 不變,
+    // 呼叫端要放圖示時自行組好節點,避免在此開 innerHTML 的口子。
+    if (labelText instanceof Node) label.appendChild(labelText);
+    else label.textContent = labelText;
     labelWrap.appendChild(label);
     if (descText) {
         const desc = document.createElement('div');
@@ -916,10 +919,18 @@ function renderSync(container) {
                     await hydrate();
                 });
                 const name = ws.name || ws.id;
-                optInBlock.appendChild(makeRow(
-                    `${ws.icon ? ws.icon + ' ' : ''}${name}`,
-                    checkbox
-                ));
+                // ws.icon 自 ISSUE-162/M3 起存 Material Symbols icon-id(如 'work'、
+                // 'menu_book'),不再是 emoji——直接字串串接會渲染成字面文字
+                // (「work MyWorkspace」)。經 resolveWorkspaceIcon 轉成 SVG,它同時
+                // 相容 legacy emoji(escapeHtml 後輸出)與缺值 fallback,故 innerHTML
+                // 安全;工作區名稱屬使用者輸入,一律走 text node。
+                const labelNode = document.createDocumentFragment();
+                const iconEl = document.createElement('span');
+                iconEl.className = 'sync-ws-icon';
+                iconEl.innerHTML = workspaceManager.resolveWorkspaceIcon(ws.icon, { size: 16 });
+                labelNode.appendChild(iconEl);
+                labelNode.appendChild(document.createTextNode(name));
+                optInBlock.appendChild(makeRow(labelNode, checkbox));
             }
         }
 

--- a/usecase_tests/puppeteer_tests/happy_path_drive_sync_section.test.js
+++ b/usecase_tests/puppeteer_tests/happy_path_drive_sync_section.test.js
@@ -160,6 +160,25 @@ describe('Options Page: Backup & Sync section', () => {
         expect(state.checked).toBe(false);
         // Not connected (placeholder client_id) → opt-in is disabled until connect.
         expect(state.disabled).toBe(true);
+
+        // The label must render the workspace icon as an ICON, not as the literal
+        // icon-id. Since ISSUE-162/M3 `ws.icon` holds a Material Symbols id
+        // ('work' by default), so string-concatenating it printed "work <name>".
+        const label = await page.$eval(rowSelector, (el) => {
+            const row = el.closest('.opt-row');
+            const labelEl = row && row.querySelector('.opt-row__label');
+            if (!labelEl) return null;
+            const icon = labelEl.querySelector('.sync-ws-icon');
+            return {
+                text: labelEl.textContent.trim(),
+                hasIconSpan: Boolean(icon),
+                hasSvg: Boolean(icon && icon.querySelector('svg')),
+            };
+        });
+        expect(label).not.toBeNull();
+        expect(label.hasIconSpan).toBe(true);
+        expect(label.hasSvg).toBe(true);              // 真的畫出圖示
+        expect(label.text).toBe('SyncOptIn E5c');     // 文字只有名稱,不含 'work'
     }, 60000);
 
     test('the opt-in persistence path flips syncEnabled in storage and round-trips to the checkbox', async () => {


### PR DESCRIPTION
## 問題

設定頁「備份與同步」中，每個工作區的同步 opt-in 列把 label 用字串串接：

```js
`${ws.icon ? ws.icon + ' ' : ''}${name}`
```

但 `ws.icon` 自 **ISSUE-162/M3** 起改存 Material Symbols 的 **icon-id**（`PRESET_ICONS`，如 `'work'`、`'menu_book'`、`'shopping_cart'`），不再是 emoji。於是這列渲染成字面文字：

```
work MyWorkspace        ← 而不是 [圖示] MyWorkspace
```

## 修法

改用既有的 `resolveWorkspaceIcon()`（icon-id → SVG、legacy emoji → `escapeHtml`、缺值 → 預設 icon），用法比照 `workspaceUI.js` 管理列的既有做法。

**`makeRow` 原本只吃字串**（`label.textContent = labelText`），因此加一行型別判斷：傳 `Node` 就 `appendChild`，字串維持原行為——26 個既有呼叫者全部不受影響。

**刻意不在 `makeRow` 內開 `innerHTML`**：把 HTML 的責任留在呼叫端，不給未來的呼叫者一個 XSS 破口。呼叫端則拆成兩段：

- 圖示 → `span.innerHTML`（`resolveWorkspaceIcon` 的輸出受控：icon-id 走白名單 SVG、legacy emoji 已 `escapeHtml`）
- 工作區名稱（**使用者輸入**）→ `createTextNode`

CSS 新增 `.sync-ws-icon`：SVG 是 inline element，直接放在文字前會沿 baseline 對齊而偏低，以 `inline-flex` + `vertical-align` 校正並留間距。

## 測試

**既有 E2E 只檢查 checkbox 的 `type`/`checked`/`disabled`，完全不看 label** —— 這就是為什麼此 bug 自 M3 重構後一直沒被抓到。

於 `happy_path_drive_sync_section.test.js` 補三條斷言：
1. `.sync-ws-icon` 容器存在
2. 其內確實有 `<svg>`（真的畫出圖示，而非文字）
3. label 文字**僅為工作區名稱**（`'SyncOptIn E5c'`，不含 `'work'`）—— 直接對應回報的症狀

**已確認該測試在修復前會 fail**（`hasSvg: false`），修復後 5 passed。

## 驗證

- unit **603 passed**（`makeRow` 改動無回歸）
- E2E happy_path **77/77 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)