### PR TITLE
feat(routing): context-menu rule creation, group picker, and options management UI (BASE-022 P2)

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -95,7 +95,7 @@ key_files:
   - file_path: modules/ui/bookmarkRenderer.js
     description: "[UI] 書籤渲染。負責書籤列表、資料夾結構以及連結分頁面板的渲染邏輯。"
   - file_path: modules/modalManager.js
-    description: "[互動] 提供客製化的 `showPrompt` 和 `showConfirm` 函式，用以取代原生對話框，提升使用者體驗。"
+    description: "[互動] 提供客製化的 `showPrompt` 和 `showConfirm` 函式，用以取代原生對話框，提升使用者體驗。BASE-022 P2 新增 showGroupPickerDialog：既有群組單選 + 新群組名稱/色票二擇一（互斥自動清除），供路由規則建立流程使用。"
   - file_path: modules/apiManager.js
     description: "[通訊] Chrome API 的封裝層。統一管理所有對 `chrome.*` API 的呼叫（包含書籤搜尋），方便維護與測試。"
   - file_path: modules/stateManager.js
@@ -110,6 +110,8 @@ key_files:
     description: "[功能][純函式] Tab Routing Rules 決策核心（BASE-022 P1）。無 chrome/Date.now，時間由參數傳入：matchRule（清單順序首中即用）、normalizeHost（www 去前綴）、isStartupRestored（瀏覽器還原分頁排除啟發式：啟動窗 10s 內自帶 URL 且無 opener）、claim 生命週期（addClaims/consumeClaim count+TTL 30s/pruneClaims）、sortRules。常數 MAX_RULES=50。"
   - file_path: modules/routing/rulesStore.js
     description: "[功能] 路由規則儲存層。chrome.storage.local 單 key routingRules {schemaVersion,rules[],tombstones}（≤50 條、刪除記 tombstone 供 P4 Drive merge）；CRUD + reorder（重寫 order 並 bump updatedAt）；claimUrls：UI context 開分頁前送 routing:claim 給 background 並 await ack（fail-open，claim 失敗不得擋開分頁）。"
+  - file_path: modules/ui/routingRuleUI.js
+    description: "[UI] 路由規則建立流程（BASE-022 P2）。promptCreateRuleForTab：右鍵選單「一律將此網站分到群組…」→ showGroupPickerDialog → addRule（網域規則）→ 立即套用一次（沿用引擎豁免：已分組/pinned 不動）→ toast + claimUndo（復原＝刪規則＋退群）。分頁右鍵選單本體在 contextMenuManager（http/https 分頁才顯示此項）。"
   - file_path: modules/routing/routingEngine.js
     description: "[Service Worker] 路由引擎（僅 background 載入，BASE-022 P1）。tabs.onCreated/onUpdated 偵測分頁首次 http 導航（免 webNavigation 權限），依規則入群/建群；豁免鏈：claim（onCreated 以 pendingUrl 綁定，redirect-proof）→ 無 candidate 不路由（僅路由引擎在場時出生的分頁）→ 全域開關 → 啟動還原排除 → 已分組/pinned。暫態集中單一 chrome.storage.session key routingSessionState，單一寫者 + promise chain 序列化（SW 終止喚醒一致、瀏覽器重啟歸零）；規則與開關快取以 storage.onChanged 失效。每分頁最多判定一次、手動拖出永不搬回。"
   - file_path: modules/rssManager.js
@@ -133,7 +135,7 @@ key_files:
   - file_path: modules/ui/aiGrouperUI.js
     description: "[UI] 智慧整理介面。負責處理未分類分頁的讀取、呼叫 AI、執行群組化，以及 Undo 復原流程（Toast 顯示/隱藏已抽至 modules/ui/toast.js 共用）。"
   - file_path: modules/ui/toast.js
-    description: "[UI] 共用 Toast（自 aiGrouperUI 抽出）。showToast/hideToast 操作 sidepanel.html 的 #toast-* DOM；另提供 initAiProviderErrorToast：監聽 aiProviderAuthErrorChanged 顯示雲端 AI 授權失敗提示（60 秒 cooldown 防洗版）。"
+    description: "[UI] 共用 Toast（自 aiGrouperUI 抽出）。showToast/hideToast 操作 sidepanel.html 的 #toast-* DOM；另提供 initAiProviderErrorToast：監聽 aiProviderAuthErrorChanged 顯示雲端 AI 授權失敗提示（60 秒 cooldown 防洗版）。BASE-022 P2：undo 按鈕改為 claimUndo 單一擁有者模式（最後聲明者贏，hide/無 undo toast 時清除）——修多功能共用 #toast-undo-btn 時舊 undo 狀態誤觸他功能 handler 的干擾（aiGrouperUI 已遷移）。"
   - file_path: modules/ui/aiCleanupUI.js
     description: "[UI] AI Tab Cleanup 介面。Phase 4b 新增；在 Smart Group 旁顯示 🧹 按鈕，inline section 展示 AI 建議的可關閉分頁清單（預設不勾選 + 全選控制；降低雲端模型下 prompt-injection 誤關分頁的影響面）。Phase 12(批B) 每列加 tab group badge（彩色圓點 + 群組名，未分組不顯示），用 resolveTabGroupBadge 判定。"
   - file_path: modules/ui/hoverSummarizeManager.js

--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -1586,5 +1586,85 @@
   },
   "tgNotReady": {
     "message": "Die Telegram-Verbindung ist noch nicht bereit. Warten Sie einen Moment und versuchen Sie es erneut. Zeigt der Status eine abgelaufene Sitzung, melden Sie sich neu an."
+  },
+  "settingsNavRouting": {
+    "message": "Regeln für automatische Gruppierung",
+    "description": "Options nav label for the Auto Grouping Rules section."
+  },
+  "routingGlobalToggle": {
+    "message": "Neue Tabs nach Regeln einsortieren",
+    "description": "Global on/off switch for rule-based tab routing."
+  },
+  "routingGlobalToggleDesc": {
+    "message": "Ein neuer Tab, der einer Regel entspricht, wird beim ersten Laden automatisch der Zielgruppe hinzugefügt.",
+    "description": "Description under the global routing switch."
+  },
+  "routingAddRule": {
+    "message": "Regel hinzufügen",
+    "description": "Button that opens the add-rule form."
+  },
+  "routingMatchDomain": {
+    "message": "Domain ist gleich",
+    "description": "Match type option: hostname equals the pattern."
+  },
+  "routingMatchContains": {
+    "message": "URL enthält",
+    "description": "Match type option: URL contains the pattern."
+  },
+  "routingPatternPlaceholder": {
+    "message": "z. B. youtube.com",
+    "description": "Placeholder for the rule pattern input."
+  },
+  "routingTargetGroup": {
+    "message": "Gruppenname",
+    "description": "Placeholder/label for the target group name input."
+  },
+  "routingColorAuto": {
+    "message": "Automatische Farbe",
+    "description": "Color select option meaning no fixed color."
+  },
+  "routingEditRule": {
+    "message": "Regel bearbeiten",
+    "description": "Title/aria-label of the edit-rule icon button."
+  },
+  "routingDeleteRule": {
+    "message": "Regel löschen",
+    "description": "Title/aria-label of the delete-rule icon button."
+  },
+  "routingRuleEnabled": {
+    "message": "Regel aktiviert",
+    "description": "Title/aria-label of the per-rule enable checkbox."
+  },
+  "routingDragHandle": {
+    "message": "Zum Sortieren ziehen",
+    "description": "Title of the drag handle used to reorder rules."
+  },
+  "routingEmptyState": {
+    "message": "Noch keine Regeln. Klicke in der Seitenleiste mit rechts auf einen Tab und wähle „Diese Website immer gruppieren…“, oder füge hier eine hinzu.",
+    "description": "Shown when the rule list is empty."
+  },
+  "routingEmptyExample": {
+    "message": "Beispiel: youtube.com → 🎵 Medien",
+    "description": "Example line under the empty state."
+  },
+  "routingLimitReached": {
+    "message": "Regellimit erreicht (50). Lösche eine Regel, um weitere hinzuzufügen.",
+    "description": "Shown when the 50-rule cap is reached."
+  },
+  "ctxAlwaysGroupSite": {
+    "message": "Diese Website immer gruppieren…",
+    "description": "Tab context-menu item that creates a routing rule for the site."
+  },
+  "groupPickerTitle": {
+    "message": "Diese Website immer gruppieren in…",
+    "description": "Title of the group picker dialog."
+  },
+  "groupPickerNewGroup": {
+    "message": "Neuer Gruppenname…",
+    "description": "Placeholder of the new-group name input in the group picker."
+  },
+  "routingRuleCreatedToast": {
+    "message": "Regel erstellt – neue Tabs dieser Website werden automatisch der Gruppe hinzugefügt.",
+    "description": "Toast shown after a routing rule is created from the context menu."
   }
 }

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1589,5 +1589,85 @@
   },
   "tgNotReady": {
     "message": "The Telegram connection is not ready yet. Wait a moment and try again. If the status shows the session has expired, log in again."
+  },
+  "settingsNavRouting": {
+    "message": "Auto Grouping Rules",
+    "description": "Options nav label for the Auto Grouping Rules section."
+  },
+  "routingGlobalToggle": {
+    "message": "Route new tabs by rules",
+    "description": "Global on/off switch for rule-based tab routing."
+  },
+  "routingGlobalToggleDesc": {
+    "message": "A new tab matching a rule joins its target group automatically on its first navigation.",
+    "description": "Description under the global routing switch."
+  },
+  "routingAddRule": {
+    "message": "Add rule",
+    "description": "Button that opens the add-rule form."
+  },
+  "routingMatchDomain": {
+    "message": "Domain equals",
+    "description": "Match type option: hostname equals the pattern."
+  },
+  "routingMatchContains": {
+    "message": "URL contains",
+    "description": "Match type option: URL contains the pattern."
+  },
+  "routingPatternPlaceholder": {
+    "message": "e.g. youtube.com",
+    "description": "Placeholder for the rule pattern input."
+  },
+  "routingTargetGroup": {
+    "message": "Group name",
+    "description": "Placeholder/label for the target group name input."
+  },
+  "routingColorAuto": {
+    "message": "Auto color",
+    "description": "Color select option meaning no fixed color."
+  },
+  "routingEditRule": {
+    "message": "Edit rule",
+    "description": "Title/aria-label of the edit-rule icon button."
+  },
+  "routingDeleteRule": {
+    "message": "Delete rule",
+    "description": "Title/aria-label of the delete-rule icon button."
+  },
+  "routingRuleEnabled": {
+    "message": "Rule enabled",
+    "description": "Title/aria-label of the per-rule enable checkbox."
+  },
+  "routingDragHandle": {
+    "message": "Drag to reorder",
+    "description": "Title of the drag handle used to reorder rules."
+  },
+  "routingEmptyState": {
+    "message": "No rules yet. Right-click a tab in the sidebar and pick “Always group this site…”, or add one here.",
+    "description": "Shown when the rule list is empty."
+  },
+  "routingEmptyExample": {
+    "message": "Example: youtube.com → 🎵 Media",
+    "description": "Example line under the empty state."
+  },
+  "routingLimitReached": {
+    "message": "Rule limit reached (50). Delete one to add more.",
+    "description": "Shown when the 50-rule cap is reached."
+  },
+  "ctxAlwaysGroupSite": {
+    "message": "Always group this site…",
+    "description": "Tab context-menu item that creates a routing rule for the site."
+  },
+  "groupPickerTitle": {
+    "message": "Always group this site into…",
+    "description": "Title of the group picker dialog."
+  },
+  "groupPickerNewGroup": {
+    "message": "New group name…",
+    "description": "Placeholder of the new-group name input in the group picker."
+  },
+  "routingRuleCreatedToast": {
+    "message": "Rule created — new tabs from this site will join the group automatically.",
+    "description": "Toast shown after a routing rule is created from the context menu."
   }
 }

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -1586,5 +1586,85 @@
   },
   "tgNotReady": {
     "message": "La conexión de Telegram aún no está lista. Espera un momento e inténtalo de nuevo. Si el estado indica que la sesión caducó, inicia sesión otra vez."
+  },
+  "settingsNavRouting": {
+    "message": "Reglas de agrupación automática",
+    "description": "Options nav label for the Auto Grouping Rules section."
+  },
+  "routingGlobalToggle": {
+    "message": "Agrupar pestañas nuevas según reglas",
+    "description": "Global on/off switch for rule-based tab routing."
+  },
+  "routingGlobalToggleDesc": {
+    "message": "Una pestaña nueva que coincida con una regla se añade automáticamente a su grupo en la primera carga.",
+    "description": "Description under the global routing switch."
+  },
+  "routingAddRule": {
+    "message": "Añadir regla",
+    "description": "Button that opens the add-rule form."
+  },
+  "routingMatchDomain": {
+    "message": "Dominio igual a",
+    "description": "Match type option: hostname equals the pattern."
+  },
+  "routingMatchContains": {
+    "message": "URL contiene",
+    "description": "Match type option: URL contains the pattern."
+  },
+  "routingPatternPlaceholder": {
+    "message": "p. ej. youtube.com",
+    "description": "Placeholder for the rule pattern input."
+  },
+  "routingTargetGroup": {
+    "message": "Nombre del grupo",
+    "description": "Placeholder/label for the target group name input."
+  },
+  "routingColorAuto": {
+    "message": "Color automático",
+    "description": "Color select option meaning no fixed color."
+  },
+  "routingEditRule": {
+    "message": "Editar regla",
+    "description": "Title/aria-label of the edit-rule icon button."
+  },
+  "routingDeleteRule": {
+    "message": "Eliminar regla",
+    "description": "Title/aria-label of the delete-rule icon button."
+  },
+  "routingRuleEnabled": {
+    "message": "Regla activada",
+    "description": "Title/aria-label of the per-rule enable checkbox."
+  },
+  "routingDragHandle": {
+    "message": "Arrastra para reordenar",
+    "description": "Title of the drag handle used to reorder rules."
+  },
+  "routingEmptyState": {
+    "message": "Aún no hay reglas. Haz clic derecho en una pestaña de la barra lateral y elige «Agrupar siempre este sitio…», o añade una aquí.",
+    "description": "Shown when the rule list is empty."
+  },
+  "routingEmptyExample": {
+    "message": "Ejemplo: youtube.com → 🎵 Multimedia",
+    "description": "Example line under the empty state."
+  },
+  "routingLimitReached": {
+    "message": "Límite de reglas alcanzado (50). Elimina una para añadir más.",
+    "description": "Shown when the 50-rule cap is reached."
+  },
+  "ctxAlwaysGroupSite": {
+    "message": "Agrupar siempre este sitio…",
+    "description": "Tab context-menu item that creates a routing rule for the site."
+  },
+  "groupPickerTitle": {
+    "message": "Agrupar siempre este sitio en…",
+    "description": "Title of the group picker dialog."
+  },
+  "groupPickerNewGroup": {
+    "message": "Nombre del grupo nuevo…",
+    "description": "Placeholder of the new-group name input in the group picker."
+  },
+  "routingRuleCreatedToast": {
+    "message": "Regla creada: las pestañas nuevas de este sitio se unirán al grupo automáticamente.",
+    "description": "Toast shown after a routing rule is created from the context menu."
   }
 }

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -1586,5 +1586,85 @@
   },
   "tgNotReady": {
     "message": "La connexion Telegram n’est pas encore prête. Patientez un instant puis réessayez. Si l’état indique que la session a expiré, reconnectez-vous."
+  },
+  "settingsNavRouting": {
+    "message": "Règles de regroupement automatique",
+    "description": "Options nav label for the Auto Grouping Rules section."
+  },
+  "routingGlobalToggle": {
+    "message": "Regrouper les nouveaux onglets selon les règles",
+    "description": "Global on/off switch for rule-based tab routing."
+  },
+  "routingGlobalToggleDesc": {
+    "message": "Un nouvel onglet correspondant à une règle rejoint automatiquement son groupe lors du premier chargement.",
+    "description": "Description under the global routing switch."
+  },
+  "routingAddRule": {
+    "message": "Ajouter une règle",
+    "description": "Button that opens the add-rule form."
+  },
+  "routingMatchDomain": {
+    "message": "Domaine égal à",
+    "description": "Match type option: hostname equals the pattern."
+  },
+  "routingMatchContains": {
+    "message": "URL contient",
+    "description": "Match type option: URL contains the pattern."
+  },
+  "routingPatternPlaceholder": {
+    "message": "ex. youtube.com",
+    "description": "Placeholder for the rule pattern input."
+  },
+  "routingTargetGroup": {
+    "message": "Nom du groupe",
+    "description": "Placeholder/label for the target group name input."
+  },
+  "routingColorAuto": {
+    "message": "Couleur automatique",
+    "description": "Color select option meaning no fixed color."
+  },
+  "routingEditRule": {
+    "message": "Modifier la règle",
+    "description": "Title/aria-label of the edit-rule icon button."
+  },
+  "routingDeleteRule": {
+    "message": "Supprimer la règle",
+    "description": "Title/aria-label of the delete-rule icon button."
+  },
+  "routingRuleEnabled": {
+    "message": "Règle activée",
+    "description": "Title/aria-label of the per-rule enable checkbox."
+  },
+  "routingDragHandle": {
+    "message": "Glisser pour réordonner",
+    "description": "Title of the drag handle used to reorder rules."
+  },
+  "routingEmptyState": {
+    "message": "Aucune règle pour l’instant. Faites un clic droit sur un onglet de la barre latérale et choisissez « Toujours regrouper ce site… », ou ajoutez-en une ici.",
+    "description": "Shown when the rule list is empty."
+  },
+  "routingEmptyExample": {
+    "message": "Exemple : youtube.com → 🎵 Médias",
+    "description": "Example line under the empty state."
+  },
+  "routingLimitReached": {
+    "message": "Limite de règles atteinte (50). Supprimez-en une pour en ajouter.",
+    "description": "Shown when the 50-rule cap is reached."
+  },
+  "ctxAlwaysGroupSite": {
+    "message": "Toujours regrouper ce site…",
+    "description": "Tab context-menu item that creates a routing rule for the site."
+  },
+  "groupPickerTitle": {
+    "message": "Toujours regrouper ce site dans…",
+    "description": "Title of the group picker dialog."
+  },
+  "groupPickerNewGroup": {
+    "message": "Nom du nouveau groupe…",
+    "description": "Placeholder of the new-group name input in the group picker."
+  },
+  "routingRuleCreatedToast": {
+    "message": "Règle créée : les nouveaux onglets de ce site rejoindront le groupe automatiquement.",
+    "description": "Toast shown after a routing rule is created from the context menu."
   }
 }

--- a/_locales/hi/messages.json
+++ b/_locales/hi/messages.json
@@ -1586,5 +1586,85 @@
   },
   "tgNotReady": {
     "message": "Telegram कनेक्शन अभी तैयार नहीं है। कुछ क्षण प्रतीक्षा करें और फिर प्रयास करें। यदि स्थिति दिखाती है कि सत्र समाप्त हो गया है, तो दोबारा लॉग इन करें।"
+  },
+  "settingsNavRouting": {
+    "message": "स्वचालित समूहन नियम",
+    "description": "Options nav label for the Auto Grouping Rules section."
+  },
+  "routingGlobalToggle": {
+    "message": "नियमों से नए टैब समूहित करें",
+    "description": "Global on/off switch for rule-based tab routing."
+  },
+  "routingGlobalToggleDesc": {
+    "message": "नियम से मेल खाने वाला नया टैब पहली बार लोड होते ही अपने समूह में अपने आप जुड़ जाता है।",
+    "description": "Description under the global routing switch."
+  },
+  "routingAddRule": {
+    "message": "नियम जोड़ें",
+    "description": "Button that opens the add-rule form."
+  },
+  "routingMatchDomain": {
+    "message": "डोमेन बराबर है",
+    "description": "Match type option: hostname equals the pattern."
+  },
+  "routingMatchContains": {
+    "message": "URL में शामिल है",
+    "description": "Match type option: URL contains the pattern."
+  },
+  "routingPatternPlaceholder": {
+    "message": "जैसे youtube.com",
+    "description": "Placeholder for the rule pattern input."
+  },
+  "routingTargetGroup": {
+    "message": "समूह का नाम",
+    "description": "Placeholder/label for the target group name input."
+  },
+  "routingColorAuto": {
+    "message": "स्वचालित रंग",
+    "description": "Color select option meaning no fixed color."
+  },
+  "routingEditRule": {
+    "message": "नियम संपादित करें",
+    "description": "Title/aria-label of the edit-rule icon button."
+  },
+  "routingDeleteRule": {
+    "message": "नियम हटाएँ",
+    "description": "Title/aria-label of the delete-rule icon button."
+  },
+  "routingRuleEnabled": {
+    "message": "नियम सक्षम",
+    "description": "Title/aria-label of the per-rule enable checkbox."
+  },
+  "routingDragHandle": {
+    "message": "क्रम बदलने के लिए खींचें",
+    "description": "Title of the drag handle used to reorder rules."
+  },
+  "routingEmptyState": {
+    "message": "अभी कोई नियम नहीं है। साइडबार में किसी टैब पर राइट-क्लिक करके “इस साइट को हमेशा समूह में रखें…” चुनें, या यहाँ जोड़ें।",
+    "description": "Shown when the rule list is empty."
+  },
+  "routingEmptyExample": {
+    "message": "उदाहरण: youtube.com → 🎵 मीडिया",
+    "description": "Example line under the empty state."
+  },
+  "routingLimitReached": {
+    "message": "नियम सीमा (50) पूरी हो गई। और जोड़ने के लिए एक हटाएँ।",
+    "description": "Shown when the 50-rule cap is reached."
+  },
+  "ctxAlwaysGroupSite": {
+    "message": "इस साइट को हमेशा समूह में रखें…",
+    "description": "Tab context-menu item that creates a routing rule for the site."
+  },
+  "groupPickerTitle": {
+    "message": "इस साइट के टैब हमेशा इस समूह में…",
+    "description": "Title of the group picker dialog."
+  },
+  "groupPickerNewGroup": {
+    "message": "नए समूह का नाम…",
+    "description": "Placeholder of the new-group name input in the group picker."
+  },
+  "routingRuleCreatedToast": {
+    "message": "नियम बन गया — अब इस साइट के नए टैब अपने आप समूह में जुड़ेंगे।",
+    "description": "Toast shown after a routing rule is created from the context menu."
   }
 }

--- a/_locales/id/messages.json
+++ b/_locales/id/messages.json
@@ -1586,5 +1586,85 @@
   },
   "tgNotReady": {
     "message": "Koneksi Telegram belum siap. Tunggu sejenak lalu coba lagi. Jika status menunjukkan sesi sudah tidak berlaku, masuk kembali."
+  },
+  "settingsNavRouting": {
+    "message": "Aturan Pengelompokan Otomatis",
+    "description": "Options nav label for the Auto Grouping Rules section."
+  },
+  "routingGlobalToggle": {
+    "message": "Kelompokkan tab baru sesuai aturan",
+    "description": "Global on/off switch for rule-based tab routing."
+  },
+  "routingGlobalToggleDesc": {
+    "message": "Tab baru yang cocok dengan aturan akan otomatis masuk ke grupnya saat pertama kali dimuat.",
+    "description": "Description under the global routing switch."
+  },
+  "routingAddRule": {
+    "message": "Tambah aturan",
+    "description": "Button that opens the add-rule form."
+  },
+  "routingMatchDomain": {
+    "message": "Domain sama dengan",
+    "description": "Match type option: hostname equals the pattern."
+  },
+  "routingMatchContains": {
+    "message": "URL mengandung",
+    "description": "Match type option: URL contains the pattern."
+  },
+  "routingPatternPlaceholder": {
+    "message": "mis. youtube.com",
+    "description": "Placeholder for the rule pattern input."
+  },
+  "routingTargetGroup": {
+    "message": "Nama grup",
+    "description": "Placeholder/label for the target group name input."
+  },
+  "routingColorAuto": {
+    "message": "Warna otomatis",
+    "description": "Color select option meaning no fixed color."
+  },
+  "routingEditRule": {
+    "message": "Edit aturan",
+    "description": "Title/aria-label of the edit-rule icon button."
+  },
+  "routingDeleteRule": {
+    "message": "Hapus aturan",
+    "description": "Title/aria-label of the delete-rule icon button."
+  },
+  "routingRuleEnabled": {
+    "message": "Aturan aktif",
+    "description": "Title/aria-label of the per-rule enable checkbox."
+  },
+  "routingDragHandle": {
+    "message": "Seret untuk mengurutkan",
+    "description": "Title of the drag handle used to reorder rules."
+  },
+  "routingEmptyState": {
+    "message": "Belum ada aturan. Klik kanan tab di bilah samping lalu pilih “Selalu kelompokkan situs ini…”, atau tambahkan di sini.",
+    "description": "Shown when the rule list is empty."
+  },
+  "routingEmptyExample": {
+    "message": "Contoh: youtube.com → 🎵 Media",
+    "description": "Example line under the empty state."
+  },
+  "routingLimitReached": {
+    "message": "Batas aturan tercapai (50). Hapus satu untuk menambah lagi.",
+    "description": "Shown when the 50-rule cap is reached."
+  },
+  "ctxAlwaysGroupSite": {
+    "message": "Selalu kelompokkan situs ini…",
+    "description": "Tab context-menu item that creates a routing rule for the site."
+  },
+  "groupPickerTitle": {
+    "message": "Selalu kelompokkan situs ini ke…",
+    "description": "Title of the group picker dialog."
+  },
+  "groupPickerNewGroup": {
+    "message": "Nama grup baru…",
+    "description": "Placeholder of the new-group name input in the group picker."
+  },
+  "routingRuleCreatedToast": {
+    "message": "Aturan dibuat — tab baru dari situs ini akan otomatis masuk ke grup.",
+    "description": "Toast shown after a routing rule is created from the context menu."
   }
 }

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -1586,5 +1586,85 @@
   },
   "tgNotReady": {
     "message": "Telegram の接続がまだ準備できていません。しばらく待ってからもう一度お試しください。セッションの期限切れが表示されている場合は再度ログインしてください。"
+  },
+  "settingsNavRouting": {
+    "message": "自動グループ化ルール",
+    "description": "Options nav label for the Auto Grouping Rules section."
+  },
+  "routingGlobalToggle": {
+    "message": "ルールで新しいタブを自動グループ化",
+    "description": "Global on/off switch for rule-based tab routing."
+  },
+  "routingGlobalToggleDesc": {
+    "message": "新しいタブの初回読み込み時、ルールに一致すると指定のグループへ自動的に追加されます。",
+    "description": "Description under the global routing switch."
+  },
+  "routingAddRule": {
+    "message": "ルールを追加",
+    "description": "Button that opens the add-rule form."
+  },
+  "routingMatchDomain": {
+    "message": "ドメインが一致",
+    "description": "Match type option: hostname equals the pattern."
+  },
+  "routingMatchContains": {
+    "message": "URL に含む",
+    "description": "Match type option: URL contains the pattern."
+  },
+  "routingPatternPlaceholder": {
+    "message": "例：youtube.com",
+    "description": "Placeholder for the rule pattern input."
+  },
+  "routingTargetGroup": {
+    "message": "グループ名",
+    "description": "Placeholder/label for the target group name input."
+  },
+  "routingColorAuto": {
+    "message": "自動カラー",
+    "description": "Color select option meaning no fixed color."
+  },
+  "routingEditRule": {
+    "message": "ルールを編集",
+    "description": "Title/aria-label of the edit-rule icon button."
+  },
+  "routingDeleteRule": {
+    "message": "ルールを削除",
+    "description": "Title/aria-label of the delete-rule icon button."
+  },
+  "routingRuleEnabled": {
+    "message": "ルールを有効にする",
+    "description": "Title/aria-label of the per-rule enable checkbox."
+  },
+  "routingDragHandle": {
+    "message": "ドラッグで並べ替え",
+    "description": "Title of the drag handle used to reorder rules."
+  },
+  "routingEmptyState": {
+    "message": "まだルールがありません。サイドバーのタブを右クリックして「このサイトを常にグループへ…」を選ぶか、ここで追加してください。",
+    "description": "Shown when the rule list is empty."
+  },
+  "routingEmptyExample": {
+    "message": "例：youtube.com → 🎵 メディア",
+    "description": "Example line under the empty state."
+  },
+  "routingLimitReached": {
+    "message": "ルールが上限（50 件）に達しました。追加するには削除してください。",
+    "description": "Shown when the 50-rule cap is reached."
+  },
+  "ctxAlwaysGroupSite": {
+    "message": "このサイトを常にグループへ…",
+    "description": "Tab context-menu item that creates a routing rule for the site."
+  },
+  "groupPickerTitle": {
+    "message": "このサイトのタブを常に入れるグループ…",
+    "description": "Title of the group picker dialog."
+  },
+  "groupPickerNewGroup": {
+    "message": "新しいグループ名…",
+    "description": "Placeholder of the new-group name input in the group picker."
+  },
+  "routingRuleCreatedToast": {
+    "message": "ルールを作成しました。今後このサイトの新しいタブは自動的にグループへ追加されます。",
+    "description": "Toast shown after a routing rule is created from the context menu."
   }
 }

--- a/_locales/ko/messages.json
+++ b/_locales/ko/messages.json
@@ -1586,5 +1586,85 @@
   },
   "tgNotReady": {
     "message": "Telegram 연결이 아직 준비되지 않았습니다. 잠시 후 다시 시도하세요. 세션이 만료된 것으로 표시되면 다시 로그인하세요."
+  },
+  "settingsNavRouting": {
+    "message": "자동 그룹화 규칙",
+    "description": "Options nav label for the Auto Grouping Rules section."
+  },
+  "routingGlobalToggle": {
+    "message": "규칙으로 새 탭 자동 그룹화",
+    "description": "Global on/off switch for rule-based tab routing."
+  },
+  "routingGlobalToggleDesc": {
+    "message": "새 탭이 처음 로드될 때 규칙과 일치하면 지정한 그룹에 자동으로 추가됩니다.",
+    "description": "Description under the global routing switch."
+  },
+  "routingAddRule": {
+    "message": "규칙 추가",
+    "description": "Button that opens the add-rule form."
+  },
+  "routingMatchDomain": {
+    "message": "도메인 일치",
+    "description": "Match type option: hostname equals the pattern."
+  },
+  "routingMatchContains": {
+    "message": "URL 포함",
+    "description": "Match type option: URL contains the pattern."
+  },
+  "routingPatternPlaceholder": {
+    "message": "예: youtube.com",
+    "description": "Placeholder for the rule pattern input."
+  },
+  "routingTargetGroup": {
+    "message": "그룹 이름",
+    "description": "Placeholder/label for the target group name input."
+  },
+  "routingColorAuto": {
+    "message": "자동 색상",
+    "description": "Color select option meaning no fixed color."
+  },
+  "routingEditRule": {
+    "message": "규칙 편집",
+    "description": "Title/aria-label of the edit-rule icon button."
+  },
+  "routingDeleteRule": {
+    "message": "규칙 삭제",
+    "description": "Title/aria-label of the delete-rule icon button."
+  },
+  "routingRuleEnabled": {
+    "message": "규칙 사용",
+    "description": "Title/aria-label of the per-rule enable checkbox."
+  },
+  "routingDragHandle": {
+    "message": "드래그하여 순서 변경",
+    "description": "Title of the drag handle used to reorder rules."
+  },
+  "routingEmptyState": {
+    "message": "아직 규칙이 없습니다. 사이드바에서 탭을 우클릭해 “이 사이트를 항상 그룹으로…”를 선택하거나 여기서 추가하세요.",
+    "description": "Shown when the rule list is empty."
+  },
+  "routingEmptyExample": {
+    "message": "예: youtube.com → 🎵 미디어",
+    "description": "Example line under the empty state."
+  },
+  "routingLimitReached": {
+    "message": "규칙이 상한(50개)에 도달했습니다. 삭제 후 추가하세요.",
+    "description": "Shown when the 50-rule cap is reached."
+  },
+  "ctxAlwaysGroupSite": {
+    "message": "이 사이트를 항상 그룹으로…",
+    "description": "Tab context-menu item that creates a routing rule for the site."
+  },
+  "groupPickerTitle": {
+    "message": "이 사이트의 탭을 항상 넣을 그룹…",
+    "description": "Title of the group picker dialog."
+  },
+  "groupPickerNewGroup": {
+    "message": "새 그룹 이름…",
+    "description": "Placeholder of the new-group name input in the group picker."
+  },
+  "routingRuleCreatedToast": {
+    "message": "규칙이 생성되었습니다. 이제 이 사이트의 새 탭은 자동으로 그룹에 추가됩니다.",
+    "description": "Toast shown after a routing rule is created from the context menu."
   }
 }

--- a/_locales/pt_BR/messages.json
+++ b/_locales/pt_BR/messages.json
@@ -1586,5 +1586,85 @@
   },
   "tgNotReady": {
     "message": "A conexão do Telegram ainda não está pronta. Aguarde um momento e tente novamente. Se o status indicar que a sessão expirou, entre novamente."
+  },
+  "settingsNavRouting": {
+    "message": "Regras de agrupamento automático",
+    "description": "Options nav label for the Auto Grouping Rules section."
+  },
+  "routingGlobalToggle": {
+    "message": "Agrupar novas abas pelas regras",
+    "description": "Global on/off switch for rule-based tab routing."
+  },
+  "routingGlobalToggleDesc": {
+    "message": "Uma nova aba que corresponda a uma regra entra automaticamente no grupo na primeira vez que carrega.",
+    "description": "Description under the global routing switch."
+  },
+  "routingAddRule": {
+    "message": "Adicionar regra",
+    "description": "Button that opens the add-rule form."
+  },
+  "routingMatchDomain": {
+    "message": "Domínio igual a",
+    "description": "Match type option: hostname equals the pattern."
+  },
+  "routingMatchContains": {
+    "message": "URL contém",
+    "description": "Match type option: URL contains the pattern."
+  },
+  "routingPatternPlaceholder": {
+    "message": "ex.: youtube.com",
+    "description": "Placeholder for the rule pattern input."
+  },
+  "routingTargetGroup": {
+    "message": "Nome do grupo",
+    "description": "Placeholder/label for the target group name input."
+  },
+  "routingColorAuto": {
+    "message": "Cor automática",
+    "description": "Color select option meaning no fixed color."
+  },
+  "routingEditRule": {
+    "message": "Editar regra",
+    "description": "Title/aria-label of the edit-rule icon button."
+  },
+  "routingDeleteRule": {
+    "message": "Excluir regra",
+    "description": "Title/aria-label of the delete-rule icon button."
+  },
+  "routingRuleEnabled": {
+    "message": "Regra ativada",
+    "description": "Title/aria-label of the per-rule enable checkbox."
+  },
+  "routingDragHandle": {
+    "message": "Arraste para reordenar",
+    "description": "Title of the drag handle used to reorder rules."
+  },
+  "routingEmptyState": {
+    "message": "Nenhuma regra ainda. Clique com o botão direito em uma aba na barra lateral e escolha “Sempre agrupar este site…”, ou adicione uma aqui.",
+    "description": "Shown when the rule list is empty."
+  },
+  "routingEmptyExample": {
+    "message": "Exemplo: youtube.com → 🎵 Mídia",
+    "description": "Example line under the empty state."
+  },
+  "routingLimitReached": {
+    "message": "Limite de regras atingido (50). Exclua uma para adicionar mais.",
+    "description": "Shown when the 50-rule cap is reached."
+  },
+  "ctxAlwaysGroupSite": {
+    "message": "Sempre agrupar este site…",
+    "description": "Tab context-menu item that creates a routing rule for the site."
+  },
+  "groupPickerTitle": {
+    "message": "Sempre agrupar este site em…",
+    "description": "Title of the group picker dialog."
+  },
+  "groupPickerNewGroup": {
+    "message": "Nome do novo grupo…",
+    "description": "Placeholder of the new-group name input in the group picker."
+  },
+  "routingRuleCreatedToast": {
+    "message": "Regra criada — novas abas deste site entrarão no grupo automaticamente.",
+    "description": "Toast shown after a routing rule is created from the context menu."
   }
 }

--- a/_locales/ru/messages.json
+++ b/_locales/ru/messages.json
@@ -1586,5 +1586,85 @@
   },
   "tgNotReady": {
     "message": "Подключение к Telegram ещё не готово. Подождите немного и попробуйте снова. Если статус показывает, что сеанс недействителен, войдите заново."
+  },
+  "settingsNavRouting": {
+    "message": "Правила автогруппировки",
+    "description": "Options nav label for the Auto Grouping Rules section."
+  },
+  "routingGlobalToggle": {
+    "message": "Группировать новые вкладки по правилам",
+    "description": "Global on/off switch for rule-based tab routing."
+  },
+  "routingGlobalToggleDesc": {
+    "message": "Новая вкладка, соответствующая правилу, автоматически попадает в свою группу при первой загрузке.",
+    "description": "Description under the global routing switch."
+  },
+  "routingAddRule": {
+    "message": "Добавить правило",
+    "description": "Button that opens the add-rule form."
+  },
+  "routingMatchDomain": {
+    "message": "Домен равен",
+    "description": "Match type option: hostname equals the pattern."
+  },
+  "routingMatchContains": {
+    "message": "URL содержит",
+    "description": "Match type option: URL contains the pattern."
+  },
+  "routingPatternPlaceholder": {
+    "message": "напр. youtube.com",
+    "description": "Placeholder for the rule pattern input."
+  },
+  "routingTargetGroup": {
+    "message": "Название группы",
+    "description": "Placeholder/label for the target group name input."
+  },
+  "routingColorAuto": {
+    "message": "Автоцвет",
+    "description": "Color select option meaning no fixed color."
+  },
+  "routingEditRule": {
+    "message": "Изменить правило",
+    "description": "Title/aria-label of the edit-rule icon button."
+  },
+  "routingDeleteRule": {
+    "message": "Удалить правило",
+    "description": "Title/aria-label of the delete-rule icon button."
+  },
+  "routingRuleEnabled": {
+    "message": "Правило включено",
+    "description": "Title/aria-label of the per-rule enable checkbox."
+  },
+  "routingDragHandle": {
+    "message": "Перетащите для сортировки",
+    "description": "Title of the drag handle used to reorder rules."
+  },
+  "routingEmptyState": {
+    "message": "Правил пока нет. Щёлкните вкладку в боковой панели правой кнопкой и выберите «Всегда группировать этот сайт…», либо добавьте правило здесь.",
+    "description": "Shown when the rule list is empty."
+  },
+  "routingEmptyExample": {
+    "message": "Пример: youtube.com → 🎵 Медиа",
+    "description": "Example line under the empty state."
+  },
+  "routingLimitReached": {
+    "message": "Достигнут лимит правил (50). Удалите одно, чтобы добавить новое.",
+    "description": "Shown when the 50-rule cap is reached."
+  },
+  "ctxAlwaysGroupSite": {
+    "message": "Всегда группировать этот сайт…",
+    "description": "Tab context-menu item that creates a routing rule for the site."
+  },
+  "groupPickerTitle": {
+    "message": "Всегда помещать вкладки этого сайта в…",
+    "description": "Title of the group picker dialog."
+  },
+  "groupPickerNewGroup": {
+    "message": "Название новой группы…",
+    "description": "Placeholder of the new-group name input in the group picker."
+  },
+  "routingRuleCreatedToast": {
+    "message": "Правило создано — новые вкладки этого сайта будут добавляться в группу автоматически.",
+    "description": "Toast shown after a routing rule is created from the context menu."
   }
 }

--- a/_locales/th/messages.json
+++ b/_locales/th/messages.json
@@ -1586,5 +1586,85 @@
   },
   "tgNotReady": {
     "message": "การเชื่อมต่อ Telegram ยังไม่พร้อม โปรดรอสักครู่แล้วลองอีกครั้ง หากสถานะแสดงว่าเซสชันหมดอายุ โปรดเข้าสู่ระบบใหม่"
+  },
+  "settingsNavRouting": {
+    "message": "กฎการจัดกลุ่มอัตโนมัติ",
+    "description": "Options nav label for the Auto Grouping Rules section."
+  },
+  "routingGlobalToggle": {
+    "message": "จัดกลุ่มแท็บใหม่ตามกฎ",
+    "description": "Global on/off switch for rule-based tab routing."
+  },
+  "routingGlobalToggleDesc": {
+    "message": "แท็บใหม่ที่ตรงกับกฎจะถูกเพิ่มเข้ากลุ่มเป้าหมายโดยอัตโนมัติเมื่อโหลดครั้งแรก",
+    "description": "Description under the global routing switch."
+  },
+  "routingAddRule": {
+    "message": "เพิ่มกฎ",
+    "description": "Button that opens the add-rule form."
+  },
+  "routingMatchDomain": {
+    "message": "โดเมนตรงกับ",
+    "description": "Match type option: hostname equals the pattern."
+  },
+  "routingMatchContains": {
+    "message": "URL มีคำว่า",
+    "description": "Match type option: URL contains the pattern."
+  },
+  "routingPatternPlaceholder": {
+    "message": "เช่น youtube.com",
+    "description": "Placeholder for the rule pattern input."
+  },
+  "routingTargetGroup": {
+    "message": "ชื่อกลุ่ม",
+    "description": "Placeholder/label for the target group name input."
+  },
+  "routingColorAuto": {
+    "message": "สีอัตโนมัติ",
+    "description": "Color select option meaning no fixed color."
+  },
+  "routingEditRule": {
+    "message": "แก้ไขกฎ",
+    "description": "Title/aria-label of the edit-rule icon button."
+  },
+  "routingDeleteRule": {
+    "message": "ลบกฎ",
+    "description": "Title/aria-label of the delete-rule icon button."
+  },
+  "routingRuleEnabled": {
+    "message": "เปิดใช้กฎ",
+    "description": "Title/aria-label of the per-rule enable checkbox."
+  },
+  "routingDragHandle": {
+    "message": "ลากเพื่อจัดลำดับ",
+    "description": "Title of the drag handle used to reorder rules."
+  },
+  "routingEmptyState": {
+    "message": "ยังไม่มีกฎ คลิกขวาที่แท็บในแถบด้านข้างแล้วเลือก “จัดไซต์นี้เข้ากลุ่มเสมอ…” หรือเพิ่มที่นี่",
+    "description": "Shown when the rule list is empty."
+  },
+  "routingEmptyExample": {
+    "message": "ตัวอย่าง: youtube.com → 🎵 มีเดีย",
+    "description": "Example line under the empty state."
+  },
+  "routingLimitReached": {
+    "message": "ถึงขีดจำกัดของกฎแล้ว (50 ข้อ) โปรดลบบางข้อก่อนเพิ่มใหม่",
+    "description": "Shown when the 50-rule cap is reached."
+  },
+  "ctxAlwaysGroupSite": {
+    "message": "จัดไซต์นี้เข้ากลุ่มเสมอ…",
+    "description": "Tab context-menu item that creates a routing rule for the site."
+  },
+  "groupPickerTitle": {
+    "message": "จัดแท็บของไซต์นี้เข้ากลุ่ม…",
+    "description": "Title of the group picker dialog."
+  },
+  "groupPickerNewGroup": {
+    "message": "ชื่อกลุ่มใหม่…",
+    "description": "Placeholder of the new-group name input in the group picker."
+  },
+  "routingRuleCreatedToast": {
+    "message": "สร้างกฎแล้ว — แท็บใหม่จากไซต์นี้จะเข้ากลุ่มโดยอัตโนมัติ",
+    "description": "Toast shown after a routing rule is created from the context menu."
   }
 }

--- a/_locales/vi/messages.json
+++ b/_locales/vi/messages.json
@@ -1586,5 +1586,85 @@
   },
   "tgNotReady": {
     "message": "Kết nối Telegram chưa sẵn sàng. Vui lòng đợi một chút rồi thử lại. Nếu trạng thái cho thấy phiên đã hết hạn, hãy đăng nhập lại."
+  },
+  "settingsNavRouting": {
+    "message": "Quy tắc nhóm tự động",
+    "description": "Options nav label for the Auto Grouping Rules section."
+  },
+  "routingGlobalToggle": {
+    "message": "Nhóm thẻ mới theo quy tắc",
+    "description": "Global on/off switch for rule-based tab routing."
+  },
+  "routingGlobalToggleDesc": {
+    "message": "Thẻ mới khớp với quy tắc sẽ tự động vào nhóm đích ngay lần tải đầu tiên.",
+    "description": "Description under the global routing switch."
+  },
+  "routingAddRule": {
+    "message": "Thêm quy tắc",
+    "description": "Button that opens the add-rule form."
+  },
+  "routingMatchDomain": {
+    "message": "Tên miền bằng",
+    "description": "Match type option: hostname equals the pattern."
+  },
+  "routingMatchContains": {
+    "message": "URL chứa",
+    "description": "Match type option: URL contains the pattern."
+  },
+  "routingPatternPlaceholder": {
+    "message": "vd: youtube.com",
+    "description": "Placeholder for the rule pattern input."
+  },
+  "routingTargetGroup": {
+    "message": "Tên nhóm",
+    "description": "Placeholder/label for the target group name input."
+  },
+  "routingColorAuto": {
+    "message": "Màu tự động",
+    "description": "Color select option meaning no fixed color."
+  },
+  "routingEditRule": {
+    "message": "Sửa quy tắc",
+    "description": "Title/aria-label of the edit-rule icon button."
+  },
+  "routingDeleteRule": {
+    "message": "Xóa quy tắc",
+    "description": "Title/aria-label of the delete-rule icon button."
+  },
+  "routingRuleEnabled": {
+    "message": "Bật quy tắc",
+    "description": "Title/aria-label of the per-rule enable checkbox."
+  },
+  "routingDragHandle": {
+    "message": "Kéo để sắp xếp",
+    "description": "Title of the drag handle used to reorder rules."
+  },
+  "routingEmptyState": {
+    "message": "Chưa có quy tắc nào. Nhấp chuột phải vào một thẻ ở thanh bên và chọn “Luôn nhóm trang này…”, hoặc thêm tại đây.",
+    "description": "Shown when the rule list is empty."
+  },
+  "routingEmptyExample": {
+    "message": "Ví dụ: youtube.com → 🎵 Media",
+    "description": "Example line under the empty state."
+  },
+  "routingLimitReached": {
+    "message": "Đã đạt giới hạn quy tắc (50). Hãy xóa bớt để thêm mới.",
+    "description": "Shown when the 50-rule cap is reached."
+  },
+  "ctxAlwaysGroupSite": {
+    "message": "Luôn nhóm trang này…",
+    "description": "Tab context-menu item that creates a routing rule for the site."
+  },
+  "groupPickerTitle": {
+    "message": "Luôn nhóm trang này vào…",
+    "description": "Title of the group picker dialog."
+  },
+  "groupPickerNewGroup": {
+    "message": "Tên nhóm mới…",
+    "description": "Placeholder of the new-group name input in the group picker."
+  },
+  "routingRuleCreatedToast": {
+    "message": "Đã tạo quy tắc — thẻ mới từ trang này sẽ tự động vào nhóm.",
+    "description": "Toast shown after a routing rule is created from the context menu."
   }
 }

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -1586,5 +1586,85 @@
   },
   "tgNotReady": {
     "message": "Telegram 连接尚未就绪。请稍候后再试一次；若状态显示 session 已失效，请重新登录。"
+  },
+  "settingsNavRouting": {
+    "message": "自动分组规则",
+    "description": "Options nav label for the Auto Grouping Rules section."
+  },
+  "routingGlobalToggle": {
+    "message": "按规则自动分组新标签页",
+    "description": "Global on/off switch for rule-based tab routing."
+  },
+  "routingGlobalToggleDesc": {
+    "message": "新标签页首次加载时，符合规则就会自动加入指定分组。",
+    "description": "Description under the global routing switch."
+  },
+  "routingAddRule": {
+    "message": "添加规则",
+    "description": "Button that opens the add-rule form."
+  },
+  "routingMatchDomain": {
+    "message": "域名等于",
+    "description": "Match type option: hostname equals the pattern."
+  },
+  "routingMatchContains": {
+    "message": "网址包含",
+    "description": "Match type option: URL contains the pattern."
+  },
+  "routingPatternPlaceholder": {
+    "message": "例：youtube.com",
+    "description": "Placeholder for the rule pattern input."
+  },
+  "routingTargetGroup": {
+    "message": "分组名称",
+    "description": "Placeholder/label for the target group name input."
+  },
+  "routingColorAuto": {
+    "message": "自动配色",
+    "description": "Color select option meaning no fixed color."
+  },
+  "routingEditRule": {
+    "message": "编辑规则",
+    "description": "Title/aria-label of the edit-rule icon button."
+  },
+  "routingDeleteRule": {
+    "message": "删除规则",
+    "description": "Title/aria-label of the delete-rule icon button."
+  },
+  "routingRuleEnabled": {
+    "message": "启用规则",
+    "description": "Title/aria-label of the per-rule enable checkbox."
+  },
+  "routingDragHandle": {
+    "message": "拖拽排序",
+    "description": "Title of the drag handle used to reorder rules."
+  },
+  "routingEmptyState": {
+    "message": "暂无规则。在侧边栏的标签页上右键选择「始终将此网站分到分组…」，或在此添加。",
+    "description": "Shown when the rule list is empty."
+  },
+  "routingEmptyExample": {
+    "message": "例：youtube.com → 🎵 影音",
+    "description": "Example line under the empty state."
+  },
+  "routingLimitReached": {
+    "message": "规则已达上限（50 条），请先删除再添加。",
+    "description": "Shown when the 50-rule cap is reached."
+  },
+  "ctxAlwaysGroupSite": {
+    "message": "始终将此网站分到分组…",
+    "description": "Tab context-menu item that creates a routing rule for the site."
+  },
+  "groupPickerTitle": {
+    "message": "此网站的标签页始终分到…",
+    "description": "Title of the group picker dialog."
+  },
+  "groupPickerNewGroup": {
+    "message": "新分组名称…",
+    "description": "Placeholder of the new-group name input in the group picker."
+  },
+  "routingRuleCreatedToast": {
+    "message": "规则已创建——之后此网站的新标签页会自动加入分组。",
+    "description": "Toast shown after a routing rule is created from the context menu."
   }
 }

--- a/_locales/zh_TW/messages.json
+++ b/_locales/zh_TW/messages.json
@@ -1586,5 +1586,85 @@
   },
   "tgNotReady": {
     "message": "Telegram 連線尚未就緒。請稍候後再試一次；若狀態顯示 session 已失效，請重新登入。"
+  },
+  "settingsNavRouting": {
+    "message": "自動分組規則",
+    "description": "Options nav label for the Auto Grouping Rules section."
+  },
+  "routingGlobalToggle": {
+    "message": "依規則自動分組新分頁",
+    "description": "Global on/off switch for rule-based tab routing."
+  },
+  "routingGlobalToggleDesc": {
+    "message": "新分頁首次載入時，符合規則就會自動加入指定群組。",
+    "description": "Description under the global routing switch."
+  },
+  "routingAddRule": {
+    "message": "新增規則",
+    "description": "Button that opens the add-rule form."
+  },
+  "routingMatchDomain": {
+    "message": "網域等於",
+    "description": "Match type option: hostname equals the pattern."
+  },
+  "routingMatchContains": {
+    "message": "網址包含",
+    "description": "Match type option: URL contains the pattern."
+  },
+  "routingPatternPlaceholder": {
+    "message": "例：youtube.com",
+    "description": "Placeholder for the rule pattern input."
+  },
+  "routingTargetGroup": {
+    "message": "群組名稱",
+    "description": "Placeholder/label for the target group name input."
+  },
+  "routingColorAuto": {
+    "message": "自動配色",
+    "description": "Color select option meaning no fixed color."
+  },
+  "routingEditRule": {
+    "message": "編輯規則",
+    "description": "Title/aria-label of the edit-rule icon button."
+  },
+  "routingDeleteRule": {
+    "message": "刪除規則",
+    "description": "Title/aria-label of the delete-rule icon button."
+  },
+  "routingRuleEnabled": {
+    "message": "啟用規則",
+    "description": "Title/aria-label of the per-rule enable checkbox."
+  },
+  "routingDragHandle": {
+    "message": "拖曳排序",
+    "description": "Title of the drag handle used to reorder rules."
+  },
+  "routingEmptyState": {
+    "message": "尚無規則。在側邊欄的分頁上按右鍵選「一律將此網站分到群組…」，或在此新增。",
+    "description": "Shown when the rule list is empty."
+  },
+  "routingEmptyExample": {
+    "message": "例：youtube.com → 🎵 影音",
+    "description": "Example line under the empty state."
+  },
+  "routingLimitReached": {
+    "message": "規則已達上限（50 條），請先刪除再新增。",
+    "description": "Shown when the 50-rule cap is reached."
+  },
+  "ctxAlwaysGroupSite": {
+    "message": "一律將此網站分到群組…",
+    "description": "Tab context-menu item that creates a routing rule for the site."
+  },
+  "groupPickerTitle": {
+    "message": "這個網站的分頁一律分到…",
+    "description": "Title of the group picker dialog."
+  },
+  "groupPickerNewGroup": {
+    "message": "新群組名稱…",
+    "description": "Placeholder of the new-group name input in the group picker."
+  },
+  "routingRuleCreatedToast": {
+    "message": "規則已建立——之後這個網站的新分頁會自動加入群組。",
+    "description": "Toast shown after a routing rule is created from the context menu."
   }
 }

--- a/docs/specs/feature/BASE-022_tab-routing-rules/SA_spec.md
+++ b/docs/specs/feature/BASE-022_tab-routing-rules/SA_spec.md
@@ -397,3 +397,4 @@ make release && unzip -l *.zip | grep routing   # prod bundle 含 routing（間�
 | Version | Date | Author | Changes |
 |---------|------|--------|---------|
 | v1.0 | 2026-07-27 | Claude Code | Initial draft（基於 codebase 實地盤點：background 監聽現況、sync 五件組模板、session 單寫者模式、E2E 慣例） |
+| v1.1 | 2026-07-27 | Claude Code | P2 落地備註：(1) 建規則流程獨立為 `modules/ui/routingRuleUI.js`（原文「sidepanel.js 或 tabListeners 對應處」的具體化）；(2) 共用 toast undo 按鈕發現既存干擾（aiGrouperUI 的 undo 狀態在 toast 消失後殘留、會誤觸他功能復原）→ toast.js 新增 `claimUndo` 單一擁有者模式，aiGrouperUI 同步遷移；(3) FR-3.06 AI Auto Routing 開關依 phase 對齊改隨 P3 出貨（避免無行為的死開關），FR-4.02 於 P2 先落地全域開關 |

--- a/modules/modalManager.js
+++ b/modules/modalManager.js
@@ -827,3 +827,98 @@ export function showTagDialog({ title, defaultName = '', defaultColor = 'blue' }
         };
     });
 }
+
+/**
+ * Group picker for routing-rule creation (BASE-022 P2): choose an EXISTING
+ * named tab group in the current window, or type a NEW group name and pick a
+ * color. Typing clears the existing-group selection and vice versa; submit
+ * resolves to whichever is active.
+ *
+ * @param {{ groups?: Array<{id:number,title:string,color:string}>, preselectGroupId?: number|null }} args
+ * @returns {Promise<{groupTitle:string, groupColor:string|null, existingGroupId:number|null} | null>}
+ */
+export function showGroupPickerDialog({ groups = [], preselectGroupId = null } = {}) {
+    return new Promise((resolve) => {
+        const namedGroups = groups.filter(g => g.title && g.title.trim());
+        let selectedColor = 'grey';
+
+        const form = document.createElement('form');
+        form.noValidate = true;
+        form.className = 'create-group-form group-picker-form';
+
+        const groupRows = namedGroups.map(g => `
+            <label class="group-picker-item">
+                <input type="radio" name="gp-existing" value="${g.id}" ${g.id === preselectGroupId ? 'checked' : ''}>
+                <span class="group-picker-dot" style="background-color: ${GROUP_COLORS[g.color] || GROUP_COLORS.grey};"></span>
+                <span class="group-picker-title">${escapeHtml(g.title)}</span>
+            </label>
+        `).join('');
+
+        const colorSwatches = Object.entries(GROUP_COLORS).map(([colorName, colorHex]) => `
+            <div class="color-swatch ${colorName === selectedColor ? 'selected' : ''}"
+                 data-color="${colorName}"
+                 style="background-color: ${colorHex};"
+                 tabindex="0" role="radio"
+                 aria-checked="${colorName === selectedColor}"
+                 aria-label="${colorName}" title="${colorName}"></div>
+        `).join('');
+
+        form.innerHTML = `
+            <h3 class="modal-title">${api.getMessage('groupPickerTitle') || 'Always group this site into…'}</h3>
+            ${namedGroups.length ? `<div class="group-picker-list" role="radiogroup">${groupRows}</div>` : ''}
+            <input type="text" class="modal-input group-picker-new-input" placeholder="${api.getMessage('groupPickerNewGroup') || 'New group name…'}">
+            <div class="color-swatches-container" role="radiogroup">${colorSwatches}</div>
+            <div class="modal-buttons">
+                <button type="button" class="modal-button cancel-btn">${api.getMessage('cancelButton') || 'Cancel'}</button>
+                <button type="submit" class="modal-button confirm-btn primary">${api.getMessage('saveButton') || 'Save'}</button>
+            </div>
+        `;
+
+        const { overlay, modalContent } = createModal(form);
+        const input = modalContent.querySelector('.group-picker-new-input');
+        const radios = [...modalContent.querySelectorAll('input[name="gp-existing"]')];
+        const swatchesContainer = modalContent.querySelector('.color-swatches-container');
+
+        // Mutual exclusion: typing a new name clears the existing selection…
+        input.addEventListener('input', () => {
+            if (input.value.trim()) radios.forEach(r => { r.checked = false; });
+        });
+        // …and picking an existing group clears the new-name input.
+        radios.forEach(r => r.addEventListener('change', () => { input.value = ''; }));
+
+        const selectSwatch = (target) => {
+            const prev = swatchesContainer.querySelector('.selected');
+            if (prev) { prev.classList.remove('selected'); prev.setAttribute('aria-checked', 'false'); }
+            target.classList.add('selected');
+            target.setAttribute('aria-checked', 'true');
+            selectedColor = target.dataset.color;
+        };
+        swatchesContainer.addEventListener('click', (e) => {
+            if (e.target.classList.contains('color-swatch')) selectSwatch(e.target);
+        });
+        swatchesContainer.addEventListener('keydown', (e) => {
+            if ((e.key === 'Enter' || e.key === ' ') && e.target.classList.contains('color-swatch')) {
+                e.preventDefault();
+                selectSwatch(e.target);
+            }
+        });
+
+        if (!preselectGroupId) input.focus();
+
+        const done = (v) => { removeModal(overlay); resolve(v); };
+        form.onsubmit = (e) => {
+            e.preventDefault();
+            const newName = input.value.trim();
+            if (newName) {
+                done({ groupTitle: newName.slice(0, 64), groupColor: selectedColor, existingGroupId: null });
+                return;
+            }
+            const checked = radios.find(r => r.checked);
+            if (!checked) { input.focus(); return; } // nothing chosen — keep the dialog open
+            const g = namedGroups.find(x => String(x.id) === checked.value);
+            done({ groupTitle: g.title, groupColor: g.color, existingGroupId: g.id });
+        };
+        modalContent.querySelector('.cancel-btn').onclick = () => done(null);
+        overlay.onclick = (e) => { if (e.target === overlay) done(null); };
+    });
+}

--- a/modules/ui/aiGrouperUI.js
+++ b/modules/ui/aiGrouperUI.js
@@ -1,11 +1,10 @@
 import * as api from '../apiManager.js';
 import * as aiManager from '../aiManager.js';
 import * as state from '../stateManager.js';
-import { showToast, hideToast } from './toast.js';
+import { showToast, hideToast, claimUndo } from './toast.js';
 
 export function initAiGrouper() {
     const aiGroupBtn = document.getElementById('ai-group-btn');
-    const undoBtn = document.getElementById('toast-undo-btn');
     const closeBtn = document.getElementById('toast-close-btn');
 
     if (aiGroupBtn) {
@@ -25,9 +24,8 @@ export function initAiGrouper() {
             }
         });
     }
-    if (undoBtn) {
-        undoBtn.addEventListener('click', handleUndoAction);
-    }
+    // Undo button ownership moved to toast.js claimUndo (shared with routing
+    // rules): the handler is claimed per-toast where the toast is shown.
     if (closeBtn) {
         closeBtn.addEventListener('click', hideToast);
     }
@@ -151,6 +149,7 @@ async function handleGroupAction() {
                 createdGroups: createdGroupIds
             });
             showToast(api.getMessage('autoGroupingSuccess'), true);
+            claimUndo(handleUndoAction);
         } else {
             showToast(api.getMessage('noTabsGrouped'));
         }

--- a/modules/ui/contextMenuManager.js
+++ b/modules/ui/contextMenuManager.js
@@ -3,8 +3,10 @@
  * Handles creation and management of custom context menus for tabs.
  */
 import * as api from '../apiManager.js';
-import { COPY_ICON_SVG, READING_LIST_ICON_SVG } from '../icons.js';
+import { COPY_ICON_SVG, READING_LIST_ICON_SVG, ADD_TO_GROUP_ICON_SVG } from '../icons.js';
 import { addToReadingList, isUrlInReadingList } from '../readingListManager.js';
+import { isRealHttpUrl } from '../routing/routingLogic.js';
+import { promptCreateRuleForTab } from './routingRuleUI.js';
 
 /**
  * Shows a custom context menu for a tab element.
@@ -142,6 +144,43 @@ export async function showContextMenu(x, y, tab, originElement) {
         }
 
         menu.appendChild(readingListOption);
+    }
+
+    // --- Always Group This Site Option (BASE-022 routing rule) ---
+    if (isRealHttpUrl(tab.url)) {
+        const routingOption = document.createElement('div');
+        routingOption.className = 'context-menu-item';
+        routingOption.setAttribute('role', 'menuitem');
+        routingOption.tabIndex = 0;
+        routingOption.innerHTML = `
+            ${ADD_TO_GROUP_ICON_SVG}
+            <span>${api.getMessage('ctxAlwaysGroupSite') || 'Always group this site…'}</span>
+        `;
+
+        const triggerCreateRule = () => {
+            // The dialog takes over the interaction — close the menu first.
+            closeMenu();
+            promptCreateRuleForTab(tab).catch(err =>
+                console.warn('[routing] create-rule flow failed', err));
+        };
+
+        routingOption.addEventListener('click', (e) => {
+            e.stopPropagation();
+            triggerCreateRule();
+        });
+        routingOption.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter') {
+                e.preventDefault();
+                e.stopPropagation();
+                triggerCreateRule();
+            } else if (e.key === 'Escape' || e.key === ' ') {
+                e.preventDefault();
+                e.stopPropagation();
+                closeMenu();
+            }
+        });
+
+        menu.appendChild(routingOption);
     }
 
     document.body.appendChild(menu);

--- a/modules/ui/routingRuleUI.js
+++ b/modules/ui/routingRuleUI.js
@@ -1,0 +1,71 @@
+// --- Routing Rule UI flow (sidepanel) ---
+// "Always group this site…" from the tab context menu (BASE-022 P2, FR-3.01~3.03):
+// group picker → persist rule → apply once to the originating tab → toast+undo.
+
+import * as api from '../apiManager.js';
+import * as modal from '../modalManager.js';
+import { addRule, deleteRule } from '../routing/rulesStore.js';
+import { normalizeHost } from '../routing/routingLogic.js';
+import { showToast, hideToast, claimUndo } from './toast.js';
+
+/**
+ * Runs the whole create-rule flow for a sidebar tab.
+ * @param {{id:number, url:string}} tab
+ */
+export async function promptCreateRuleForTab(tab) {
+    let domain;
+    try {
+        domain = normalizeHost(new URL(tab.url).hostname);
+    } catch {
+        return;
+    }
+    if (!domain) return;
+
+    const groups = await api.getTabGroupsInCurrentWindow();
+    const preselectGroupId = (tab.groupId !== undefined && tab.groupId !== chrome.tabGroups.TAB_GROUP_ID_NONE)
+        ? tab.groupId
+        : null;
+    const pick = await modal.showGroupPickerDialog({ groups, preselectGroupId });
+    if (!pick) return;
+
+    const rule = await addRule({
+        matchType: 'domain',
+        pattern: domain,
+        groupTitle: pick.groupTitle,
+        groupColor: pick.groupColor,
+    });
+    if (!rule) {
+        showToast(api.getMessage('routingLimitReached')
+            || 'Rule limit reached (50). Delete one in Settings to add more.');
+        return;
+    }
+
+    // FR-3.03: apply once right away — but only when the tab is still routable
+    // (same exemptions as the engine: not grouped, not pinned).
+    let applied = false;
+    try {
+        const fresh = await api.getTab(tab.id);
+        if (fresh && !fresh.pinned && fresh.groupId === chrome.tabGroups.TAB_GROUP_ID_NONE) {
+            if (pick.existingGroupId !== null) {
+                await api.groupTabs([tab.id], pick.existingGroupId);
+            } else {
+                await api.addTabToNewGroup(tab.id, pick.groupTitle, pick.groupColor || undefined);
+            }
+            applied = true;
+        }
+    } catch (err) {
+        console.warn('[routing] immediate apply failed', err);
+    }
+
+    showToast(api.getMessage('routingRuleCreatedToast')
+        || 'Rule created — new tabs from this site will join the group automatically.', true);
+    claimUndo(async () => {
+        try {
+            await deleteRule(rule.id);
+            if (applied) await api.ungroupTabs([tab.id]);
+        } catch (err) {
+            console.warn('[routing] undo failed', err);
+        }
+        hideToast();
+    });
+}

--- a/modules/ui/toast.js
+++ b/modules/ui/toast.js
@@ -3,18 +3,43 @@
  *
  * Extracted from aiGrouperUI so other features (e.g. cloud AI auth-error
  * surfacing) can reuse the same `#toast-*` DOM defined in sidepanel.html.
- * The undo BUTTON's click handling stays with its feature owner
- * (aiGrouperUI binds #toast-undo-btn); this module only controls visibility.
+ * The undo BUTTON is shared too: features claim it per-toast via claimUndo
+ * (last claim wins), so stale undo state can never fire another feature's
+ * handler.
  */
 import * as api from '../apiManager.js';
 import * as driveAuth from '../sync/driveAuth.js';
 
 let toastTimeoutId = null;
+let currentUndoHandler = null;
+let undoBound = false;
+
+/**
+ * Claims the shared #toast-undo-btn for the CURRENT toast (last claim wins).
+ * The toast shows one message at a time, so Undo ownership follows the
+ * visible message — claiming replaces any previous feature's pending undo,
+ * whose offer is no longer on screen anyway. This is what makes multiple
+ * undo-capable features (AI grouping, routing rules) safe on one button.
+ * Call right after showToast(message, true).
+ * @param {Function} handler - invoked once on click, then cleared
+ */
+export function claimUndo(handler) {
+    currentUndoHandler = handler;
+    if (undoBound) return;
+    const undoBtn = document.getElementById('toast-undo-btn');
+    if (!undoBtn) return;
+    undoBtn.addEventListener('click', () => {
+        const h = currentUndoHandler;
+        currentUndoHandler = null;
+        if (h) h();
+    });
+    undoBound = true;
+}
 
 /**
  * Shows the toast with a message; auto-hides after 10s.
  * @param {string} message
- * @param {boolean} [allowUndo] - Show the Undo button (caller owns its click handler).
+ * @param {boolean} [allowUndo] - Show the Undo button (claim it via claimUndo).
  */
 export function showToast(message, allowUndo = false) {
     const toastContainer = document.getElementById('toast-container');
@@ -29,6 +54,7 @@ export function showToast(message, allowUndo = false) {
         undoBtn.classList.remove('hidden');
     } else {
         undoBtn.classList.add('hidden');
+        currentUndoHandler = null;
     }
 
     toastContainer.classList.remove('hidden');
@@ -42,7 +68,7 @@ export function showToast(message, allowUndo = false) {
     }, 10000); // 10 seconds limit for Undo
 }
 
-/** Hides the toast and clears the auto-hide timer. */
+/** Hides the toast, clears the auto-hide timer and any pending undo claim. */
 export function hideToast() {
     const toastContainer = document.getElementById('toast-container');
     if (toastContainer) {
@@ -52,6 +78,7 @@ export function hideToast() {
         clearTimeout(toastTimeoutId);
         toastTimeoutId = null;
     }
+    currentUndoHandler = null;
 }
 
 // === Cloud AI provider auth-error surfacing ===

--- a/options.css
+++ b/options.css
@@ -80,3 +80,33 @@ body {
 @media (prefers-reduced-motion: reduce) {
     .newswire-card-toggle .opt-row__label::before { transition: none; }
 }
+
+/* --- Auto Grouping Rules section (BASE-022 P2) --- */
+.routing-rules-list { display: flex; flex-direction: column; margin: 8px 0; }
+.routing-rule-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 4px;
+    border-bottom: 1px solid var(--border-color, #45475a);
+    flex-wrap: wrap;
+}
+.routing-drag-handle { cursor: grab; opacity: 0.6; user-select: none; letter-spacing: -2px; }
+.routing-rule-text { flex: 1; min-width: 120px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.routing-rule-target { display: inline-flex; align-items: center; gap: 6px; max-width: 40%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.routing-rule-dot { width: 10px; height: 10px; border-radius: 50%; flex-shrink: 0; }
+.routing-icon-btn {
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: inherit;
+    opacity: 0.7;
+    padding: 4px;
+    border-radius: 4px;
+    display: inline-flex;
+}
+.routing-icon-btn:hover { opacity: 1; background: var(--element-bg-hover-color, rgba(128,128,128,.2)); }
+.routing-rule-form { display: flex; gap: 8px; flex-wrap: wrap; align-items: center; width: 100%; padding: 8px 0; }
+.routing-rule-form .modal-input { flex: 1; min-width: 140px; }
+.routing-empty-state { padding: 12px 0; }
+#routing-add-rule-btn { margin-top: 8px; }

--- a/options.js
+++ b/options.js
@@ -2321,8 +2321,19 @@ async function renderRouting(container) {
         return form;
     }
 
+    let sortableInstance = null;
+
     async function renderList() {
         const state = await rulesStore.getRoutingState();
+        // renderList reuses the same container, so destroy the previous
+        // Sortable first (same convention as dragDropManager). Note: stacked
+        // instances would NOT double-fire onEnd (SortableJS has a global
+        // active-drag singleton — verified empirically); this guards against
+        // instance/listener leaks across re-renders, not double writes.
+        if (sortableInstance) {
+            sortableInstance.destroy();
+            sortableInstance = null;
+        }
         listEl.textContent = '';
 
         const atCap = state.rules.length >= MAX_RULES;
@@ -2401,7 +2412,7 @@ async function renderRouting(container) {
 
         // Drag reorder via the Sortable global loaded by options.html.
         if (typeof Sortable !== 'undefined') {
-            new Sortable(listEl, {
+            sortableInstance = new Sortable(listEl, {
                 handle: '.routing-drag-handle',
                 animation: 150,
                 onEnd: async () => {

--- a/options.js
+++ b/options.js
@@ -11,6 +11,9 @@ import * as modalManager from './modules/modalManager.js';
 import * as driveAuth from './modules/sync/driveAuth.js';
 import * as workspaceManager from './modules/workspace/workspaceManager.js';
 import { renderIcon } from './modules/icons.js';
+import * as rulesStore from './modules/routing/rulesStore.js';
+import { MAX_RULES, VALID_GROUP_COLORS } from './modules/routing/routingLogic.js';
+import { GROUP_COLORS } from './modules/ui/groupColors.js';
 import { mergeSectionOrder, DEFAULT_SECTION_ORDER, SECTION_ORDER_KEY } from './modules/utils/sectionOrder.js';
 import { NEWSWIRE_CONFIG_KEY, NEWSWIRE_KEYS_KEY, defaultNewswireConfig } from './modules/newswire/feedManager.js';
 
@@ -2196,10 +2199,239 @@ function renderNewswire(container) {
     })().catch((err) => console.warn('[newswire] renderNewswire failed:', err?.message || err));
 }
 
+/**
+ * 渲染自動分組規則區塊（BASE-022 P2，FR-4.01~4.03）：全域開關、規則清單
+ * （啟停/編輯/刪除/拖曳排序）、inline 新增/編輯表單、空狀態與 50 條上限提示。
+ * 規則經 modules/routing/rulesStore.js 寫入 chrome.storage.local；background
+ * 引擎透過 storage.onChanged 立即生效，不 dispatch CustomEvent。
+ * AI Auto Routing 的獨立開關（FR-3.06）隨 P3 行為一起出貨，本區塊屆時補列。
+ * @param {HTMLElement} container
+ */
+async function renderRouting(container) {
+    const h = document.createElement('h2');
+    h.textContent = api.getMessage('settingsNavRouting') || 'Auto Grouping Rules';
+    container.appendChild(h);
+
+    const stored = await api.getStorage('sync', { routingEnabled: true });
+    const toggle = document.createElement('input');
+    toggle.type = 'checkbox';
+    toggle.id = 'routing-enabled-toggle';
+    toggle.checked = stored.routingEnabled !== false;
+    toggle.addEventListener('change', async (e) => {
+        await api.setStorage('sync', { routingEnabled: e.target.checked });
+    });
+    container.appendChild(makeRow(
+        api.getMessage('routingGlobalToggle') || 'Route new tabs by rules',
+        toggle,
+        api.getMessage('routingGlobalToggleDesc')
+            || 'A new tab matching a rule joins its target group automatically on its first navigation.'
+    ));
+
+    const listEl = document.createElement('div');
+    listEl.className = 'routing-rules-list';
+    container.appendChild(listEl);
+
+    const limitNote = document.createElement('div');
+    limitNote.className = 'opt-row__desc routing-limit-note';
+    limitNote.hidden = true;
+    limitNote.textContent = api.getMessage('routingLimitReached')
+        || `Rule limit reached (${MAX_RULES}). Delete one to add more.`;
+    container.appendChild(limitNote);
+
+    const addBtn = document.createElement('button');
+    addBtn.type = 'button';
+    addBtn.id = 'routing-add-rule-btn';
+    addBtn.className = 'modal-button';
+    addBtn.textContent = api.getMessage('routingAddRule') || 'Add rule';
+    container.appendChild(addBtn);
+
+    const matchTypeLabel = (mt) => (mt === 'contains'
+        ? (api.getMessage('routingMatchContains') || 'URL contains')
+        : (api.getMessage('routingMatchDomain') || 'Domain equals'));
+
+    /** Inline add/edit form; resolves via callbacks (no modal on the options page). */
+    function buildRuleForm(rule, onDone) {
+        const form = document.createElement('form');
+        form.className = 'routing-rule-form';
+        form.noValidate = true;
+
+        const typeSel = document.createElement('select');
+        for (const mt of ['domain', 'contains']) {
+            const opt = document.createElement('option');
+            opt.value = mt;
+            opt.textContent = matchTypeLabel(mt);
+            typeSel.appendChild(opt);
+        }
+        typeSel.value = rule ? rule.matchType : 'domain';
+
+        const patternInput = document.createElement('input');
+        patternInput.type = 'text';
+        patternInput.className = 'modal-input';
+        patternInput.placeholder = api.getMessage('routingPatternPlaceholder') || 'e.g. youtube.com';
+        patternInput.value = rule ? rule.pattern : '';
+
+        const titleInput = document.createElement('input');
+        titleInput.type = 'text';
+        titleInput.className = 'modal-input';
+        titleInput.placeholder = api.getMessage('routingTargetGroup') || 'Group name';
+        titleInput.value = rule ? rule.groupTitle : '';
+
+        const colorSel = document.createElement('select');
+        const noneOpt = document.createElement('option');
+        noneOpt.value = '';
+        noneOpt.textContent = api.getMessage('routingColorAuto') || 'Auto color';
+        colorSel.appendChild(noneOpt);
+        for (const c of VALID_GROUP_COLORS) {
+            const opt = document.createElement('option');
+            opt.value = c;
+            opt.textContent = c;
+            colorSel.appendChild(opt);
+        }
+        colorSel.value = rule && rule.groupColor ? rule.groupColor : '';
+
+        const saveBtn = document.createElement('button');
+        saveBtn.type = 'submit';
+        saveBtn.className = 'modal-button confirm-btn primary';
+        saveBtn.textContent = api.getMessage('saveButton') || 'Save';
+        const cancelBtn = document.createElement('button');
+        cancelBtn.type = 'button';
+        cancelBtn.className = 'modal-button cancel-btn';
+        cancelBtn.textContent = api.getMessage('cancelButton') || 'Cancel';
+
+        form.append(typeSel, patternInput, titleInput, colorSel, saveBtn, cancelBtn);
+
+        form.onsubmit = async (e) => {
+            e.preventDefault();
+            const payload = {
+                matchType: typeSel.value,
+                pattern: patternInput.value,
+                groupTitle: titleInput.value,
+                groupColor: colorSel.value || null,
+            };
+            let ok;
+            if (rule) {
+                ok = await rulesStore.updateRule(rule.id, payload);
+            } else {
+                ok = (await rulesStore.addRule(payload)) !== null;
+            }
+            if (!ok) { patternInput.focus(); return; } // invalid input or cap hit — keep the form open
+            onDone(true);
+        };
+        cancelBtn.onclick = () => onDone(false);
+        return form;
+    }
+
+    async function renderList() {
+        const state = await rulesStore.getRoutingState();
+        listEl.textContent = '';
+
+        const atCap = state.rules.length >= MAX_RULES;
+        limitNote.hidden = !atCap;
+        addBtn.disabled = atCap;
+
+        if (state.rules.length === 0) {
+            const empty = document.createElement('div');
+            empty.className = 'opt-row__desc routing-empty-state';
+            empty.textContent = (api.getMessage('routingEmptyState')
+                || 'No rules yet. Right-click a tab in the sidebar and pick “Always group this site…”, or add one here.')
+                + ' ' + (api.getMessage('routingEmptyExample') || 'Example: youtube.com → 🎵 Media');
+            listEl.appendChild(empty);
+            return;
+        }
+
+        for (const rule of state.rules) {
+            const row = document.createElement('div');
+            row.className = 'routing-rule-row';
+            row.dataset.ruleId = rule.id;
+
+            const handle = document.createElement('span');
+            handle.className = 'routing-drag-handle';
+            handle.textContent = '⋮⋮';
+            handle.title = api.getMessage('routingDragHandle') || 'Drag to reorder';
+
+            const enabledBox = document.createElement('input');
+            enabledBox.type = 'checkbox';
+            enabledBox.checked = rule.enabled !== false;
+            enabledBox.title = api.getMessage('routingRuleEnabled') || 'Rule enabled';
+            enabledBox.setAttribute('aria-label', enabledBox.title);
+            enabledBox.addEventListener('change', async (e) => {
+                await rulesStore.setRuleEnabled(rule.id, e.target.checked);
+            });
+
+            const text = document.createElement('span');
+            text.className = 'routing-rule-text';
+            text.textContent = `${rule.pattern} (${matchTypeLabel(rule.matchType)})`;
+
+            const target = document.createElement('span');
+            target.className = 'routing-rule-target';
+            const dot = document.createElement('span');
+            dot.className = 'routing-rule-dot';
+            dot.style.backgroundColor = GROUP_COLORS[rule.groupColor] || GROUP_COLORS.grey;
+            const targetTitle = document.createElement('span');
+            targetTitle.textContent = `→ ${rule.groupTitle}`;
+            target.append(dot, targetTitle);
+
+            const editBtn = document.createElement('button');
+            editBtn.type = 'button';
+            editBtn.className = 'routing-icon-btn routing-edit-btn';
+            editBtn.innerHTML = renderIcon('edit', { size: 16 });
+            editBtn.title = api.getMessage('routingEditRule') || 'Edit rule';
+            editBtn.setAttribute('aria-label', editBtn.title);
+            editBtn.addEventListener('click', () => {
+                if (row.querySelector('.routing-rule-form')) return;
+                const form = buildRuleForm(rule, async () => { await renderList(); });
+                row.appendChild(form);
+                form.querySelector('input').focus();
+            });
+
+            const deleteBtn = document.createElement('button');
+            deleteBtn.type = 'button';
+            deleteBtn.className = 'routing-icon-btn routing-delete-btn';
+            deleteBtn.innerHTML = renderIcon('delete', { size: 16 });
+            deleteBtn.title = api.getMessage('routingDeleteRule') || 'Delete rule';
+            deleteBtn.setAttribute('aria-label', deleteBtn.title);
+            deleteBtn.addEventListener('click', async () => {
+                await rulesStore.deleteRule(rule.id);
+                await renderList();
+            });
+
+            row.append(handle, enabledBox, text, target, editBtn, deleteBtn);
+            listEl.appendChild(row);
+        }
+
+        // Drag reorder via the Sortable global loaded by options.html.
+        if (typeof Sortable !== 'undefined') {
+            new Sortable(listEl, {
+                handle: '.routing-drag-handle',
+                animation: 150,
+                onEnd: async () => {
+                    const ids = [...listEl.querySelectorAll('.routing-rule-row')].map(r => r.dataset.ruleId);
+                    await rulesStore.reorderRules(ids);
+                },
+            });
+        }
+    }
+
+    addBtn.addEventListener('click', () => {
+        if (container.querySelector('.routing-rule-form')) return;
+        const form = buildRuleForm(null, async (saved) => {
+            form.remove();
+            addBtn.hidden = false;
+            if (saved) await renderList();
+        });
+        addBtn.hidden = true;
+        container.insertBefore(form, limitNote);
+        form.querySelector('input').focus();
+    });
+
+    await renderList();
+}
+
 const SECTIONS = [
     { id: 'appearance', labelKey: 'settingsNavAppearance', render: renderAppearance },
     { id: 'language',   labelKey: 'settingsNavLanguage',   render: renderLanguage },
     { id: 'features',   labelKey: 'settingsNavFeatures',   render: renderFeatures },
+    { id: 'routing',    labelKey: 'settingsNavRouting',    render: renderRouting, labelFallback: 'Auto Grouping Rules' },
     { id: 'sync',       labelKey: 'settingsNavSync',       render: renderSync, labelFallback: 'Backup & Sync' },
     { id: 'ai',         labelKey: 'settingsNavAi',         render: renderAi },
     { id: 'rss',        labelKey: 'settingsNavRss',        render: renderRss },

--- a/sidepanel.css
+++ b/sidepanel.css
@@ -3931,3 +3931,36 @@ mark.url-match {
     resize: vertical;
     margin-bottom: 8px;
 }
+
+/* --- Group Picker dialog (routing rules, BASE-022 P2) --- */
+.group-picker-list {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    max-height: 180px;
+    overflow-y: auto;
+    margin-bottom: 10px;
+}
+.group-picker-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 8px;
+    border-radius: 6px;
+    cursor: pointer;
+}
+.group-picker-item:hover {
+    background: var(--element-bg-hover-color);
+}
+.group-picker-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+.group-picker-title {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    min-width: 0;
+}

--- a/usecase_tests/puppeteer_tests/happy_path_options_page.test.js
+++ b/usecase_tests/puppeteer_tests/happy_path_options_page.test.js
@@ -30,9 +30,9 @@ describe('Options Page Use Case', () => {
         await teardownBrowser(browser);
     });
 
-    test('left nav renders 8 sections with appearance active by default', async () => {
+    test('left nav renders all sections with appearance active by default', async () => {
         const navItems = await page.$$('.opt-nav__item');
-        expect(navItems.length).toBe(9); // +快訊(newswire, BASE-016 N2)
+        expect(navItems.length).toBe(10); // +快訊(newswire, BASE-016 N2) +自動分組規則(routing, BASE-022 P2)
 
         // The appearance section is active on load.
         await page.waitForSelector('.opt-section.active', { timeout: 5000 });

--- a/usecase_tests/puppeteer_tests/happy_path_routing_context_menu.test.js
+++ b/usecase_tests/puppeteer_tests/happy_path_routing_context_menu.test.js
@@ -1,0 +1,91 @@
+// BASE-022 P2 — "Always group this site…" from the tab context menu
+// (FR-3.01 entry, FR-3.03 immediate apply + toast undo).
+const { setupBrowser, teardownBrowser } = require('./setup');
+
+describe('Routing rule via tab context menu', () => {
+    let browser;
+    let page;
+    const tabUrl = 'https://example.com/ctx-rule';
+
+    beforeAll(async () => {
+        const setup = await setupBrowser();
+        browser = setup.browser;
+        page = setup.page;
+        await page.waitForSelector('#tab-list', { timeout: 15000 });
+    }, 120000);
+
+    afterAll(async () => {
+        try {
+            await page.evaluate(async (url) => {
+                const tabs = await chrome.tabs.query({});
+                const t = tabs.find(x => (x.url || '').startsWith(url));
+                if (t) await chrome.tabs.remove(t.id);
+            }, tabUrl);
+        } catch (e) { }
+        await teardownBrowser(browser);
+    });
+
+    test('creates a rule, applies it to the tab immediately, and undo reverts both', async () => {
+        await page.evaluate((url) => chrome.tabs.create({ url, active: false }), tabUrl);
+        await page.waitForFunction((url) => {
+            return !!Array.from(document.querySelectorAll('.tab-item')).find(
+                el => el.dataset.url && el.dataset.url.startsWith(url)
+            );
+        }, { timeout: 10000 }, tabUrl);
+
+        const targetTab = await page.evaluateHandle((url) => {
+            return Array.from(document.querySelectorAll('.tab-item')).find(
+                el => el.dataset.url && el.dataset.url.startsWith(url)
+            );
+        }, tabUrl);
+        await targetTab.click({ button: 'right' });
+        await page.waitForSelector('.custom-context-menu', { timeout: 15000 });
+
+        // Click the routing item, located by its localized label (host-locale-proof).
+        const clicked = await page.evaluate(() => {
+            const label = chrome.i18n.getMessage('ctxAlwaysGroupSite');
+            const item = Array.from(document.querySelectorAll('.custom-context-menu .context-menu-item'))
+                .find(el => el.textContent.trim() === label.trim());
+            if (!item) return false;
+            item.click();
+            return true;
+        });
+        expect(clicked).toBe(true);
+
+        // Group picker: type a new group name and save.
+        await page.waitForSelector('.group-picker-form', { timeout: 5000 });
+        await page.type('.group-picker-new-input', 'CtxRouted');
+        await page.click('.group-picker-form .confirm-btn');
+
+        // Rule persisted with the tab's normalized domain.
+        await page.waitForFunction(async () => {
+            const v = await chrome.storage.local.get('routingRules');
+            return v.routingRules && v.routingRules.rules.length === 1;
+        }, { timeout: 5000 });
+        const rule = await page.evaluate(async () => {
+            const v = await chrome.storage.local.get('routingRules');
+            return v.routingRules.rules[0];
+        });
+        expect(rule).toMatchObject({ matchType: 'domain', pattern: 'example.com', groupTitle: 'CtxRouted' });
+
+        // FR-3.03: the originating tab was grouped immediately.
+        const groupTitle = await page.evaluate(async (url) => {
+            const tabs = await chrome.tabs.query({});
+            const t = tabs.find(x => (x.url || '').startsWith(url));
+            if (!t || t.groupId === -1) return null;
+            return (await chrome.tabGroups.get(t.groupId)).title;
+        }, tabUrl);
+        expect(groupTitle).toBe('CtxRouted');
+
+        // Undo: rule deleted AND the tab leaves the group.
+        await page.waitForSelector('#toast-container:not(.hidden)', { timeout: 5000 });
+        await page.click('#toast-undo-btn');
+        await page.waitForFunction(async (url) => {
+            const v = await chrome.storage.local.get('routingRules');
+            if (v.routingRules.rules.length !== 0) return false;
+            const tabs = await chrome.tabs.query({});
+            const t = tabs.find(x => (x.url || '').startsWith(url));
+            return t && t.groupId === -1;
+        }, { timeout: 5000 }, tabUrl);
+    }, 90000);
+});

--- a/usecase_tests/puppeteer_tests/happy_path_routing_options.test.js
+++ b/usecase_tests/puppeteer_tests/happy_path_routing_options.test.js
@@ -1,0 +1,102 @@
+// BASE-022 P2 — options "Auto Grouping Rules" section (FR-4.01~4.03, FR-2.06 UI).
+// Follows the happy_path_drive_sync_section pattern: drive the real options
+// page, assert storage round-trips through modules/routing/rulesStore.js.
+const { setupBrowser, teardownBrowser } = require('./setup');
+
+describe('Routing options section', () => {
+    let browser;
+    let page;
+    let extensionId;
+
+    beforeAll(async () => {
+        const setup = await setupBrowser();
+        browser = setup.browser;
+        page = setup.page;
+        extensionId = setup.extensionId;
+        await page.goto(`chrome-extension://${extensionId}/options.html`);
+        await page.waitForSelector('.opt-nav__item[data-section="routing"]', { timeout: 15000 });
+        await page.click('.opt-nav__item[data-section="routing"]');
+        await page.waitForSelector('.opt-section[data-section="routing"].active', { timeout: 5000 });
+    }, 120000);
+
+    afterAll(async () => {
+        await teardownBrowser(browser);
+    });
+
+    test('renders the global toggle and empty state; toggle persists to storage.sync', async () => {
+        await page.waitForSelector('#routing-enabled-toggle', { timeout: 5000 });
+        await page.waitForSelector('.routing-empty-state', { timeout: 5000 });
+
+        await page.click('#routing-enabled-toggle'); // default on → off
+        await page.waitForFunction(async () => {
+            const v = await chrome.storage.sync.get({ routingEnabled: true });
+            return v.routingEnabled === false;
+        }, { timeout: 5000 });
+
+        await page.click('#routing-enabled-toggle'); // back on
+        await page.waitForFunction(async () => {
+            const v = await chrome.storage.sync.get({ routingEnabled: true });
+            return v.routingEnabled === true;
+        }, { timeout: 5000 });
+    }, 60000);
+
+    test('adds, disables and deletes a rule through the inline form', async () => {
+        // --- Add ---
+        await page.click('#routing-add-rule-btn');
+        await page.waitForSelector('.routing-rule-form', { timeout: 5000 });
+        await page.type('.routing-rule-form input:nth-of-type(1)', 'example.com');
+        await page.type('.routing-rule-form input:nth-of-type(2)', 'Routed');
+        await page.select('.routing-rule-form select:nth-of-type(2)', 'red');
+        await page.click('.routing-rule-form .confirm-btn');
+
+        await page.waitForSelector('.routing-rule-row', { timeout: 5000 });
+        const stored = await page.evaluate(async () => {
+            const v = await chrome.storage.local.get('routingRules');
+            return v.routingRules;
+        });
+        expect(stored.rules).toHaveLength(1);
+        expect(stored.rules[0]).toMatchObject({
+            matchType: 'domain',
+            pattern: 'example.com',
+            groupTitle: 'Routed',
+            groupColor: 'red',
+            enabled: true,
+        });
+
+        // --- Disable via the row checkbox ---
+        await page.click('.routing-rule-row input[type="checkbox"]');
+        await page.waitForFunction(async () => {
+            const v = await chrome.storage.local.get('routingRules');
+            return v.routingRules.rules[0].enabled === false;
+        }, { timeout: 5000 });
+
+        // --- Delete ---
+        await page.click('.routing-rule-row .routing-delete-btn');
+        await page.waitForSelector('.routing-empty-state', { timeout: 5000 });
+        const after = await page.evaluate(async () => {
+            const v = await chrome.storage.local.get('routingRules');
+            return v.routingRules;
+        });
+        expect(after.rules).toHaveLength(0);
+        expect(Object.keys(after.tombstones)).toHaveLength(1); // P4 merge safety
+    }, 60000);
+
+    test('edit form sanitizes input through the shared rulesStore path', async () => {
+        await page.click('#routing-add-rule-btn');
+        await page.waitForSelector('.routing-rule-form', { timeout: 5000 });
+        await page.type('.routing-rule-form input:nth-of-type(1)', '  docs.google.com  ');
+        await page.type('.routing-rule-form input:nth-of-type(2)', 'Docs');
+        await page.click('.routing-rule-form .confirm-btn');
+        await page.waitForSelector('.routing-rule-row', { timeout: 5000 });
+
+        const pattern = await page.evaluate(async () => {
+            const v = await chrome.storage.local.get('routingRules');
+            return v.routingRules.rules[0].pattern;
+        });
+        expect(pattern).toBe('docs.google.com'); // trimmed by sanitizeRuleInput
+
+        // Cleanup for a hermetic retry.
+        await page.click('.routing-rule-row .routing-delete-btn');
+        await page.waitForSelector('.routing-empty-state', { timeout: 5000 });
+    }, 60000);
+});

--- a/usecase_tests/puppeteer_tests/happy_path_routing_options.test.js
+++ b/usecase_tests/puppeteer_tests/happy_path_routing_options.test.js
@@ -81,6 +81,73 @@ describe('Routing options section', () => {
         expect(Object.keys(after.tombstones)).toHaveLength(1); // P4 merge safety
     }, 60000);
 
+    test('drag reorder after re-renders: order persists with exactly one write', async () => {
+        // NOTE: this is a behavioral invariant test (drag works end-to-end and
+        // writes storage exactly once), not a stacking-regression detector —
+        // SortableJS's global active-drag singleton means stacked instances
+        // would not double-fire onEnd anyway (verified by running this test
+        // against a build without the destroy() fix; the fix prevents
+        // instance/listener leaks, which E2E cannot observe).
+        // Two rules to drag between.
+        for (const [pattern, title] of [['a-site.com', 'GroupA'], ['b-site.com', 'GroupB']]) {
+            await page.click('#routing-add-rule-btn');
+            await page.waitForSelector('.routing-rule-form', { timeout: 5000 });
+            await page.type('.routing-rule-form input:nth-of-type(1)', pattern);
+            await page.type('.routing-rule-form input:nth-of-type(2)', title);
+            await page.click('.routing-rule-form .confirm-btn');
+            await page.waitForFunction((p) => {
+                return !!Array.from(document.querySelectorAll('.routing-rule-row .routing-rule-text'))
+                    .find(el => el.textContent.includes(p));
+            }, { timeout: 5000 }, pattern);
+        }
+
+        // Provoke instance stacking: three edit-open/cancel cycles, each of
+        // which re-runs renderList() on the SAME container (the regression the
+        // destroy-before-recreate fix guards against).
+        for (let i = 0; i < 3; i++) {
+            await page.click('.routing-rule-row .routing-edit-btn');
+            await page.waitForSelector('.routing-rule-form', { timeout: 5000 });
+            await page.click('.routing-rule-form .cancel-btn');
+            await page.waitForFunction(
+                () => !document.querySelector('.routing-rule-form'), { timeout: 5000 });
+        }
+
+        // Count routingRules writes during ONE real drag.
+        await page.evaluate(() => {
+            window.__routingWrites = 0;
+            chrome.storage.onChanged.addListener((changes, area) => {
+                if (area === 'local' && changes.routingRules) window.__routingWrites++;
+            });
+        });
+
+        const rows = await page.$$('.routing-rule-row .routing-drag-handle');
+        expect(rows.length).toBe(2);
+        const from = await rows[0].boundingBox();
+        const to = await rows[1].boundingBox();
+        await page.mouse.move(from.x + from.width / 2, from.y + from.height / 2);
+        await page.mouse.down();
+        // Sortable needs intermediate movement to register the drag.
+        await page.mouse.move(to.x + to.width / 2, to.y + to.height / 2 + 10, { steps: 12 });
+        await page.mouse.up();
+
+        // The reorder persisted with the swapped order…
+        await page.waitForFunction(async () => {
+            const v = await chrome.storage.local.get('routingRules');
+            const sorted = [...v.routingRules.rules].sort((a, b) => a.order - b.order);
+            return sorted[0].pattern === 'b-site.com';
+        }, { timeout: 5000 });
+        // …and exactly ONE write happened (stacked instances would each fire onEnd).
+        const writes = await page.evaluate(() => window.__routingWrites);
+        expect(writes).toBe(1);
+
+        // Cleanup for hermetic retries.
+        while (await page.$('.routing-rule-row .routing-delete-btn')) {
+            await page.click('.routing-rule-row .routing-delete-btn');
+            await new Promise(r => setTimeout(r, 150));
+        }
+        await page.waitForSelector('.routing-empty-state', { timeout: 5000 });
+    }, 90000);
+
     test('edit form sanitizes input through the shared rulesStore path', async () => {
         await page.click('#routing-add-rule-btn');
         await page.waitForSelector('.routing-rule-form', { timeout: 5000 });


### PR DESCRIPTION
## 摘要 (Summary)

**BASE-022 Tab Routing Rules 的 P2**（[P1 = #215](https://github.com/Tai-ch0802/arc-like-chrome-extension/pull/215)）：規則的兩條使用者動線——側欄右鍵零學習成本建規則、options 完整管理介面——以及 20 個 i18n keys × 14 語。Spec：`docs/specs/feature/BASE-022_tab-routing-rules/`（SA v1.1 已記錄本階段落地備註）。

## 📝 變更內容 (Changes)

### 新增 (Added)

- **側欄右鍵動線**（FR-3.01~3.03）：`contextMenuManager` 第三項「一律將此網站分到群組…」（僅 http/https 分頁）→ `modalManager.showGroupPickerDialog`（既有群組單選 ↔ 新群組名稱+色票，互斥自動清除；已在群組內時預選該群組）→ `modules/ui/routingRuleUI.js` 建立網域規則、**立即套用一次**（沿用引擎豁免：已分組/pinned 不動）→ toast 復原（刪規則＋退群）。
- **options 管理區**（FR-4.01~4.03、FR-2.06 UI）：新「自動分組規則」section——全域開關、規則清單（啟停/編輯/刪除）、Sortable 拖曳排序（複用既有 `lib/Sortable.min.js`）、空狀態說明、50 條上限提示與擋新增。
- **i18n**：20 keys × 14 語。先驗證全部 `messages.json` round-trip byte-stable 再以腳本注入，diff 純新增（+1,120 行）。

### 修復 (Fixed)

- **共用 toast undo 按鈕的跨功能誤觸（既存 bug）**：`#toast-undo-btn` 由 aiGrouperUI 無條件綁定，且其 `lastAutoGroupState` 在 toast 消失後殘留——任何第二個共用 undo 的功能都會誤觸舊的 AI 分組復原。根因是共用按鈕無單一擁有者：`toast.js` 新增 `claimUndo`（最後聲明者贏；hide 或無 undo toast 時清除），aiGrouperUI 遷移至同機制。

### 修改 (Changed)

- `happy_path_options_page`：nav 數量斷言 9 → 10（新 section，SA 事前列管的連動）。
- `GEMINI.md` key_files：+`routingRuleUI.js`，更新 modalManager / toast 描述。

### SA 對齊備註（v1.1）

- 建規則流程獨立為 `modules/ui/routingRuleUI.js`（SA 原文「sidepanel.js 或 tabListeners 對應處」的具體化）。
- **FR-3.06（AI Auto Routing 開關）改隨 P3 行為一起出貨**——避免 P2 先出現一顆沒有行為的死開關；FR-4.02 本階段先落地全域開關。

## 🧪 測試 (Testing)

- `npm run test:unit`：✅ 652 passed
- 新 E2E ×2：✅ `happy_path_routing_options`（開關持久化、inline 表單 CRUD、tombstone、淨化 round-trip）、`happy_path_routing_context_menu`（右鍵→選擇器→規則入庫→立即套用→undo 雙重復原）
- 四個 routing E2E 合跑：✅ 11 passed × **連跑 3 次全綠**
- 受影響既有 E2E：✅ `happy_path_context_menu`、`happy_path_options_page`（更新後）
- `npm run test:ci` happy-path 全套：✅ **28 suites / 89 passed**
- `make && make release`：✅ dev zip 含 `routingRuleUI.js`；prod `options.js` bundle 含 rulesStore、`sidepanel.js` bundle 含 group picker（grep 驗證）

### PRD AC 對照（P2 範圍）

- AC for FR-3.01/3.03（context menu 建規則＋立即套用＋undo）：✅ `happy_path_routing_context_menu`
- AC for FR-4.01（排序/啟停持久化）：✅ `happy_path_routing_options`（拖曳排序由 Sortable 承載，E2E 驗 CRUD/啟停；排序持久化走同一 `reorderRules`，單元測試覆蓋）
- FR-4.02：全域開關 ✅；AI 開關 → P3。FR-4.03 空狀態 ✅。FR-5.01 i18n ✅。

---

## 🌐 English Version

### Summary

P2 of BASE-022 Tab Routing Rules (P1 = #215): the two user-facing flows — zero-friction rule creation from the sidebar tab context menu, and a full management section in options — plus 20 i18n keys across 14 locales.

### Changes

- **Added** the context-menu flow (menu item → group picker dialog with existing-group/new-group mutual exclusion → domain rule persisted → applied once immediately with the engine's exemptions → undoable toast), the options "Auto Grouping Rules" section (global switch, rule list with enable/edit/delete, Sortable drag reorder, empty state, 50-rule cap), and 20 i18n keys × 14 locales (byte-stable JSON round-trip verified before scripted injection).
- **Fixed** a pre-existing shared-toast hazard: the Undo button was bound unconditionally by aiGrouperUI and its undo state outlived the toast, so any second feature sharing Undo could trigger a stale AI-grouping revert. `toast.js` now owns the button via `claimUndo` (last claim wins); aiGrouperUI migrated.
- **Deferred** the AI Auto Routing switch (FR-3.06) to P3 so it ships together with its behavior; noted in SA v1.1.

### Testing

Unit 652 passed; 4 routing E2E suites (11 tests) green 3 consecutive runs; full happy-path suite 28 suites / 89 passed; both builds verified to package the new module and bundle the new code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
