### PR TITLE
ci(codeql): drop the python analyzer — it has no source to scan

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -47,8 +47,13 @@ jobs:
           build-mode: none
         - language: javascript-typescript
           build-mode: none
-        - language: python
-          build-mode: none
+        # NOTE: 'python' was removed. This repository ships no Python source that
+        # CodeQL can see — the only .py files live under .agent/skills/ (agent
+        # tooling, and CodeQL skips dot-directories by default), so the Python
+        # analyzer always reported "Processed 0 modules". GitHub now treats
+        # "no source code seen" as a fatal error (exit 32), which broke every PR
+        # and every push to main. Re-add this entry if real Python code is ever
+        # added outside a dot-directory.
         # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'rust', 'swift'
         # Use `c-cpp` to analyze code written in C, C++ or both
         # Use 'java-kotlin' to analyze code written in Java, Kotlin or both


### PR DESCRIPTION
## 問題

CodeQL 的 **Analyze (python)** 自 2026-07-25 15:00 起，在 `main` 與**所有 PR** 上持續失敗：

```
CodeQL could not process any code written in Python.
[INFO] Processed 0 modules in 0.10s
Exit code was 32
```

`main` 上連續三次 CodeQL run 皆 failure（15:00 / 15:05 / 15:13），任何 PR 都會被擋。

## 根因：這個 analyzer 從設定第一天起就是空跑

- 本 repo 是**純 vanilla JS** 的 Chrome 擴充功能，沒有任何產品端 Python 程式碼。
- 唯一的三支 `.py` 位於 `.agent/skills/skill-creator/scripts/`（agent 工具腳本），而 **CodeQL 預設略過 dot-directory**，因此掃不到。
- **關鍵證據**：對照兩次 job log，**失敗之前那次「成功」的 run 也是 `Processed 0 modules`**。差別只在 GitHub 近期把「no source code seen」從警告改判為 **fatal error**。

換句話說：不是新引入的問題，也不是任何 PR 造成的——是一個一直沒在做事的 analyzer，被上游行為變更掀了出來。

## 修法

從 language matrix 移除 `python`，保留實際有在掃這個專案的 `actions` 與 `javascript-typescript`。

原處留下註解說明判斷依據，以及「日後若在 dot-directory 之外新增真正的 Python 程式碼就加回來」的條件——避免後人誤以為是隨手砍掉的。

## 驗證

- `js-yaml` 載入通過（YAML 結構有效）
- matrix 剩 `actions` / `javascript-typescript`
- 本 PR 的 CI 本身即為驗證：`Analyze (python)` 不再出現，其餘 check 應維持通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)