### PR TITLE
feat(search): extend sidebar search filtering and highlighting to archive and newswire (BASE-025)

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -103,7 +103,7 @@ key_files:
   - file_path: modules/dragDropManager.js
     description: "[功能] 拖曳排序模組。封裝 SortableJS 的所有邏輯，處理分頁與書籤的拖曳事件，並在拖曳分頁成為書籤時建立關聯。"
   - file_path: modules/searchManager.js
-    description: "[功能] 搜尋過濾模組。負責處理搜尋框的輸入與列表的即時過濾邏輯。"
+    description: "[功能] 搜尋過濾模組。多關鍵字(AND)+tag: 語法解析,過濾+<mark>反白+URL網域比對,覆蓋 tabs/其他視窗/bookmarks/readingList/newswire/archive 全區塊(BASE-025 補齊後兩者;共用 highlightTitleEl/clearTitleEl/setMatchedDomainEl helper,tab 路徑因 _refs 快取另行)。反白安全依據:highlightText 對每一段先 escapeHtml 才組 mark(BASE-017 的快訊反白禁令據此解除)。收合區塊有命中→search-reveal 疊加 class 蓋 display(不碰收合狀態機,清除搜尋自動復原)。監聽 sectionContentRerendered(archive/newswire 重繪後 dispatch)於查詢作用中 debounce 250ms 重跑——快訊即時 prepend 的新列才會被過濾(搜尋中 handleSearch 含書籤樹重繪,連續批次必須收斂)。"
   - file_path: modules/readingListManager.js
     description: "[功能] 閱讀清單業務邏輯。管理閱讀清單 CRUD 操作、自動分組開啟的分頁（BASE-022：開分頁前先 await claimUrls 註冊 routing 豁免，防與路由引擎競速）、刪除時標記 hash 防止 RSS 重複加入、清除所有已讀功能。"
   - file_path: modules/routing/routingLogic.js

--- a/docs/specs/feature/BASE-025_search-archive-newswire/SPEC.md
+++ b/docs/specs/feature/BASE-025_search-archive-newswire/SPEC.md
@@ -1,0 +1,83 @@
+# BASE-025 — 搜尋欄擴及封存區與快訊區（過濾＋反白）
+
+> T1 輕量 SPEC（分級理由：不動 storage schema／manifest／跨 context 協定、無資料遺失風險；
+> 是把既有互動延伸到兩個既有區塊）。隨 PR 一起審。
+
+## 背景與問題
+
+sidebar 搜尋欄本質是 filter：解析多關鍵字（AND）＋ `tag:` 語法，對命中項過濾顯示並以
+`<mark>` 反白匹配片段，同時比對標題與 URL 網域。現況覆蓋盤點（實地精讀 `searchManager.js` 後）：
+
+| 區塊 | 過濾 | 反白 | URL/網域比對 | tag: 查詢時隱藏 |
+|---|---|---|---|---|
+| tabs / 其他視窗 | ✅ | ✅ | ✅ | ✅ |
+| bookmarks | ✅ | ✅ | ✅ | （目標區塊） |
+| reading list | ✅ | ✅ | ✅ | ✅ |
+| **newswire** | ✅（BASE-017） | ❌ | ❌（只比 title+source） | ✅ |
+| **archive（BASE-024）** | ❌ | ❌ | ❌ | ❌ ←上線時漏接 |
+
+兩個真 gap：**封存區完全未接**（含 tag: 查詢不隱藏的既存遺漏——搜尋時封存區顯示全部項目形同雜訊）；
+**快訊有過濾但無反白也無網域比對**。
+
+另外兩個整合難點（本案「比較難」的實質）：
+1. **BASE-017 的反白禁令**：當時以「快訊標題為外部不可信內容，維持 textContent-only」為由不做反白。
+   本案查證 `textUtils.highlightText`：**每一段**（匹配與非匹配區間）都先 `escapeHtml` 才組
+   `<mark>`（textUtils.js:89-99），不可信內容走此路徑安全——閱讀清單標題同屬外部內容、
+   已行之有年。禁令據此解除，並在 filterNewswire 註解記錄查證依據。
+2. **搜尋中重繪洗掉過濾**：快訊即時事件 `prependEvents` 於頂部插入未過濾的新列；封存區在
+   storage 變更時 `reconcileDOM` 重繪。兩者都會讓作用中的搜尋出現漏網項目。
+
+## 方案
+
+- **`filterArchive(keywords, regexes)`**（searchManager 新增）：比對 `dataset.title` ＋
+  `extractDomain(dataset.url)`；反白 `.archive-item-title`；URL 命中（非標題命中）時附
+  `.matched-domain`；snooze 項同列表一起過濾；計數併入 `searchResultUpdated`。
+- **`filterNewswire` 升級**：補網域比對（renderer 補 `dataset.url`，值已經 normalizer 的
+  `new URL` http/https 驗證）＋反白 `.newswire-item__title`。
+- **共用 helper 抽取**：`highlightTitleEl` / `clearTitleEl` / `setMatchedDomainEl`
+  （originalText dataset 模式），readingList／archive／newswire 共用；tab 路徑因 `_refs`
+  快取結構特殊維持原樣。
+- **`hideNonBookmarkSections` 補 archive**（修 BASE-024 上線遺漏）。
+- **收合區塊的搜尋顯示——`search-reveal` 疊加 class**：`#newswire-list.collapsed.search-reveal`
+  ／`#archive-list` 同，CSS override display。**刻意不走 readingList 的 remove-collapsed 作法**：
+  newswire 的收合是 module 變數＋storage 狀態機，直接摘 class 會 desync（下次點 toggle 要按兩次）；
+  疊加 class 不碰狀態機、清除搜尋自動恢復收合。readingList 既有行為不動（不擴scope）。
+- **重繪同步——`sectionContentRerendered` DOM 事件**：archiveRenderer refresh 後、
+  newswireRenderer `renderAll`／`prependEvents` 後 dispatch；searchManager 監聽（沿
+  `bookmarkCacheReady` 慣例），查詢作用中才重跑 `handleSearch`，**debounce 250ms**——
+  搜尋中的 handleSearch 含書籤樹重繪，快訊連續批次必須收斂為一次。
+
+排除的替代方案：renderer 端自行感知搜尋狀態過濾新列（把查詢狀態耦合進兩個 renderer，
+且反白邏輯要三份）；search-reveal 統一套用到 readingList（改既有語意，另案再議）。
+
+## 影響面
+
+- `modules/searchManager.js`：filterArchive 新增、filterNewswire 升級、三個共用 helper、
+  hideNonBookmarkSections、rerender 監聽、計數。
+- `modules/ui/archiveRenderer.js`：`dataset.title/url` ＋ refresh 後 dispatch。
+- `modules/ui/newswireRenderer.js`：`dataset.url` ＋ renderAll/prependEvents 後 dispatch。
+- `sidepanel.css`：search-reveal override 兩條。
+- 無 storage／manifest／訊息協定變更；`<mark>` 樣式沿用既有 `.title-match`／`.url-match`。
+
+## Test Impact
+
+- 新 E2E `happy_path_search_archive_newswire.test.js`：
+  - 封存：seed 項目 → 搜尋 → 非命中 hidden、命中含 `mark.title-match`、URL 命中顯示
+    `.matched-domain`、收合時 search-reveal、清除搜尋還原（反白移除、恢復收合）。
+  - 快訊：以第二個 extension 頁廣播 `{type:'newswire:events'}` 注入事件（`runtime.sendMessage`
+    不自投遞的既有教訓）→ 搜尋過濾＋反白斷言；**搜尋作用中再 prepend 新事件 → 新列被即時
+    過濾**（整合難點的回歸測試）。
+  - `tag:` 查詢：封存與快訊整批隱藏（前者即 BASE-024 遺漏的迴歸）。
+- 既有搜尋相關 E2E（happy_path_spotlight_search／search_group_expand 等）全套跑過確認不破壞。
+- 驗證指令：`npm run test:unit`、`npx jest --testPathPatterns 'happy_path_search_archive_newswire'`、
+  `npm run test:ci`、`make && make release`。
+
+## 驗收條件
+
+- [ ] 搜尋關鍵字時：封存與快訊只顯示標題／網域（快訊另含來源標籤）命中的項目，其餘 hidden。
+- [ ] 命中片段以 `<mark>` 反白（封存＋快訊標題）；URL 命中時封存項顯示反白網域行。
+- [ ] 收合中的封存／快訊區有命中時內容可見；清除搜尋後恢復原收合狀態且反白清除。
+- [ ] `tag:` 查詢時封存與快訊整批隱藏。
+- [ ] 搜尋作用中，快訊新事件與封存重繪產生的新列即時套用過濾。
+- [ ] `searchResultUpdated` 計數含封存命中數。
+- [ ] 全部既有測試綠（unit + happy-path 全套）。

--- a/modules/searchManager.js
+++ b/modules/searchManager.js
@@ -46,10 +46,59 @@ async function handleSearch() {
         clearHighlights();
     }
 
+    // 快取靜態區塊計數:動態區塊(archive/newswire)重繪後的輕量 refilter
+    // 只重算那兩區,其餘沿用本輪結果(review PR #223)。
+    lastStaticCounts = { tabCount, otherWindowsTabCount, readingListCount, bookmarkCount };
+
     const event = new CustomEvent('searchResultUpdated', {
         detail: { tabCount: tabCount + otherWindowsTabCount + readingListCount + newswireCount + archiveCount, bookmarkCount }
     });
     document.dispatchEvent(event);
+}
+
+// 靜態區塊(不會在搜尋中自行重繪者)的最近一輪計數,供輕量 refilter 沿用。
+let lastStaticCounts = { tabCount: 0, otherWindowsTabCount: 0, readingListCount: 0, bookmarkCount: 0 };
+
+/**
+ * 動態區塊輕量 refilter(BASE-025;review PR #223 效能建議):
+ * archive/newswire 在搜尋作用中重繪(快訊即時 prepend、封存 storage 刷新)時,
+ * 只重跑這兩區的過濾——完整 handleSearch 會連帶把整棵書籤樹砍掉重繪,
+ * 與這兩區的重繪毫無關係。計數沿用 lastStaticCounts 重發 searchResultUpdated。
+ */
+function refilterDynamicSections() {
+    const { keywords, tags } = parseSearchQuery(ui.searchBox.value.trim());
+    const { filterPanelSections } = searchScope({ keywords, tags });
+
+    let newswireCount = 0;
+    let archiveCount = 0;
+    if (filterPanelSections) {
+        const regexes = keywords.map(keyword => new RegExp(`(${escapeRegExp(keyword)})`, 'gi'));
+        newswireCount = filterNewswire(keywords, regexes);
+        archiveCount = filterArchive(keywords, regexes);
+    } else {
+        // tag: 查詢作用中:重繪出的新列一樣整批隱藏
+        hideDynamicSections();
+    }
+
+    const { tabCount, otherWindowsTabCount, readingListCount, bookmarkCount } = lastStaticCounts;
+    document.dispatchEvent(new CustomEvent('searchResultUpdated', {
+        detail: { tabCount: tabCount + otherWindowsTabCount + readingListCount + newswireCount + archiveCount, bookmarkCount }
+    }));
+}
+
+/**
+ * 隱藏動態區塊全部項目並清掉 search-reveal(review PR #223 邊界情境:
+ * 關鍵字命中收合區→search-reveal 撐開後,追加 tag: 切到隱藏分支,
+ * 若不清 reveal 會殘留「展開但全空」直到下一輪關鍵字查詢)。
+ */
+function hideDynamicSections() {
+    for (const listId of ['newswire-list', 'archive-list']) {
+        const list = document.getElementById(listId);
+        if (!list) continue;
+        list.querySelectorAll(listId === 'newswire-list' ? '.newswire-item' : '.archive-item')
+            .forEach(i => i.classList.add('hidden'));
+        list.classList.remove('search-reveal');
+    }
 }
 
 // --- Shared per-item highlight helpers (BASE-025) ---
@@ -487,16 +536,8 @@ function hideNonBookmarkSections() {
     if (rl) {
         rl.querySelectorAll('.reading-list-item').forEach(i => i.classList.add('hidden'));
     }
-    // 快訊項目(BASE-017)
-    const nw = document.getElementById('newswire-list');
-    if (nw) {
-        nw.querySelectorAll('.newswire-item').forEach(i => i.classList.add('hidden'));
-    }
-    // 封存項目(BASE-025;BASE-024 上線時此處漏接,tag: 查詢時封存區不會被藏)
-    const ar = document.getElementById('archive-list');
-    if (ar) {
-        ar.querySelectorAll('.archive-item').forEach(i => i.classList.add('hidden'));
-    }
+    // 快訊+封存(BASE-025;BASE-024 上線時封存漏接):整批隱藏並清 search-reveal
+    hideDynamicSections();
 }
 
 // Search state to track if we are currently showing filtered results
@@ -748,11 +789,13 @@ function initialize() {
     // BASE-025: archive/newswire re-render DURING an active search (live
     // newswire events prepend unfiltered rows; archive refreshes on storage
     // change) — re-apply the filter so fresh rows respect the query.
-    // Debounced: handleSearch re-RENDERS the bookmark tree while a query is
-    // active, so rapid newswire bursts must collapse into one re-run.
+    // Scoped to the two dynamic sections (review PR #223): a full
+    // handleSearch would also tear down and re-render the bookmark tree,
+    // which has nothing to do with these re-renders. Debounce collapses
+    // newswire bursts.
     const debouncedRefilter = debounce(() => {
         if (ui.searchBox.value.trim().length > 0) {
-            handleSearch();
+            refilterDynamicSections();
         }
     }, 250);
     document.addEventListener('sectionContentRerendered', debouncedRefilter);

--- a/modules/searchManager.js
+++ b/modules/searchManager.js
@@ -24,12 +24,14 @@ async function handleSearch() {
     let otherWindowsTabCount = 0;
     let readingListCount = 0;
     let newswireCount = 0;
+    let archiveCount = 0;
     if (filterPanelSections) {
-        // 一般/關鍵字查詢:照舊過濾分頁、其他視窗、閱讀清單、快訊
+        // 一般/關鍵字查詢:照舊過濾分頁、其他視窗、閱讀清單、快訊、封存
         tabCount = filterTabsAndGroups(keywords);
         otherWindowsTabCount = filterOtherWindowsTabs(keywords);
         readingListCount = filterReadingList(keywords, regexes);
-        newswireCount = filterNewswire(keywords);
+        newswireCount = filterNewswire(keywords, regexes);
+        archiveCount = filterArchive(keywords, regexes);
     } else {
         // tag: 查詢:標籤只屬書籤,其餘區塊整批隱藏
         hideNonBookmarkSections();
@@ -45,9 +47,84 @@ async function handleSearch() {
     }
 
     const event = new CustomEvent('searchResultUpdated', {
-        detail: { tabCount: tabCount + otherWindowsTabCount + readingListCount + newswireCount, bookmarkCount }
+        detail: { tabCount: tabCount + otherWindowsTabCount + readingListCount + newswireCount + archiveCount, bookmarkCount }
     });
     document.dispatchEvent(event);
+}
+
+// --- Shared per-item highlight helpers (BASE-025) ---
+// The tab path keeps its own _refs-based variant; list-style sections
+// (readingList / archive / newswire) share these.
+
+/** Highlight a title element in place, remembering the original text. */
+function highlightTitleEl(titleEl, regexes) {
+    if (!titleEl || regexes.length === 0) return;
+    const originalTitle = titleEl.dataset.originalText || titleEl.textContent;
+    const highlighted = highlightText(originalTitle, regexes, 'title');
+    if (highlighted !== originalTitle) {
+        titleEl.innerHTML = highlighted; // highlightText escapes EVERY segment
+        if (!titleEl.dataset.originalText) titleEl.dataset.originalText = originalTitle;
+    }
+}
+
+/** Restore a highlighted title element to its original text. */
+function clearTitleEl(titleEl) {
+    if (titleEl && titleEl.dataset.originalText) {
+        titleEl.textContent = titleEl.dataset.originalText;
+        delete titleEl.dataset.originalText;
+    }
+}
+
+/** Show (or remove) the highlighted matched-domain line under an item. */
+function setMatchedDomainEl(item, parentEl, domain, regexes) {
+    const existing = item.querySelector('.matched-domain');
+    if (existing) existing.remove();
+    if (!domain || !parentEl) return;
+    const domainElement = document.createElement('div');
+    domainElement.className = 'matched-domain';
+    domainElement.innerHTML = highlightText(domain, regexes, 'url') + '...';
+    parentEl.appendChild(domainElement);
+}
+
+/**
+ * 過濾封存區項目(BASE-025):比對標題與網域、反白標題、URL 命中時附
+ * matched-domain;搜尋命中時以 search-reveal 蓋過收合(不動收合狀態機)。
+ * snooze 與封存項同列表一起過濾。
+ * @returns {number} 有搜尋時的可見項目數
+ */
+function filterArchive(keywords, regexes = []) {
+    const container = document.getElementById('archive-list');
+    if (!container) return 0;
+    const items = container.querySelectorAll('.archive-item');
+    if (items.length === 0) return 0;
+
+    let visibleCount = 0;
+    items.forEach(item => {
+        const title = item.dataset.title || '';
+        const domain = extractDomain(item.dataset.url || '');
+        const titleMatches = matchesAnyKeyword(title, keywords);
+        const urlMatches = matchesAnyKeyword(domain, keywords);
+        const matches = keywords.length === 0 || titleMatches || urlMatches;
+        item.classList.toggle('hidden', !matches);
+
+        const titleEl = item.querySelector('.archive-item-title');
+        if (matches && keywords.length > 0) {
+            visibleCount++;
+            highlightTitleEl(titleEl, regexes);
+            setMatchedDomainEl(
+                item,
+                (urlMatches && !titleMatches) ? item.querySelector('.archive-item-content') : null,
+                domain,
+                regexes
+            );
+        } else if (keywords.length === 0) {
+            clearTitleEl(titleEl);
+            setMatchedDomainEl(item, null, '', regexes);
+        }
+    });
+
+    container.classList.toggle('search-reveal', keywords.length > 0 && visibleCount > 0);
+    return visibleCount;
 }
 
 // --- Shared Filter Helpers ---
@@ -338,13 +415,15 @@ function filterReadingList(keywords, regexes = []) {
 }
 
 /**
- * 過濾快訊項目(BASE-017)。比對標題與來源標籤;空 keyword=全顯示。
- * 不做 innerHTML 高亮——快訊標題為外部不可信內容,維持該區塊
- * textContent-only 的安全紀律(newswireRenderer 同)。
+ * 過濾快訊項目(BASE-017;BASE-025 升級)。比對標題、來源標籤與網域;
+ * 反白標題——BASE-017 原基於安全紀律不做 innerHTML 反白,BASE-025 查證
+ * highlightText 對「每一段」(匹配與非匹配)皆先 escapeHtml 才組 <mark>,
+ * 不可信內容走此路徑安全(閱讀清單標題同屬外部內容、行之有年),故解除。
  * @param {string[]} keywords
+ * @param {RegExp[]} regexes
  * @returns {number} 有搜尋時的可見項目數
  */
-function filterNewswire(keywords) {
+function filterNewswire(keywords, regexes = []) {
     const container = document.getElementById('newswire-list');
     if (!container) return 0;
 
@@ -355,12 +434,24 @@ function filterNewswire(keywords) {
     items.forEach(item => {
         const title = item.dataset.title || '';
         const source = item.dataset.source || '';
+        const domain = extractDomain(item.dataset.url || '');
+        const titleMatches = matchesAnyKeyword(title, keywords);
         const matches = keywords.length === 0
-            || matchesAnyKeyword(title, keywords)
-            || matchesAnyKeyword(source, keywords);
+            || titleMatches
+            || matchesAnyKeyword(source, keywords)
+            || matchesAnyKeyword(domain, keywords);
         item.classList.toggle('hidden', !matches);
-        if (matches && keywords.length > 0) visibleCount++;
+
+        const titleEl = item.querySelector('.newswire-item__title');
+        if (matches && keywords.length > 0) {
+            visibleCount++;
+            highlightTitleEl(titleEl, regexes);
+        } else if (keywords.length === 0) {
+            clearTitleEl(titleEl);
+        }
     });
+
+    container.classList.toggle('search-reveal', keywords.length > 0 && visibleCount > 0);
     return visibleCount;
 }
 
@@ -400,6 +491,11 @@ function hideNonBookmarkSections() {
     const nw = document.getElementById('newswire-list');
     if (nw) {
         nw.querySelectorAll('.newswire-item').forEach(i => i.classList.add('hidden'));
+    }
+    // 封存項目(BASE-025;BASE-024 上線時此處漏接,tag: 查詢時封存區不會被藏)
+    const ar = document.getElementById('archive-list');
+    if (ar) {
+        ar.querySelectorAll('.archive-item').forEach(i => i.classList.add('hidden'));
     }
 }
 
@@ -648,6 +744,18 @@ function initialize() {
             handleSearch();
         }
     });
+
+    // BASE-025: archive/newswire re-render DURING an active search (live
+    // newswire events prepend unfiltered rows; archive refreshes on storage
+    // change) — re-apply the filter so fresh rows respect the query.
+    // Debounced: handleSearch re-RENDERS the bookmark tree while a query is
+    // active, so rapid newswire bursts must collapse into one re-run.
+    const debouncedRefilter = debounce(() => {
+        if (ui.searchBox.value.trim().length > 0) {
+            handleSearch();
+        }
+    }, 250);
+    document.addEventListener('sectionContentRerendered', debouncedRefilter);
 }
 
 export { initialize, handleSearch, filterTabsAndGroups, filterBookmarks };

--- a/modules/ui/archiveRenderer.js
+++ b/modules/ui/archiveRenderer.js
@@ -53,6 +53,9 @@ function buildItem(item, { snoozed }) {
     row.className = `archive-item${snoozed ? ' archive-item--snoozed' : ''}`;
     row.dataset.itemId = item.id;
     row.dataset.kind = snoozed ? 'snoozed' : 'archived';
+    // BASE-025: searchManager filters/highlights off these datasets.
+    row.dataset.title = item.title || '';
+    row.dataset.url = item.url || '';
     row.tabIndex = 0;
     row.setAttribute('role', 'button');
     row.title = item.url;
@@ -137,6 +140,9 @@ export async function refreshArchiveSection() {
         ...archived.items.map(i => buildItem(i, { snoozed: false })),
     ];
     reconcileDOM(list, children);
+
+    // BASE-025: fresh rows must respect an active search query.
+    document.dispatchEvent(new CustomEvent('sectionContentRerendered', { detail: { section: 'archive' } }));
 }
 
 function initToggle() {

--- a/modules/ui/newswireRenderer.js
+++ b/modules/ui/newswireRenderer.js
@@ -56,6 +56,8 @@ function renderRow(ev) {
     // 供 searchManager 過濾(BASE-017):快訊參與側欄搜尋。
     row.dataset.title = ev.title || '';
     row.dataset.source = ev.source || '';
+    // BASE-025: url 供搜尋的網域比對(已經 normalizer 的 new URL 驗證)。
+    row.dataset.url = ev.url || '';
 
     row.append(time, source, title);
 
@@ -89,6 +91,8 @@ function renderAll(events) {
     els.list.appendChild(frag);
     trimRows();
     for (const ev of events) latestTs = Math.max(latestTs, ev.tsIngest || 0);
+    // BASE-025: fresh rows must respect an active search query.
+    document.dispatchEvent(new CustomEvent('sectionContentRerendered', { detail: { section: 'newswire' } }));
 }
 
 /** 插入即時事件於頂部(events 新→舊;由舊到新逐一插到最上方保持排序)。 */
@@ -105,6 +109,9 @@ function prependEvents(events) {
     if (keepPosition) {
         els.list.scrollTop += els.list.scrollHeight - prevHeight;
     }
+    // BASE-025: live-inserted rows must respect an active search query
+    // (searchManager listens and re-filters only while a query is active).
+    document.dispatchEvent(new CustomEvent('sectionContentRerendered', { detail: { section: 'newswire' } }));
 }
 
 function refreshBadge() {

--- a/sidepanel.css
+++ b/sidepanel.css
@@ -4013,3 +4013,9 @@ mark.url-match {
 .snooze-slots { display: flex; flex-direction: column; gap: 6px; margin-bottom: 10px; }
 .snooze-slot-btn { display: flex; justify-content: space-between; align-items: center; gap: 12px; width: 100%; }
 .snooze-slot-time { opacity: 0.65; font-size: 0.85em; }
+
+/* --- Search reveal (BASE-025): a hit inside a collapsed section shows its
+   list for the duration of the search WITHOUT touching the collapse state
+   machine (module vars / storage stay intact; clearing the search restores). */
+#newswire-list.collapsed.search-reveal,
+#archive-list.collapsed.search-reveal { display: block; }

--- a/usecase_tests/puppeteer_tests/happy_path_search_archive_newswire.test.js
+++ b/usecase_tests/puppeteer_tests/happy_path_search_archive_newswire.test.js
@@ -1,0 +1,171 @@
+// BASE-025 — sidebar search extended to the Archive and Newswire sections.
+// Covers: filtering + <mark> highlighting, URL/domain matching, tag: bulk
+// hide (the BASE-024 omission), search-reveal over collapsed lists, and the
+// integration hazard — rows rendered DURING an active search must be filtered.
+const { setupBrowser, teardownBrowser } = require('./setup');
+
+describe('Search across archive + newswire', () => {
+    let browser;
+    let page;
+    let extensionId;
+
+    const seedArchive = () => ({
+        archivedTabs: {
+            schemaVersion: 1,
+            items: [
+                { id: 'sa1', url: 'https://alpha-site.com/doc', title: 'Alpha guide', favIconUrl: '', archivedAt: Date.now() - 3600_000, source: 'auto' },
+                { id: 'sa2', url: 'https://beta-site.com/page', title: 'Beta notes', favIconUrl: '', archivedAt: Date.now() - 3600_000, source: 'auto' },
+            ],
+        },
+    });
+
+    async function typeSearch(text) {
+        await page.evaluate(() => { document.getElementById('search-box').value = ''; });
+        await page.type('#search-box', text);
+        // Search debounce is 300ms; wait for the filter to take effect.
+        await new Promise(r => setTimeout(r, 600));
+    }
+
+    async function clearSearch() {
+        await page.evaluate(() => {
+            const box = document.getElementById('search-box');
+            box.value = '';
+            box.dispatchEvent(new Event('input', { bubbles: true }));
+        });
+        await new Promise(r => setTimeout(r, 600));
+    }
+
+    async function broadcastNewswire(events) {
+        const sender = await browser.newPage();
+        await sender.goto(`chrome-extension://${extensionId}/options.html`, { waitUntil: 'domcontentloaded' });
+        await sender.evaluate((evs) => chrome.runtime.sendMessage({ type: 'newswire:events', events: evs }).catch(() => {}), events);
+        await sender.close();
+        await page.bringToFront();
+    }
+
+    const nwEvent = (id, title, over = {}) => ({
+        id, title, source: 'fj', importance: 2,
+        tsIngest: Date.now(), ts: Date.now(),
+        url: `https://newswire-src.com/${id}`, ...over,
+    });
+
+    beforeAll(async () => {
+        const setup = await setupBrowser();
+        browser = setup.browser;
+        page = setup.page;
+        extensionId = setup.extensionId;
+        await page.waitForSelector('#tab-list', { timeout: 15000 });
+        await page.evaluate((seed) => chrome.storage.local.set(seed), seedArchive());
+        await page.waitForFunction(() => document.querySelectorAll('.archive-item').length === 2, { timeout: 5000 });
+        await broadcastNewswire([nwEvent('n1', 'Alpha market news'), nwEvent('n2', 'Gamma report')]);
+        await page.waitForFunction(() => document.querySelectorAll('.newswire-item').length >= 2, { timeout: 5000 });
+    }, 120000);
+
+    afterAll(async () => {
+        await teardownBrowser(browser);
+    });
+
+    test('keyword filters both sections and highlights matches (title path)', async () => {
+        await typeSearch('Alpha');
+
+        const state = await page.evaluate(() => ({
+            archiveVisible: [...document.querySelectorAll('.archive-item:not(.hidden)')].map(el => el.dataset.itemId),
+            archiveHidden: [...document.querySelectorAll('.archive-item.hidden')].map(el => el.dataset.itemId),
+            archiveMark: document.querySelector('.archive-item:not(.hidden) .archive-item-title mark.title-match')?.textContent,
+            nwVisible: [...document.querySelectorAll('.newswire-item:not(.hidden)')].map(el => el.dataset.eventId),
+            nwHidden: [...document.querySelectorAll('.newswire-item.hidden')].map(el => el.dataset.eventId),
+            nwMark: document.querySelector('.newswire-item:not(.hidden) .newswire-item__title mark.title-match')?.textContent,
+        }));
+        expect(state.archiveVisible).toEqual(['sa1']);
+        expect(state.archiveHidden).toEqual(['sa2']);
+        expect(state.archiveMark).toBe('Alpha');
+        expect(state.nwVisible).toEqual(['n1']);
+        expect(state.nwHidden).toContain('n2');
+        expect(state.nwMark).toBe('Alpha');
+    }, 60000);
+
+    test('domain matching works for both sections; archive shows the matched-domain line', async () => {
+        await typeSearch('beta-site');
+        const archive = await page.evaluate(() => ({
+            visible: [...document.querySelectorAll('.archive-item:not(.hidden)')].map(el => el.dataset.itemId),
+            domainLine: document.querySelector('.archive-item:not(.hidden) .matched-domain mark.url-match')?.textContent,
+        }));
+        expect(archive.visible).toEqual(['sa2']);
+        expect(archive.domainLine).toBe('beta-site');
+
+        await typeSearch('newswire-src');
+        const nwVisible = await page.evaluate(() =>
+            [...document.querySelectorAll('.newswire-item:not(.hidden)')].map(el => el.dataset.eventId));
+        expect(nwVisible.sort()).toEqual(['n1', 'n2']); // both share the domain
+    }, 60000);
+
+    test('rows rendered DURING an active search get filtered (integration hazard)', async () => {
+        await typeSearch('Alpha');
+        // A live newswire batch arrives mid-search: one match, one miss.
+        await broadcastNewswire([nwEvent('n3', 'Alpha follow-up'), nwEvent('n4', 'Delta digest')]);
+
+        // The re-filter listener is debounced (250ms) after the prepend.
+        await page.waitForFunction(() => {
+            const n3 = document.querySelector('.newswire-item[data-event-id="n3"]');
+            const n4 = document.querySelector('.newswire-item[data-event-id="n4"]');
+            return n3 && n4
+                && !n3.classList.contains('hidden')
+                && n4.classList.contains('hidden');
+        }, { timeout: 8000 });
+
+        // The fresh matching row is highlighted too.
+        const mark = await page.$eval('.newswire-item[data-event-id="n3"] .newswire-item__title mark.title-match',
+            el => el.textContent);
+        expect(mark).toBe('Alpha');
+    }, 60000);
+
+    test('search-reveal shows a collapsed section with hits; clearing restores collapse + highlights', async () => {
+        // Collapse the archive section via its real toggle.
+        await clearSearch();
+        await page.click('#archive-toggle');
+        await page.waitForFunction(() =>
+            document.getElementById('archive-list').classList.contains('collapsed'), { timeout: 5000 });
+
+        await typeSearch('Alpha');
+        const revealed = await page.evaluate(() => {
+            const list = document.getElementById('archive-list');
+            return {
+                hasReveal: list.classList.contains('search-reveal'),
+                displayed: window.getComputedStyle(list).display !== 'none',
+            };
+        });
+        expect(revealed.hasReveal).toBe(true);
+        expect(revealed.displayed).toBe(true);
+
+        await clearSearch();
+        const after = await page.evaluate(() => {
+            const list = document.getElementById('archive-list');
+            return {
+                hasReveal: list.classList.contains('search-reveal'),
+                collapsed: list.classList.contains('collapsed'),
+                displayed: window.getComputedStyle(list).display !== 'none',
+                anyMark: !!document.querySelector('.archive-item mark, .newswire-item mark'),
+                anyHidden: !!document.querySelector('.archive-item.hidden, .newswire-item.hidden'),
+            };
+        });
+        expect(after.hasReveal).toBe(false);
+        expect(after.collapsed).toBe(true);   // user's collapse preference intact
+        expect(after.displayed).toBe(false);
+        expect(after.anyMark).toBe(false);    // highlights cleared
+        expect(after.anyHidden).toBe(false);  // all items visible again
+
+        // Restore expanded state for other tests.
+        await page.click('#archive-toggle');
+    }, 60000);
+
+    test('tag: query hides archive and newswire wholesale (BASE-024 omission regression)', async () => {
+        await typeSearch('tag:worktag');
+        const bulk = await page.evaluate(() => ({
+            archiveAllHidden: [...document.querySelectorAll('.archive-item')].every(el => el.classList.contains('hidden')),
+            nwAllHidden: [...document.querySelectorAll('.newswire-item')].every(el => el.classList.contains('hidden')),
+        }));
+        expect(bulk.archiveAllHidden).toBe(true);
+        expect(bulk.nwAllHidden).toBe(true);
+        await clearSearch();
+    }, 60000);
+});

--- a/usecase_tests/puppeteer_tests/happy_path_search_archive_newswire.test.js
+++ b/usecase_tests/puppeteer_tests/happy_path_search_archive_newswire.test.js
@@ -158,14 +158,32 @@ describe('Search across archive + newswire', () => {
         await page.click('#archive-toggle');
     }, 60000);
 
-    test('tag: query hides archive and newswire wholesale (BASE-024 omission regression)', async () => {
-        await typeSearch('tag:worktag');
+    test('tag: query hides archive and newswire wholesale and clears a lingering search-reveal', async () => {
+        // Collapse the archive section, then hit it with a keyword so
+        // search-reveal props it open…
+        await page.click('#archive-toggle');
+        await page.waitForFunction(() =>
+            document.getElementById('archive-list').classList.contains('collapsed'), { timeout: 5000 });
+        await typeSearch('Alpha');
+        await page.waitForFunction(() =>
+            document.getElementById('archive-list').classList.contains('search-reveal'), { timeout: 5000 });
+
+        // …then append a tag: filter in the SAME query: the hide branch must
+        // clear the reveal too, or the section lingers "open but empty"
+        // (review PR #223 edge case).
+        await typeSearch('Alpha tag:worktag');
         const bulk = await page.evaluate(() => ({
             archiveAllHidden: [...document.querySelectorAll('.archive-item')].every(el => el.classList.contains('hidden')),
             nwAllHidden: [...document.querySelectorAll('.newswire-item')].every(el => el.classList.contains('hidden')),
+            archiveReveal: document.getElementById('archive-list').classList.contains('search-reveal'),
+            nwReveal: document.getElementById('newswire-list').classList.contains('search-reveal'),
         }));
         expect(bulk.archiveAllHidden).toBe(true);
         expect(bulk.nwAllHidden).toBe(true);
+        expect(bulk.archiveReveal).toBe(false);
+        expect(bulk.nwReveal).toBe(false);
+
         await clearSearch();
+        await page.click('#archive-toggle'); // restore expanded
     }, 60000);
 });


### PR DESCRIPTION
## 摘要 (Summary)

**BASE-025：搜尋欄擴及封存區與快訊區**（T1，SPEC 隨本 PR 審：`docs/specs/feature/BASE-025_search-archive-newswire/SPEC.md`）。搜尋的過濾＋`<mark>` 反白＋URL 網域比對，補齊最後兩個未覆蓋區塊——自此六個 sidebar 區塊（tabs／其他視窗／bookmarks／readingList／newswire／archive）全部納入同一套搜尋語意。

## 📝 變更內容 (Changes)

### 盤點修正（實況與請求的落差）

快訊的「過濾」**BASE-017 已存在**（比對 title＋source），真 gap 是無反白、無網域比對；封存區則**完全未接**——含 `tag:` 查詢不隱藏的 BASE-024 上線遺漏（搜尋時封存區顯示全部項目形同雜訊）。

### 新增 (Added)

- **`filterArchive`**：標題＋網域比對、標題反白、URL 命中附 `.matched-domain` 反白網域行、snooze 項同列表過濾、命中數併入 `searchResultUpdated`。
- **`filterNewswire` 升級**：補網域比對（renderer 補 `dataset.url`，值已經 normalizer 的 `new URL` 驗證）＋標題反白。
- **共用 highlight helpers**（`highlightTitleEl`／`clearTitleEl`／`setMatchedDomainEl`）：readingList／archive／newswire 三區共用 originalText-dataset 模式；tab 路徑因 `_refs` 快取結構維持原樣。
- **`search-reveal` 疊加 class**：收合中的封存／快訊區有命中時內容可見。
- **`sectionContentRerendered` 事件**：archive refresh 與 newswire `renderAll`/`prependEvents` 後 dispatch，searchManager 於查詢作用中 **debounce 250ms** 重跑。
- 新 E2E（5 案）：過濾＋反白、網域比對、**「搜尋中 prepend 新事件被即時過濾」**（整合難點的核心回歸）、search-reveal＋清除還原、`tag:` 整批隱藏迴歸。

### 兩個關鍵查證/設計決策（review 重點）

1. **BASE-017 反白禁令解除，附查證依據**：`highlightText` 對**每一段**（匹配與非匹配區間）都先 `escapeHtml` 才組 `<mark>`（textUtils.js:89-99）——不可信內容走此路徑安全，閱讀清單標題（同屬外部內容）已行之有年。filterNewswire 註解記錄此依據。
2. **收合顯示不走 readingList 的 remove-collapsed 作法**：newswire 收合是 module 變數＋storage 狀態機，直接摘 class 會 desync（下次 toggle 要按兩次）；`search-reveal` 疊加 class 不碰狀態機、清除搜尋自動恢復收合。readingList 既有行為不動（不擴 scope）。

## 🧪 測試 (Testing)

- 新 E2E `happy_path_search_archive_newswire`：✅ 5 tests × **連跑 3 次全綠**（快訊事件注入沿用「`runtime.sendMessage` 不自投遞、由第二個 extension 頁廣播」的既有教訓）
- `npm run test:unit`：✅ 713 passed
- `npm run test:ci` happy-path 全套：✅ **34 suites / 111 passed**（含既有搜尋相關 E2E 全數不破壞）
- `make && make release`：✅ prod bundle 含新程式碼（grep 驗證）

### SPEC 驗收條件對照

過濾＋反白（兩區）✅／URL 命中網域行 ✅／search-reveal＋清除還原（含反白清除、收合復原）✅／`tag:` 整批隱藏 ✅／**搜尋中重繪即時過濾** ✅／計數併入 ✅／既有測試全綠 ✅。

---

## 🌐 English Version

### Summary

BASE-025 (T1, SPEC ships with this PR): the sidebar search's filtering + `<mark>` highlighting + domain matching now covers the Archive and Newswire sections — completing all six sidebar sections under one search semantic.

### Changes

Reality-check first: newswire FILTERING already existed (BASE-017, title+source only); the real gaps were highlighting + domain matching there, and the Archive section being entirely unwired (including the tag:-query bulk-hide omission from BASE-024). Added `filterArchive`, upgraded `filterNewswire`, extracted shared highlight helpers, introduced a `search-reveal` overlay class for collapsed sections (deliberately NOT the remove-collapsed approach — newswire's collapse is a module-variable state machine that would desync), and a `sectionContentRerendered` event with a 250ms-debounced re-filter so rows rendered DURING an active search (live newswire prepends, archive refreshes) respect the query. The BASE-017 no-highlight rule is lifted with evidence: `highlightText` escapes every segment before composing `<mark>`, so untrusted content is safe on this path (reading-list titles have used it all along).

### Testing

New E2E suite (5 tests, incl. the mid-search prepend regression) green ×3; unit 713; full happy-path 34 suites / 111 passed; prod bundle verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
