### PR TITLE
fix(jest): exclude .claude worktrees from the test scan

### DIFF
--- a/.agent/skills/puppeteer-test/SKILL.md
+++ b/.agent/skills/puppeteer-test/SKILL.md
@@ -169,6 +169,10 @@ const config = {
     '^.+\\.m?js$': '<rootDir>/jest.esbuild-transform.cjs', // 用 esbuild 轉 ESM
   },
   testMatch: ['**/?(*.)+(spec|test).[jt]s?(x)', '**/?(*.)+(spec|test).mjs'],
+  // 自訂此欄位會「取代」Jest 預設的 ['/node_modules/']，所以要一併寫回。
+  // '/\\.claude/' 擋掉 .claude/worktrees/ 底下的 worktree（各自帶著本 repo 的
+  // 測試副本，否則會被掃入變成假失敗）。守門測試：unit_tests/jestConfigIntegrity。
+  testPathIgnorePatterns: ['/node_modules/', '/\\.claude/'],
 };
 module.exports = config;
 ```

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,6 +7,10 @@ const config = {
         '^.+\\.m?js$': '<rootDir>/jest.esbuild-transform.cjs',
     },
     testMatch: ['**/?(*.)+(spec|test).[jt]s?(x)', '**/?(*.)+(spec|test).mjs'],
+    // Setting this REPLACES Jest's default ['/node_modules/'] — keep it listed.
+    // '/\\.claude/' skips the git worktrees under .claude/worktrees/, which carry
+    // their own copy of this repo's tests (guard: jestConfigIntegrity.test.mjs).
+    testPathIgnorePatterns: ['/node_modules/', '/\\.claude/'],
 };
 
 module.exports = config;

--- a/usecase_tests/unit_tests/jestConfigIntegrity.test.mjs
+++ b/usecase_tests/unit_tests/jestConfigIntegrity.test.mjs
@@ -1,0 +1,33 @@
+// Jest scan-scope guard. `.claude/worktrees/` holds live git worktrees of this
+// same repo, each carrying its own copy of usecase_tests/ (and sometimes its own
+// node_modules with an ESM-only puppeteer). Without an explicit ignore list Jest
+// scanned them too: 258 suites instead of 56, with 56 bogus "Test suite failed
+// to run" failures masking real ones locally. CI never saw it — no worktrees there.
+//
+// The trap this guards: testPathIgnorePatterns REPLACES Jest's default
+// ['/node_modules/'] rather than extending it, so dropping /node_modules/ from
+// the list silently pulls dependency tests back into the scan.
+import config from '../../jest.config.js';
+
+const IGNORED = [
+    '/repo/.claude/worktrees/some-branch-abc123/usecase_tests/unit_tests/foo.test.mjs',
+    '/repo/node_modules/some-dep/lib/bar.test.js',
+];
+
+const SCANNED = [
+    '/repo/usecase_tests/unit_tests/foo.test.mjs',
+    '/repo/usecase_tests/puppeteer_tests/bar.test.js',
+    '/repo/benchmark/modal_perf.test.js',
+];
+
+const matches = (p) => (config.testPathIgnorePatterns || []).some(pattern => new RegExp(pattern).test(p));
+
+describe('jest testPathIgnorePatterns', () => {
+    test.each(IGNORED)('ignores %s', (p) => {
+        expect(matches(p)).toBe(true);
+    });
+
+    test.each(SCANNED)('still scans %s', (p) => {
+        expect(matches(p)).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary

本機直接跑 `npm test` 會出現 56 個 `Test suite failed to run` 的假失敗，全部來自 `.claude/worktrees/` 底下的殘留 git worktree，不是真的測試壞掉。

根因：`jest.config.js` 沒設 `testPathIgnorePatterns`，Jest 預設值只排除 `/node_modules/`。`.claude/worktrees/` 下的 4 個 worktree 各自帶著這個 repo 的 `usecase_tests/` 副本，被 `testMatch` 一併掃入；其中 `claude-md-skill-cleanup-712a9e` 還有自己的 `node_modules`，裝的是 ESM-only 的 puppeteer 25.x，在 CommonJS runtime 下 `export * from 'puppeteer-core'` 直接 SyntaxError。CI 上沒有 worktree 所以不受影響，但本機這 56 個假失敗會蓋掉真正的失敗、誤導判斷。

修法是讓 Jest 忽略 `/\.claude/`，**不是**去清那些 worktree — 它們可能仍是進行中的工作。

一個要注意的坑：`testPathIgnorePatterns` 一旦自訂就會**取代**（而非擴充）Jest 預設的 `['/node_modules/']`，所以 `/node_modules/` 必須一併寫回，否則依賴套件內的測試檔會被掃進來。`usecase_tests/unit_tests/jestConfigIntegrity.test.mjs` 就是守這件事的回歸測試：驗證 worktree 與 node_modules 路徑會被忽略、正常測試路徑不會被誤殺。未修前該測試會 fail（實測 2 failed / 5）。

分級：T0（一行 config + 一支守門測試），依 `sdd` skill 不另立 SPEC.md。

`.agent/skills/puppeteer-test/SKILL.md` 一併更新：它貼著 `jest.config.js` 全文並標明「本專案實際設定」，不同步就會 drift。

## Test plan

| 驗證 | 結果 |
|---|---|
| 修前跑守門測試（紅） | `Tests: 2 failed, 3 passed, 5 total` |
| 修後跑守門測試（綠） | `Tests: 5 passed, 5 total` |
| `npx jest --listTests` 是否還掃到 worktree | `grep -c '\.claude'` → **0** |
| `npm test`（不帶任何額外 flag） | `Test Suites: 54 of 56 total`（修前是 **250 of 258**），56 個假失敗全數消失 |
| `npm run test:unit` | `55 passed, 55 total` / `746 tests passed` |

**誠實回報一項既有失敗**：`npm test` 跑完是 `1 failed, 2 skipped, 53 passed, 54 of 56 total` / `Tests: 4 failed`，紅的是 `happy_path_routing_engine.test.js`（`Attempted to use detached Frame`）。這是本機 macOS + 目前 Chrome 版本的既有問題，與本 PR 無關 — 用 `--runTestsByPath` 單獨指定精確路徑重跑（`testPathIgnorePatterns` 完全不介入的路徑）仍是同樣 4 failed。Linux CI 不受影響。

`Makefile` 打包清單不需同步（測試檔與 `jest.config.js` 都不在 `DEV_SRC_FILES` / prod esbuild 清單內，已 grep 確認）。

---

## English Version

### Summary

Running `npm test` locally produced 56 bogus `Test suite failed to run` failures, all from leftover git worktrees under `.claude/worktrees/` — not real test breakage.

Root cause: `jest.config.js` never set `testPathIgnorePatterns`, and Jest's default only excludes `/node_modules/`. The four worktrees each carry their own copy of this repo's `usecase_tests/`, so `testMatch` swept them in; one of them also has its own `node_modules` with an ESM-only puppeteer 25.x that SyntaxErrors on load under the CommonJS runtime. CI has no worktrees and was never affected, but locally those 56 fake failures masked real ones.

The fix makes Jest ignore `/\.claude/` — it does **not** remove the worktrees, which may still be active work.

The pitfall worth calling out: setting `testPathIgnorePatterns` **replaces** Jest's default `['/node_modules/']` rather than extending it, so `/node_modules/` has to be listed again. `usecase_tests/unit_tests/jestConfigIntegrity.test.mjs` guards exactly that: worktree and node_modules paths must be ignored, legitimate test paths must not be. It fails before the fix (2 of 5 failed).

Graded T0 (one config line plus a guard test), so no separate SPEC.md per the `sdd` skill.

`.agent/skills/puppeteer-test/SKILL.md` is updated too — it embeds the full `jest.config.js` and labels it as the project's actual config, so it drifts if left alone.

### Test plan

- Guard test before the fix: `2 failed, 3 passed, 5 total` (red)
- Guard test after the fix: `5 passed, 5 total` (green)
- `npx jest --listTests | grep -c '\.claude'` → `0`
- Plain `npm test`, no extra flags: `54 of 56 total` suites (was `250 of 258`); all 56 fake failures gone
- `npm run test:unit`: `55 passed, 55 total`, `746 tests passed`

**One pre-existing failure, reported honestly**: the full `npm test` run ends at `1 failed, 2 skipped, 53 passed` / `4 failed` tests in `happy_path_routing_engine.test.js` (`Attempted to use detached Frame`). That is a known local macOS/Chrome issue unrelated to this PR — rerunning that file alone via `--runTestsByPath`, where `testPathIgnorePatterns` plays no part at all, reproduces the same 4 failures. Linux CI is unaffected.

No `Makefile` packaging sync needed — neither test files nor `jest.config.js` appear in the packaging lists (verified by grep).
